### PR TITLE
fix: add check for question length for parser

### DIFF
--- a/src/editors/containers/ProblemEditor/hooks.js
+++ b/src/editors/containers/ProblemEditor/hooks.js
@@ -12,30 +12,32 @@ export const state = StrictDict({
 
 export const parseContentForLabels = ({ editor, updateQuestion }) => {
   let content = editor.getContent();
-  const parsedLabels = content.split(/<label>|<\/label>/gm);
-  let updatedContent;
-  parsedLabels.forEach((label, i) => {
-    let updatedLabel = label;
-    if (!label.startsWith('<') && !label.endsWith('>')) {
-      let previousLabel = parsedLabels[i - 1];
-      let nextLabel = parsedLabels[i + 1];
-      if (!previousLabel.endsWith('<p>')) {
-        previousLabel = `${previousLabel}</p><p>`;
-        updatedContent = content.replace(parsedLabels[i - 1], previousLabel);
-        content = updatedContent;
+  if (content && content?.length > 0) {
+    const parsedLabels = content.split(/<label>|<\/label>/gm);
+    let updatedContent;
+    parsedLabels.forEach((label, i) => {
+      let updatedLabel = label;
+      if (!label.startsWith('<') && !label.endsWith('>')) {
+        let previousLabel = parsedLabels[i - 1];
+        let nextLabel = parsedLabels[i + 1];
+        if (!previousLabel.endsWith('<p>')) {
+          previousLabel = `${previousLabel}</p><p>`;
+          updatedContent = content.replace(parsedLabels[i - 1], previousLabel);
+          content = updatedContent;
+        }
+        if (previousLabel.endsWith('</p>') && !label.startWith('<p>')) {
+          updatedLabel = `<p>${label}`;
+          updatedContent = content.replace(label, updatedLabel);
+          content = updatedContent;
+        }
+        if (!nextLabel.startsWith('</p>')) {
+          nextLabel = `</p><p>${nextLabel}`;
+          updatedContent = content.replace(parsedLabels[i + 1], nextLabel);
+          content = updatedContent;
+        }
       }
-      if (previousLabel.endsWith('</p>') && !label.startWith('<p>')) {
-        updatedLabel = `<p>${label}`;
-        updatedContent = content.replace(label, updatedLabel);
-        content = updatedContent;
-      }
-      if (!nextLabel.startsWith('</p>')) {
-        nextLabel = `</p><p>${nextLabel}`;
-        updatedContent = content.replace(parsedLabels[i + 1], nextLabel);
-        content = updatedContent;
-      }
-    }
-  });
+    });
+  }
   updateQuestion(content);
 };
 

--- a/src/editors/containers/ProblemEditor/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/hooks.test.js
@@ -58,10 +58,18 @@ describe('Problem editor hooks', () => {
     });
 
     describe('parseContentForLabels', () => {
-      test('it calls getContent and setContent', () => {
+      test('it calls getContent and updateQuestion for some content', () => {
         const editor = { getContent: jest.fn(() => '<p><label>Some question label</label></p><p>some content <label>around a label</label> followed by more text</p><img src="/static/soMEImagEURl1.jpeg"/>') };
         const updateQuestion = jest.fn();
         const content = '<p><label>Some question label</label></p><p>some content </p><p><label>around a label</label></p><p> followed by more text</p><img src="/static/soMEImagEURl1.jpeg"/>';
+        module.parseContentForLabels({ editor, updateQuestion });
+        expect(editor.getContent).toHaveBeenCalled();
+        expect(updateQuestion).toHaveBeenCalledWith(content);
+      });
+      test('it calls getContent and updateQuestion for empty content', () => {
+        const editor = { getContent: jest.fn(() => '') };
+        const updateQuestion = jest.fn();
+        const content = '';
         module.parseContentForLabels({ editor, updateQuestion });
         expect(editor.getContent).toHaveBeenCalled();
         expect(updateQuestion).toHaveBeenCalledWith(content);


### PR DESCRIPTION
This PR fixes the `endsWith` bug when a question was not defined or an empty string. Previously, the label parser assumed the question would have a length. Now, if the question is undefined or an empty string , it will not be parsed for labels.