### PR TITLE
feat: update onclick to close modal + top scroll

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -203,3 +203,15 @@ export const typeRowHooks = ({
     onClick,
   };
 };
+
+export const confirmSwitchToAdvancedEditor = ({
+  switchToAdvancedEditor,
+  setConfirmOpen,
+}) => {
+  switchToAdvancedEditor();
+  setConfirmOpen(false);
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth',
+  });
+}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -214,4 +214,4 @@ export const confirmSwitchToAdvancedEditor = ({
     top: 0,
     behavior: 'smooth',
   });
-}
+};

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -266,4 +266,19 @@ describe('Problem settings hooks', () => {
       expect(updateField).toHaveBeenCalledWith({ problemType: typekey });
     });
   });
+  describe('Type row hooks', () => {
+    test('test onClick', () => {
+      const switchToAdvancedEditor = jest.fn();
+      const setConfirmOpen = jest.fn();
+      const mockScrollTo = jest.fn();
+      window.scrollTo = jest.fn();
+      hooks.confirmSwitchToAdvancedEditor({
+        switchToAdvancedEditor,
+        setConfirmOpen,
+      });
+      expect(switchToAdvancedEditor).toHaveBeenCalled();
+      expect(setConfirmOpen).toHaveBeenCalledWith(false);
+      expect(window.scrollTo).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -270,7 +270,6 @@ describe('Problem settings hooks', () => {
     test('test onClick', () => {
       const switchToAdvancedEditor = jest.fn();
       const setConfirmOpen = jest.fn();
-      const mockScrollTo = jest.fn();
       window.scrollTo = jest.fn();
       hooks.confirmSwitchToAdvancedEditor({
         switchToAdvancedEditor,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/SwitchToAdvancedEditorCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/SwitchToAdvancedEditorCard.jsx
@@ -6,19 +6,12 @@ import PropTypes from 'prop-types';
 import messages from '../messages';
 import { thunkActions } from '../../../../../../data/redux';
 import BaseModal from '../../../../../TextEditor/components/BaseModal';
+import { confirmSwitchToAdvancedEditor } from '../hooks';
 
 export const SwitchToAdvancedEditorCard = ({
   switchToAdvancedEditor,
 }) => {
   const [isConfirmOpen, setConfirmOpen] = React.useState(false);
-  const openAdvancedEditor = () => {
-    switchToAdvancedEditor();
-    setConfirmOpen(false);
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-  };
 
   return (
     <Card>
@@ -28,7 +21,7 @@ export const SwitchToAdvancedEditorCard = ({
         title={(<FormattedMessage {...messages.ConfirmSwitchMessageTitle} />)}
         confirmAction={(
           <Button
-            onClick={openAdvancedEditor}
+            onClick={() => confirmSwitchToAdvancedEditor({ switchToAdvancedEditor, setConfirmOpen })}
           >
             <FormattedMessage {...messages.ConfirmSwitchButtonLabel} />
           </Button>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/SwitchToAdvancedEditorCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/SwitchToAdvancedEditorCard.jsx
@@ -11,6 +11,15 @@ export const SwitchToAdvancedEditorCard = ({
   switchToAdvancedEditor,
 }) => {
   const [isConfirmOpen, setConfirmOpen] = React.useState(false);
+  const openAdvancedEditor = () => {
+    switchToAdvancedEditor();
+    setConfirmOpen(false);
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
   return (
     <Card>
       <BaseModal
@@ -19,7 +28,7 @@ export const SwitchToAdvancedEditorCard = ({
         title={(<FormattedMessage {...messages.ConfirmSwitchMessageTitle} />)}
         confirmAction={(
           <Button
-            onClick={switchToAdvancedEditor}
+            onClick={openAdvancedEditor}
           >
             <FormattedMessage {...messages.ConfirmSwitchButtonLabel} />
           </Button>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/SwitchToAdvancedEditorCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/SwitchToAdvancedEditorCard.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`SwitchToAdvancedEditorCard snapshot snapshot: SwitchToAdvancedEditorCar
     close={[Function]}
     confirmAction={
       <Button
-        onClick={[MockFunction switchToAdvancedEditor]}
+        onClick={[Function]}
       >
         <FormattedMessage
           defaultMessage="Switch To Advanced Editor"


### PR DESCRIPTION
JIRA Tickets: [TNL-10374](https://2u-internal.atlassian.net/browse/TNL-10374) and [TNL-10375](https://2u-internal.atlassian.net/browse/TNL-10375)

This PR fixes the Advanced Problem Editor confirmation dialog not closing on confirmation and scrolls to the top of the page after confirmed.