### PR TITLE
Fix: advanced problem template reference

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -22,7 +22,6 @@ export const EditProblemView = ({
 
   const getContent = parseState(problemState, isAdvancedProblemType, editorRef);
 
-  console.log(problemState.rawOLX);
   return (
     <EditorContainer getContent={getContent}>
       <Container fluid>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -22,6 +22,7 @@ export const EditProblemView = ({
 
   const getContent = parseState(problemState, isAdvancedProblemType, editorRef);
 
+  console.log(problemState.rawOLX);
   return (
     <EditorContainer getContent={getContent}>
       <Container fluid>

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
@@ -20,7 +20,7 @@ export const selectHooks = () => {
 
 export const onSelect = (selected, updateField) => () => {
   if (Object.values(AdvanceProblemKeys).includes(selected)) {
-    updateField({ problemType: ProblemTypeKeys.ADVANCED, rawOLX: AdvanceProblems[selected] });
+    updateField({ problemType: ProblemTypeKeys.ADVANCED, rawOLX: AdvanceProblems[selected].template });
   } else {
     const newOLX = ProblemTypes[selected].template;
     const { settings, ...newState } = getDataFromOlx({ rawOLX: newOLX, rawSettings: {} });

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.test.js
@@ -48,7 +48,7 @@ describe('SelectTypeModal hooks', () => {
       module.onSelect(mockAdvancedSelected, mockUpdateField)();
       expect(mockUpdateField).toHaveBeenCalledWith({
         problemType: ProblemTypeKeys.ADVANCED,
-        rawOLX: AdvanceProblems[mockAdvancedSelected],
+        rawOLX: AdvanceProblems[mockAdvancedSelected].template,
       });
     });
     test('updateField is called with selected on visual propblems', () => {

--- a/src/editors/data/constants/advancedOlxTemplates/circuitschematic.js
+++ b/src/editors/data/constants/advancedOlxTemplates/circuitschematic.js
@@ -89,4 +89,4 @@ export const circuitSchematic = `<problem>
     </schematicresponse>
 </problem>`;
 
-export default { circuitSchematic };
+export default circuitSchematic;

--- a/src/editors/data/constants/advancedOlxTemplates/customgrader.js
+++ b/src/editors/data/constants/advancedOlxTemplates/customgrader.js
@@ -76,4 +76,4 @@ export const customGrader = `<problem>
     </customresponse>
 </problem>`;
 
-export default { customGrader };
+export default customGrader;

--- a/src/editors/data/constants/advancedOlxTemplates/drag_and_drop.js
+++ b/src/editors/data/constants/advancedOlxTemplates/drag_and_drop.js
@@ -85,4 +85,4 @@ export const dragAndDrop = `<problem>
     </customresponse>
 </problem>`;
 
-export default { dragAndDrop };
+export default dragAndDrop;

--- a/src/editors/data/constants/advancedOlxTemplates/formularesponse.js
+++ b/src/editors/data/constants/advancedOlxTemplates/formularesponse.js
@@ -13,4 +13,4 @@ export const formulaResponse = `<problem>
         <formulaequationinput size="40"/>
     </formularesponse>
 </problem>`;
-export default { formulaResponse };
+export default formulaResponse;

--- a/src/editors/data/constants/advancedOlxTemplates/imageresponse.js
+++ b/src/editors/data/constants/advancedOlxTemplates/imageresponse.js
@@ -30,4 +30,4 @@ export const imageResponse = `<problem>
         </imageresponse>
     </problem>`;
 
-export default { imageResponse };
+export default imageResponse;

--- a/src/editors/data/constants/advancedOlxTemplates/jsinput_response.js
+++ b/src/editors/data/constants/advancedOlxTemplates/jsinput_response.js
@@ -78,4 +78,4 @@ export const jsInputResponse = `<problem>
     </customresponse>
 </problem>`;
 
-export default { jsInputResponse };
+export default jsInputResponse;

--- a/src/editors/data/constants/advancedOlxTemplates/problem_with_hint.js
+++ b/src/editors/data/constants/advancedOlxTemplates/problem_with_hint.js
@@ -43,4 +43,4 @@ export const problemWithHint = `<problem>
     </text>
 </problem>`;
 
-export default { problemWithHint };
+export default problemWithHint;


### PR DESCRIPTION
As I was writing the select type egress, I fixed a bug where the wrong rawolx object was being loaded in for basic problem types. this fixes it for advanced ones as well.