### PR TITLE
fix: add check if field is cleared

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
@@ -11,35 +11,37 @@ import { isEdxVideo } from '../../../../../../data/services/cms/api';
  * @param {object} source - object for the Video Source field functions and values
  */
 export const updateVideoId = ({ dispatch }) => ({ e, source }) => {
-  if (source.formValue !== e.target.value) {
-    source.onBlur(e);
-    let videoId;
-    let videoSource;
-    if (isEdxVideo(source.local)) {
-      videoId = source.local;
-      videoSource = '';
-    } else if (source.local.includes('youtu.be') || source.local.includes('youtube')) {
-      videoId = '';
-      videoSource = source.local;
-    } else {
-      videoId = '';
-      videoSource = source.local;
+  if (source.local !== '') {
+    if (source.formValue !== e.target.value) {
+      source.onBlur(e);
+      let videoId;
+      let videoSource;
+      if (isEdxVideo(source.local)) {
+        videoId = source.local;
+        videoSource = '';
+      } else if (source.local.includes('youtu.be') || source.local.includes('youtube')) {
+        videoId = '';
+        videoSource = source.local;
+      } else {
+        videoId = '';
+        videoSource = source.local;
+      }
+      dispatch(actions.video.updateField({
+        videoId,
+        videoSource,
+        allowVideoDownloads: false,
+        thumbnail: null,
+        transcripts: [],
+        allowTranscriptDownloads: false,
+        showTranscriptByDefault: false,
+        duration: {
+          startTime: '00:00:00',
+          stopTime: '00:00:00',
+          total: '00:00:00',
+        },
+        licenseType: null,
+      }));
     }
-    dispatch(actions.video.updateField({
-      videoId,
-      videoSource,
-      allowVideoDownloads: false,
-      thumbnail: null,
-      transcripts: [],
-      allowTranscriptDownloads: false,
-      showTranscriptByDefault: false,
-      duration: {
-        startTime: '00:00:00',
-        stopTime: '00:00:00',
-        total: '00:00:00',
-      },
-      licenseType: null,
-    }));
   }
 };
 


### PR DESCRIPTION
This is a follow on[ PR to separating video ID and video URL into two fields](https://github.com/openedx/frontend-lib-content-components/pull/164). In the previous implementation and user could clear one of the fields and it would end up clearing both. Now only the expected field is cleared onBlur.