### PR TITLE
feat: make problem select and preview a fixed size

### DIFF
--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/__snapshots__/index.test.jsx.snap
@@ -6,19 +6,21 @@ exports[`SelectTypeModal snapshot 1`] = `
   selected="mOcKsELEcted"
 >
   <Row
-    className="justify-content-center align-items-stretch m-4"
+    className="justify-content-center"
   >
-    <Col>
+    <Stack
+      className="flex-wrap"
+      direction="horizontal"
+      gap={4}
+    >
       <injectIntl(ShimmedIntlComponent)
         selected="mOcKsELEcted"
         setSelected={[MockFunction setSelected]}
       />
-    </Col>
-    <Col>
       <injectIntl(ShimmedIntlComponent)
         problemType="mOcKsELEcted"
       />
-    </Col>
+    </Stack>
   </Row>
 </injectIntl(ShimmedIntlComponent)>
 `;

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/Preview.jsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/Preview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Hyperlink, Image } from '@edx/paragon';
+import { Hyperlink, Image, Container } from '@edx/paragon';
 import {
   FormattedMessage,
   injectIntl,
@@ -19,7 +19,7 @@ export const Preview = ({
   }
   const data = ProblemTypes[problemType];
   return (
-    <div className="bg-light-300 rounded p-4">
+    <Container style={{ width: '494px', height: '400px' }} className="bg-light-300 rounded p-4">
       <div className="small">
         {intl.formatMessage(messages.previewTitle, { previewTitle: data.title })}
       </div>
@@ -38,7 +38,7 @@ export const Preview = ({
       >
         <FormattedMessage {...messages.learnMoreButtonLabel} />
       </Hyperlink>
-    </div>
+    </Container>
   );
 };
 

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/ProblemTypeSelect.jsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/ProblemTypeSelect.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, SelectableBox } from '@edx/paragon';
+import { Button, Container, SelectableBox } from '@edx/paragon';
 import { FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
 import { ProblemTypes, ProblemTypeKeys, AdvanceProblemKeys } from '../../../../../data/constants/problem';
 import messages from './messages';
@@ -14,7 +14,7 @@ export const ProblemTypeSelect = ({
   const settings = { 'aria-label': 'checkbox', type: 'radio' };
 
   return (
-    <>
+    <Container style={{ width: '494px', height: '400px' }}>
       <SelectableBox.Set
         columns={1}
         onChange={handleChange}
@@ -24,7 +24,12 @@ export const ProblemTypeSelect = ({
         {Object.values(ProblemTypeKeys).map((key) => (
           key !== 'advanced'
             ? (
-              <SelectableBox className="text-primary-500" id={key} value={key} {...settings}>
+              <SelectableBox
+                className="border border-light-400 text-primary-500 shadow-none"
+                id={key}
+                value={key}
+                {...settings}
+              >
                 {ProblemTypes[key].title}
               </SelectableBox>
             )
@@ -34,7 +39,7 @@ export const ProblemTypeSelect = ({
       <Button variant="link" className="pl-0 mt-2" onClick={handleClick}>
         <FormattedMessage {...messages.advanceProblemButtonLabel} />
       </Button>
-    </>
+    </Container>
   );
 };
 ProblemTypeSelect.propTypes = {

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/__snapshots__/AdvanceTypeSelect.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/__snapshots__/AdvanceTypeSelect.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with default
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>
@@ -343,7 +343,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with problem
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>
@@ -645,7 +645,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with problem
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>
@@ -947,7 +947,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with problem
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>
@@ -1249,7 +1249,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with problem
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>
@@ -1551,7 +1551,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with problem
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>
@@ -1853,7 +1853,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with problem
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>
@@ -2155,7 +2155,7 @@ exports[`AdvanceTypeSelect snapshots snapshots: renders as expected with problem
           id="blankadvanced"
           value="blankadvanced"
         >
-          Blank advance problem
+          Blank advanced problem
         </Radio>
         <ActionRow.Spacer />
       </ActionRow>

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/__snapshots__/Preview.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/__snapshots__/Preview.test.jsx.snap
@@ -3,8 +3,14 @@
 exports[`Preview snapshots snapshots: renders as expected with default props 1`] = `""`;
 
 exports[`Preview snapshots snapshots: renders as expected with problemType is choiceresponse 1`] = `
-<div
+<Container
   className="bg-light-300 rounded p-4"
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
 >
   <div
     className="small"
@@ -39,12 +45,18 @@ exports[`Preview snapshots snapshots: renders as expected with problemType is ch
       id="authoring.problemEditor.learnMoreButtonLabel.label"
     />
   </Hyperlink>
-</div>
+</Container>
 `;
 
 exports[`Preview snapshots snapshots: renders as expected with problemType is multiplechoiceresponse 1`] = `
-<div
+<Container
   className="bg-light-300 rounded p-4"
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
 >
   <div
     className="small"
@@ -79,12 +91,18 @@ exports[`Preview snapshots snapshots: renders as expected with problemType is mu
       id="authoring.problemEditor.learnMoreButtonLabel.label"
     />
   </Hyperlink>
-</div>
+</Container>
 `;
 
 exports[`Preview snapshots snapshots: renders as expected with problemType is numericalresponse 1`] = `
-<div
+<Container
   className="bg-light-300 rounded p-4"
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
 >
   <div
     className="small"
@@ -119,12 +137,18 @@ exports[`Preview snapshots snapshots: renders as expected with problemType is nu
       id="authoring.problemEditor.learnMoreButtonLabel.label"
     />
   </Hyperlink>
-</div>
+</Container>
 `;
 
 exports[`Preview snapshots snapshots: renders as expected with problemType is optionresponse 1`] = `
-<div
+<Container
   className="bg-light-300 rounded p-4"
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
 >
   <div
     className="small"
@@ -159,12 +183,18 @@ exports[`Preview snapshots snapshots: renders as expected with problemType is op
       id="authoring.problemEditor.learnMoreButtonLabel.label"
     />
   </Hyperlink>
-</div>
+</Container>
 `;
 
 exports[`Preview snapshots snapshots: renders as expected with problemType is stringresponse 1`] = `
-<div
+<Container
   className="bg-light-300 rounded p-4"
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
 >
   <div
     className="small"
@@ -199,5 +229,5 @@ exports[`Preview snapshots snapshots: renders as expected with problemType is st
       id="authoring.problemEditor.learnMoreButtonLabel.label"
     />
   </Hyperlink>
-</div>
+</Container>
 `;

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/__snapshots__/ProblemTypeSelect.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/__snapshots__/ProblemTypeSelect.test.jsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProblemTypeSelect snapshot DROPDOWN 1`] = `
-<Fragment>
+<Container
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
+>
   <SelectableBox.Set
     columns={1}
     onChange={[Function]}
@@ -10,7 +17,7 @@ exports[`ProblemTypeSelect snapshot DROPDOWN 1`] = `
   >
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="multiplechoiceresponse"
       type="radio"
       value="multiplechoiceresponse"
@@ -19,7 +26,7 @@ exports[`ProblemTypeSelect snapshot DROPDOWN 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="choiceresponse"
       type="radio"
       value="choiceresponse"
@@ -28,7 +35,7 @@ exports[`ProblemTypeSelect snapshot DROPDOWN 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="optionresponse"
       type="radio"
       value="optionresponse"
@@ -37,7 +44,7 @@ exports[`ProblemTypeSelect snapshot DROPDOWN 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="numericalresponse"
       type="radio"
       value="numericalresponse"
@@ -46,7 +53,7 @@ exports[`ProblemTypeSelect snapshot DROPDOWN 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="stringresponse"
       type="radio"
       value="stringresponse"
@@ -65,11 +72,18 @@ exports[`ProblemTypeSelect snapshot DROPDOWN 1`] = `
       id="authoring.problemEditor.problemSelect.advanceButton.label"
     />
   </Button>
-</Fragment>
+</Container>
 `;
 
 exports[`ProblemTypeSelect snapshot MULTISELECT 1`] = `
-<Fragment>
+<Container
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
+>
   <SelectableBox.Set
     columns={1}
     onChange={[Function]}
@@ -78,7 +92,7 @@ exports[`ProblemTypeSelect snapshot MULTISELECT 1`] = `
   >
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="multiplechoiceresponse"
       type="radio"
       value="multiplechoiceresponse"
@@ -87,7 +101,7 @@ exports[`ProblemTypeSelect snapshot MULTISELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="choiceresponse"
       type="radio"
       value="choiceresponse"
@@ -96,7 +110,7 @@ exports[`ProblemTypeSelect snapshot MULTISELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="optionresponse"
       type="radio"
       value="optionresponse"
@@ -105,7 +119,7 @@ exports[`ProblemTypeSelect snapshot MULTISELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="numericalresponse"
       type="radio"
       value="numericalresponse"
@@ -114,7 +128,7 @@ exports[`ProblemTypeSelect snapshot MULTISELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="stringresponse"
       type="radio"
       value="stringresponse"
@@ -133,11 +147,18 @@ exports[`ProblemTypeSelect snapshot MULTISELECT 1`] = `
       id="authoring.problemEditor.problemSelect.advanceButton.label"
     />
   </Button>
-</Fragment>
+</Container>
 `;
 
 exports[`ProblemTypeSelect snapshot NUMERIC 1`] = `
-<Fragment>
+<Container
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
+>
   <SelectableBox.Set
     columns={1}
     onChange={[Function]}
@@ -146,7 +167,7 @@ exports[`ProblemTypeSelect snapshot NUMERIC 1`] = `
   >
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="multiplechoiceresponse"
       type="radio"
       value="multiplechoiceresponse"
@@ -155,7 +176,7 @@ exports[`ProblemTypeSelect snapshot NUMERIC 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="choiceresponse"
       type="radio"
       value="choiceresponse"
@@ -164,7 +185,7 @@ exports[`ProblemTypeSelect snapshot NUMERIC 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="optionresponse"
       type="radio"
       value="optionresponse"
@@ -173,7 +194,7 @@ exports[`ProblemTypeSelect snapshot NUMERIC 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="numericalresponse"
       type="radio"
       value="numericalresponse"
@@ -182,7 +203,7 @@ exports[`ProblemTypeSelect snapshot NUMERIC 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="stringresponse"
       type="radio"
       value="stringresponse"
@@ -201,11 +222,18 @@ exports[`ProblemTypeSelect snapshot NUMERIC 1`] = `
       id="authoring.problemEditor.problemSelect.advanceButton.label"
     />
   </Button>
-</Fragment>
+</Container>
 `;
 
 exports[`ProblemTypeSelect snapshot SINGLESELECT 1`] = `
-<Fragment>
+<Container
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
+>
   <SelectableBox.Set
     columns={1}
     onChange={[Function]}
@@ -214,7 +242,7 @@ exports[`ProblemTypeSelect snapshot SINGLESELECT 1`] = `
   >
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="multiplechoiceresponse"
       type="radio"
       value="multiplechoiceresponse"
@@ -223,7 +251,7 @@ exports[`ProblemTypeSelect snapshot SINGLESELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="choiceresponse"
       type="radio"
       value="choiceresponse"
@@ -232,7 +260,7 @@ exports[`ProblemTypeSelect snapshot SINGLESELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="optionresponse"
       type="radio"
       value="optionresponse"
@@ -241,7 +269,7 @@ exports[`ProblemTypeSelect snapshot SINGLESELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="numericalresponse"
       type="radio"
       value="numericalresponse"
@@ -250,7 +278,7 @@ exports[`ProblemTypeSelect snapshot SINGLESELECT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="stringresponse"
       type="radio"
       value="stringresponse"
@@ -269,11 +297,18 @@ exports[`ProblemTypeSelect snapshot SINGLESELECT 1`] = `
       id="authoring.problemEditor.problemSelect.advanceButton.label"
     />
   </Button>
-</Fragment>
+</Container>
 `;
 
 exports[`ProblemTypeSelect snapshot TEXTINPUT 1`] = `
-<Fragment>
+<Container
+  style={
+    Object {
+      "height": "400px",
+      "width": "494px",
+    }
+  }
+>
   <SelectableBox.Set
     columns={1}
     onChange={[Function]}
@@ -282,7 +317,7 @@ exports[`ProblemTypeSelect snapshot TEXTINPUT 1`] = `
   >
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="multiplechoiceresponse"
       type="radio"
       value="multiplechoiceresponse"
@@ -291,7 +326,7 @@ exports[`ProblemTypeSelect snapshot TEXTINPUT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="choiceresponse"
       type="radio"
       value="choiceresponse"
@@ -300,7 +335,7 @@ exports[`ProblemTypeSelect snapshot TEXTINPUT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="optionresponse"
       type="radio"
       value="optionresponse"
@@ -309,7 +344,7 @@ exports[`ProblemTypeSelect snapshot TEXTINPUT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="numericalresponse"
       type="radio"
       value="numericalresponse"
@@ -318,7 +353,7 @@ exports[`ProblemTypeSelect snapshot TEXTINPUT 1`] = `
     </SelectableBox>
     <SelectableBox
       aria-label="checkbox"
-      className="text-primary-500"
+      className="border border-light-400 text-primary-500 shadow-none"
       id="stringresponse"
       type="radio"
       value="stringresponse"
@@ -337,5 +372,5 @@ exports[`ProblemTypeSelect snapshot TEXTINPUT 1`] = `
       id="authoring.problemEditor.problemSelect.advanceButton.label"
     />
   </Button>
-</Fragment>
+</Container>
 `;

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Col, Row } from '@edx/paragon';
+import { Row, Stack } from '@edx/paragon';
 import ProblemTypeSelect from './content/ProblemTypeSelect';
 import Preview from './content/Preview';
 import AdvanceTypeSelect from './content/AdvanceTypeSelect';
@@ -17,16 +17,12 @@ export const SelectTypeModal = ({
 
   return (
     <SelectTypeWrapper onClose={onClose} selected={selected}>
-      <Row className="justify-content-center align-items-stretch m-4">
+      <Row className="justify-content-center">
         {(!Object.values(AdvanceProblemKeys).includes(selected)) ? (
-          <>
-            <Col>
-              <ProblemTypeSelect selected={selected} setSelected={setSelected} />
-            </Col>
-            <Col>
-              <Preview problemType={selected} />
-            </Col>
-          </>
+          <Stack direction="horizontal" gap={4} className="flex-wrap">
+            <ProblemTypeSelect selected={selected} setSelected={setSelected} />
+            <Preview problemType={selected} />
+          </Stack>
         ) : <AdvanceTypeSelect selected={selected} setSelected={setSelected} />}
       </Row>
     </SelectTypeWrapper>

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -84,7 +84,7 @@ export const AdvanceProblemKeys = StrictDict({
 
 export const AdvanceProblems = StrictDict({
   [AdvanceProblemKeys.BLANK]: {
-    title: 'Blank advance problem',
+    title: 'Blank advanced problem',
     status: '',
     template: '<problem></problem>',
   },


### PR DESCRIPTION
JIRA Tickets: [TNL-10356](https://2u-internal.atlassian.net/browse/TNL-10356), [TNL-10359](https://2u-internal.atlassian.net/browse/TNL-10359), and [TNL-10357](https://2u-internal.atlassian.net/browse/TNL-10357)

This PR changes the following:

1.  the containers on the Problem Select page from flex to fixed sizes
2. "Blank advance problem" to "Blank advanced problem"
3. remove box shadow from problem select buttons