### PR TITLE
fix: change # destination to advance settings url

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
 import { Form, Hyperlink } from '@edx/paragon';
 import SettingsOption from '../SettingsOption';
 import { ShowAnswerTypes, ShowAnswerTypesKeys } from '../../../../../../data/constants/problem';
+import { selectors } from '../../../../../../data/redux';
 import messages from '../messages';
 import { showAnswerCardHooks } from '../hooks';
 
@@ -12,6 +14,9 @@ export const ShowAnswerCard = ({
   updateSettings,
   // inject
   intl,
+  // redux
+  studioEndpointUrl,
+  learningContextId,
 }) => {
   const {
     handleShowAnswerChange,
@@ -29,7 +34,7 @@ export const ShowAnswerCard = ({
         </span>
       </div>
       <div className="spacedMessage">
-        <Hyperlink destination="#" target="_blank">
+        <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}`} target="_blank">
           <FormattedMessage {...messages.advancedSettingsLinkText} />
         </Hyperlink>
       </div>
@@ -49,7 +54,7 @@ export const ShowAnswerCard = ({
           ))}
         </Form.Control>
       </Form.Group>
-      { showAttempts
+      {showAttempts
         && (
         <Form.Group>
           <Form.Control
@@ -69,6 +74,15 @@ ShowAnswerCard.propTypes = {
   // eslint-disable-next-line
   showAnswer: PropTypes.any.isRequired,
   updateSettings: PropTypes.func.isRequired,
+  studioEndpointUrl: PropTypes.string.isRequired,
+  learningContextId: PropTypes.string.isRequired,
 };
 
-export default injectIntl(ShowAnswerCard);
+export const mapStateToProps = (state) => ({
+  studioEndpointUrl: selectors.app.studioEndpointUrl(state),
+  learningContextId: selectors.app.learningContextId(state),
+});
+
+export const mapDispatchToProps = {};
+
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(ShowAnswerCard));

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
@@ -1,11 +1,21 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { formatMessage } from '../../../../../../../testUtils';
-import { ShowAnswerCard } from './ShowAnswerCard';
+import { selectors } from '../../../../../../data/redux';
+import { ShowAnswerCard, mapStateToProps, mapDispatchToProps } from './ShowAnswerCard';
 import { showAnswerCardHooks } from '../hooks';
 
 jest.mock('../hooks', () => ({
   showAnswerCardHooks: jest.fn(),
+}));
+
+jest.mock('../../../../../../data/redux', () => ({
+  selectors: {
+    app: {
+      studioEndpointUrl: jest.fn(state => ({ studioEndpointUrl: state })),
+      learningContextId: jest.fn(state => ({ learningContextId: state })),
+    },
+  },
 }));
 
 describe('ShowAnswerCard', () => {
@@ -17,7 +27,11 @@ describe('ShowAnswerCard', () => {
   };
   const props = {
     showAnswer,
+    // injected
     intl: { formatMessage },
+    // redux
+    studioEndpointUrl: 'SoMEeNDpOinT',
+    learningContextId: 'sOMEcouRseId',
   };
 
   const showAnswerCardHooksProps = {
@@ -37,6 +51,24 @@ describe('ShowAnswerCard', () => {
   describe('snapshot', () => {
     test('snapshot: show answer setting card', () => {
       expect(shallow(<ShowAnswerCard {...props} />)).toMatchSnapshot();
+    });
+  });
+  describe('mapStateToProps', () => {
+    const testState = { A: 'pple', B: 'anana', C: 'ucumber' };
+    test('studioEndpointUrl from app.studioEndpointUrl', () => {
+      expect(
+        mapStateToProps(testState).studioEndpointUrl,
+      ).toEqual(selectors.app.studioEndpointUrl(testState));
+    });
+    test('learningContextId from app.learningContextId', () => {
+      expect(
+        mapStateToProps(testState).learningContextId,
+      ).toEqual(selectors.app.learningContextId(testState));
+    });
+  });
+  describe('mapDispatchToProps', () => {
+    test('equal an empty object', () => {
+      expect(mapDispatchToProps).toEqual({});
     });
   });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`ShowAnswerCard snapshot snapshot: show answer setting card 1`] = `
     className="spacedMessage"
   >
     <Hyperlink
-      destination="#"
+      destination="SoMEeNDpOinT/settings/advanced/sOMEcouRseId"
       target="_blank"
     >
       <FormattedMessage


### PR DESCRIPTION
JIRA Ticket: [TNL-10326](https://2u-internal.atlassian.net/browse/TNL-10326)

This PR sets the "Set a default value in advanced settings" link to `<studiourl>/settings/advanced/<courseID>`. Previously the link was set to `#` so it was opening the problem editor page, but in a different tab.