### PR TITLE
feat: show view license link at all levels

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDisplay.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDisplay.jsx
@@ -10,7 +10,7 @@ import {
   Hyperlink,
 } from '@edx/paragon';
 
-import { LicenseLevel, LicenseTypes } from '../../../../../../data/constants/licenses';
+import { LicenseTypes } from '../../../../../../data/constants/licenses';
 
 import LicenseBlurb from './LicenseBlurb';
 import { messages } from './messages';
@@ -19,7 +19,6 @@ export const LicenseDisplay = ({
   license,
   details,
   licenseDescription,
-  level,
 }) => {
   if (license !== LicenseTypes.select) {
     return (
@@ -29,15 +28,13 @@ export const LicenseDisplay = ({
           <LicenseBlurb license={license} details={details} />
           <div className="x-small">{licenseDescription}</div>
         </div>
-        {level !== LicenseLevel.course ? (
-          <Hyperlink
-            className="text-primary-500 x-small"
-            destination="https://creativecommons.org/about"
-            target="_blank"
-          >
-            <FormattedMessage {...messages.viewLicenseDetailsLabel} />
-          </Hyperlink>
-        ) : null }
+        <Hyperlink
+          className="text-primary-500 x-small"
+          destination="https://creativecommons.org/about"
+          target="_blank"
+        >
+          <FormattedMessage {...messages.viewLicenseDetailsLabel} />
+        </Hyperlink>
       </Stack>
     );
   }

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/LicenseDisplay.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/LicenseDisplay.test.jsx.snap
@@ -26,6 +26,17 @@ exports[`LicenseDisplay snapshots snapshots: renders as expected with default pr
       FormattedMessage component with license description
     </div>
   </div>
+  <Hyperlink
+    className="text-primary-500 x-small"
+    destination="https://creativecommons.org/about"
+    target="_blank"
+  >
+    <FormattedMessage
+      defaultMessage="View license details"
+      description="Label for view license details button"
+      id="authoring.videoeditor.license.viewLicenseDetailsLabel.label"
+    />
+  </Hyperlink>
 </Stack>
 `;
 

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/index.test.jsx.snap
@@ -35,7 +35,6 @@ exports[`LicenseWidget snapshots snapshots: renders as expected with default pro
     />
     <injectIntl(ShimmedIntlComponent)
       details={Object {}}
-      level="course"
       license="all-rights-reserved"
       licenseDescription={
         <FormattedMessage
@@ -99,7 +98,6 @@ exports[`LicenseWidget snapshots snapshots: renders as expected with isLibrary t
     />
     <injectIntl(ShimmedIntlComponent)
       details={Object {}}
-      level="library"
       license="all-rights-reserved"
       licenseDescription={
         <FormattedMessage
@@ -148,7 +146,6 @@ exports[`LicenseWidget snapshots snapshots: renders as expected with licenseType
     />
     <injectIntl(ShimmedIntlComponent)
       details={Object {}}
-      level="block"
       license="all-rights-reserved"
       licenseDescription={
         <FormattedMessage

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/index.jsx
@@ -63,7 +63,6 @@ export const LicenseWidget = ({
               license={license}
               details={details}
               licenseDescription={licenseDescription}
-              level={level}
             />
           </>
         ) : null }


### PR DESCRIPTION
This PR removes the condition that prevents "View License Details" hyperlink when showing course level license.

JIRA Ticket: [TNL-10271](https://2u-internal.atlassian.net/browse/TNL-10271)