### PR TITLE
feat: react to OLX parser process number answers

### DIFF
--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -270,7 +270,7 @@ class ReactStateOLXParser {
   }
 
   hasAttributeWithValue(obj, attr) {
-    return _.has(obj, attr) && _.get(obj, attr, '').trim() !== '';
+    return _.has(obj, attr) && _.get(obj, attr, '').toString().trim() !== '';
   }
 
   buildOLX() {


### PR DESCRIPTION
This PR seeks to correct the following error which was triggering when attempting to save number only answers.
```
Uncaught TypeError: o.default.get(...).trim is not a function
    at e.value (ReactStateOLXParser.js:252:53)
    at ReactStateOLXParser.js:47:16
    at Array.forEach (<anonymous>)
    at e.value (ReactStateOLXParser.js:44:13)
    at e.value (ReactStateOLXParser.js:107:31)
    at e.value (ReactStateOLXParser.js:263:30)
    at hooks.js:12:47
    at hooks.js:27:14
    at Object.s (react-dom.production.min.js:14:84)
    at d (react-dom.production.min.js:14:238)
```