### PR TITLE
fix: selectTypeModal header z-index

### DIFF
--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/__snapshots__/index.test.jsx.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectTypeWrapper snapshot 1`] = `
-<div>
-  <ModalDialog.Header>
+<div
+  className="position-relative zindex-0"
+>
+  <ModalDialog.Header
+    className="shadow-sm zindex-10"
+  >
     <ModalDialog.Title>
       <FormattedMessage
         defaultMessage="Select problem type"

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/index.jsx
@@ -16,8 +16,10 @@ export const SelectTypeWrapper = ({
   const handleCancel = hooks.handleCancel({ onClose });
 
   return (
-    <div>
-      <ModalDialog.Header>
+    <div
+      className="position-relative zindex-0"
+    >
+      <ModalDialog.Header className="shadow-sm zindex-10">
         <ModalDialog.Title>
           <FormattedMessage {...messages.selectTypeTitle} />
           <div className="pgn__modal-close-container">


### PR DESCRIPTION
JIRA Ticket: [TNL-10407](https://2u-internal.atlassian.net/browse/TNL-10407)

This PR changes the z-index for the `SelectTypeModal` header. Previously, the header would be covered by the content in the main body when the page was scrolled. Now, the content scrolls below the header preventing, a visual conflict.