### PR TITLE
feat: add margin to prevent footer blocking content

### DIFF
--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/__snapshots__/index.test.jsx.snap
@@ -19,7 +19,9 @@ exports[`SelectTypeWrapper snapshot 1`] = `
       </div>
     </ModalDialog.Title>
   </ModalDialog.Header>
-  <ModalDialog.Body>
+  <ModalDialog.Body
+    classname="pb-6"
+  >
     <h1>
       test child
     </h1>

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.jsx
@@ -29,7 +29,7 @@ export const SelectTypeWrapper = ({
           </div>
         </ModalDialog.Title>
       </ModalDialog.Header>
-      <ModalDialog.Body>
+      <ModalDialog.Body classname="pb-6">
         {children}
       </ModalDialog.Body>
       <SelectTypeFooter

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/__snapshots__/index.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`SelectTypeModal snapshot 1`] = `
     className="justify-content-center"
   >
     <Stack
-      className="flex-wrap"
+      className="flex-wrap mb-6"
       direction="horizontal"
       gap={4}
     >

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/index.jsx
@@ -19,7 +19,7 @@ export const SelectTypeModal = ({
     <SelectTypeWrapper onClose={onClose} selected={selected}>
       <Row className="justify-content-center">
         {(!Object.values(AdvanceProblemKeys).includes(selected)) ? (
-          <Stack direction="horizontal" gap={4} className="flex-wrap">
+          <Stack direction="horizontal" gap={4} className="flex-wrap mb-6">
             <ProblemTypeSelect selected={selected} setSelected={setSelected} />
             <Preview problemType={selected} />
           </Stack>


### PR DESCRIPTION
JIRA Ticket: [TNL-10408](https://2u-internal.atlassian.net/browse/TNL-10408)

This ticket fixes the margin error that caused the footer on the `SelectTypeModal` screen to overlap with the content on the page. After adding margins to the `ModalDialog.Body`, all content can be seen and the footer remains fixed at the bottom.