### PR TITLE
feat: set videoId to '' instead of null on load

### DIFF
--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -27,7 +27,7 @@ export const loadVideoData = () => (dispatch, getState) => {
   });
 
   dispatch(actions.video.load({
-    videoSource: videoUrl,
+    videoSource: videoUrl || '',
     videoId,
     fallbackVideos,
     allowVideoDownloads: rawVideoData.download_video,
@@ -91,7 +91,7 @@ export const determineVideoSources = ({
     [videoUrl, fallbackVideos] = [html5Sources[0], html5Sources.slice(1)];
   }
   return {
-    videoId: edxVideoId,
+    videoId: edxVideoId || '',
     videoUrl: videoUrl || '',
     fallbackVideos: fallbackVideos || [],
   };

--- a/src/editors/data/redux/thunkActions/video.test.js
+++ b/src/editors/data/redux/thunkActions/video.test.js
@@ -181,6 +181,19 @@ describe('video thunkActions', () => {
     const youtubeId = 'yOuTuBEiD';
     const youtubeUrl = `https://youtu.be/${youtubeId}`;
     const html5Sources = ['htmLOne', 'hTMlTwo', 'htMLthrEE'];
+    describe('when edx id, youtube id and source values are null', () => {
+      it('returns empty strings for ids and an empty array for sources', () => {
+        expect(thunkActions.determineVideoSources({
+          edxVideoId: null,
+          youtubeId: null,
+          html5Sources: null,
+        })).toEqual({
+          videoUrl: '',
+          videoId: '',
+          fallbackVideos: [],
+        });
+      });
+    });
     describe('when there is an edx video id, youtube id and html5 sources', () => {
       it('returns all three with the youtube id wrapped in url', () => {
         expect(thunkActions.determineVideoSources({


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/TNL-10300?search_id=baca607e-d134-45c0-a15c-32fe484fc03f

Partners were facing an issue with manually imported transcripts where they were not seeing transcripts after uploading and saving them. The expected behavior for uploading a transcript for a youtube url is that an edx video id would be created to be tied to that transcript. However, the issue was that we were not saving this edx video id because the `videoId` field was set to null instead of '' on load.

A workaround for this issue would be to click to and away from the Video Id form field to set `videoId` to ''.

This PR resolves the issue by ensuring we keep the field as '' during load.

**Testing**
Case 1: Youtube URL with manually added transcript
Manually added transcript displays in studio.

Case 2: Edx Video Id with manually added transcript
Manually added transcript displays in studio.

Case 3: Youtube URL with imported transcript
Imported transcript displays in studio.

Case 4: Adding a manual transcript to a Youtube URL with an already imported transcript
See results for case 6 multiple transcripts.

Case 5: Importing a youtube transcript to a Youtube URL with an existing manually added transcript
You should not be able to import a youtube transcript when you have a manually added transcript already.

Case 6: Multiple transcripts
English transcript displays in studio (may need to re-save the video block). If there is no english transcript, the first language in alphabetical order will display in studio (again, may need to re-save the video block).