### PR TITLE
fix: settings col width in advanced view

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page 1`] = `
   className="settingsWidget ml-4"
 >
   <div
-    className="mb-3 settingsCardTopdiv"
+    className="mb-3"
   >
     <injectIntl(ShimmedIntlComponent)
       problemType="stringresponse"
@@ -85,7 +85,7 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page advanced
   className="settingsWidget ml-4"
 >
   <div
-    className="mb-3 settingsCardTopdiv"
+    className="mb-3"
   >
     <injectIntl(ShimmedIntlComponent)
       problemType="stringresponse"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -35,7 +35,7 @@ export const SettingsWidget = ({
   const { isAdvancedCardsVisible, showAdvancedCards } = showAdvancedSettingsCards();
   return (
     <div className="settingsWidget ml-4">
-      <div className="mb-3 settingsCardTopdiv">
+      <div className="mb-3">
         <TypeCard
           answers={answers}
           blockTitle={blockTitle}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -191,7 +191,7 @@ export const messages = {
   },
   ConfirmSwitchButtonLabel: {
     id: 'authoring.problemeditor.settings.switchtoadvancededitor.message',
-    defaultMessage: 'Switch To Advanced Editor',
+    defaultMessage: 'Switch to advanced editor',
     description: 'message to confirm that a user wants to use the advanced editor',
   },
   explanationInputLabel: {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/SwitchToAdvancedEditorCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/SwitchToAdvancedEditorCard.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`SwitchToAdvancedEditorCard snapshot snapshot: SwitchToAdvancedEditorCar
         variant="default"
       >
         <FormattedMessage
-          defaultMessage="Switch To Advanced Editor"
+          defaultMessage="Switch to advanced editor"
           description="message to confirm that a user wants to use the advanced editor"
           id="authoring.problemeditor.settings.switchtoadvancededitor.message"
         />

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -8,8 +8,8 @@ exports[`EditorProblemView component renders raw editor 1`] = `
     className="editProblemView d-flex flex-row flex-nowrap justify-content-end"
   >
     <Container
-      className="mt-4.5"
-      size="lg"
+      className="advancedEditorTopMargin p-0"
+      fluid={true}
     >
       <RawEditor
         content={null}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -5,10 +5,11 @@ exports[`EditorProblemView component renders raw editor 1`] = `
   getContent={[Function]}
 >
   <div
-    className="editProblemView d-flex flex-row flex-nowrap justify-content-around"
+    className="editProblemView d-flex flex-row flex-nowrap justify-content-end"
   >
-    <div
+    <Container
       className="mt-4.5"
+      size="lg"
     >
       <RawEditor
         content={null}
@@ -18,13 +19,8 @@ exports[`EditorProblemView component renders raw editor 1`] = `
           }
         }
         lang="xml"
-        width={
-          Object {
-            "width": "75%",
-          }
-        }
       />
-    </div>
+    </Container>
     <span
       className="editProblemView-settingsColumn"
     >
@@ -41,7 +37,7 @@ exports[`EditorProblemView component renders simple view 1`] = `
   getContent={[Function]}
 >
   <div
-    className="editProblemView d-flex flex-row flex-nowrap justify-content-around"
+    className="editProblemView d-flex flex-row flex-nowrap justify-content-end"
   >
     <span
       className="flex-grow-1"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -5,10 +5,10 @@ exports[`EditorProblemView component renders raw editor 1`] = `
   getContent={[Function]}
 >
   <div
-    className="editProblemView d-flex flex-row flex-nowrap justify-content-end"
+    className="editProblemView d-flex flex-row flex-nowrap justify-content-around"
   >
-    <span
-      className="flex-grow-1"
+    <div
+      className="mt-4.5"
     >
       <RawEditor
         content={null}
@@ -18,8 +18,13 @@ exports[`EditorProblemView component renders raw editor 1`] = `
           }
         }
         lang="xml"
+        width={
+          Object {
+            "width": "75%",
+          }
+        }
       />
-    </span>
+    </div>
     <span
       className="editProblemView-settingsColumn"
     >
@@ -36,7 +41,7 @@ exports[`EditorProblemView component renders simple view 1`] = `
   getContent={[Function]}
 >
   <div
-    className="editProblemView d-flex flex-row flex-nowrap justify-content-end"
+    className="editProblemView d-flex flex-row flex-nowrap justify-content-around"
   >
     <span
       className="flex-grow-1"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -24,17 +24,17 @@ export const EditProblemView = ({
 
   return (
     <EditorContainer getContent={getContent}>
-      <div className="editProblemView d-flex flex-row flex-nowrap justify-content-end">
-        <span className="flex-grow-1">
-          {isAdvancedProblemType ? (
-            <RawEditor editorRef={editorRef} lang="xml" content={problemState.rawOLX} />
-          ) : (
-            <>
-              <QuestionWidget />
-              <AnswerWidget problemType={problemType} />
-            </>
-          )}
-        </span>
+      <div className="editProblemView d-flex flex-row flex-nowrap justify-content-around">
+        {isAdvancedProblemType ? (
+          <div className="mt-4.5">
+            <RawEditor editorRef={editorRef} lang="xml" content={problemState.rawOLX} width={{ width: '75%' }} />
+          </div>
+        ) : (
+          <span className="flex-grow-1">
+            <QuestionWidget />
+            <AnswerWidget problemType={problemType} />
+          </span>
+        )}
         <span className="editProblemView-settingsColumn">
           <SettingsWidget problemType={problemType} />
         </span>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -2,6 +2,8 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { connect } from 'react-redux';
+import { Container } from '@edx/paragon';
+
 import AnswerWidget from './AnswerWidget';
 import SettingsWidget from './SettingsWidget';
 import QuestionWidget from './QuestionWidget';
@@ -24,11 +26,11 @@ export const EditProblemView = ({
 
   return (
     <EditorContainer getContent={getContent}>
-      <div className="editProblemView d-flex flex-row flex-nowrap justify-content-around">
+      <div className="editProblemView d-flex flex-row flex-nowrap justify-content-end">
         {isAdvancedProblemType ? (
-          <div className="mt-4.5">
-            <RawEditor editorRef={editorRef} lang="xml" content={problemState.rawOLX} width={{ width: '75%' }} />
-          </div>
+          <Container size="lg" className="mt-4.5">
+            <RawEditor editorRef={editorRef} lang="xml" content={problemState.rawOLX} />
+          </Container>
         ) : (
           <span className="flex-grow-1">
             <QuestionWidget />

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -28,7 +28,7 @@ export const EditProblemView = ({
     <EditorContainer getContent={getContent}>
       <div className="editProblemView d-flex flex-row flex-nowrap justify-content-end">
         {isAdvancedProblemType ? (
-          <Container size="lg" className="mt-4.5">
+          <Container fluid className="advancedEditorTopMargin p-0">
             <RawEditor editorRef={editorRef} lang="xml" content={problemState.rawOLX} />
           </Container>
         ) : (

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
@@ -1,6 +1,11 @@
 .editProblemView {
   .editProblemView-settingsColumn {
-    flex-basis: 320px;
+    width: 320px;
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
+  .advancedEditorTopMargin {
+    margin-top: 40px;
   }
 }
 

--- a/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
@@ -251,6 +251,7 @@ exports[`TextEditor snapshots loaded, raw editor 1`] = `
         }
       }
       lang="html"
+      width={null}
     />
   </div>
 </EditorContainer>

--- a/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
@@ -251,7 +251,6 @@ exports[`TextEditor snapshots loaded, raw editor 1`] = `
         }
       }
       lang="html"
-      width={null}
     />
   </div>
 </EditorContainer>

--- a/src/editors/sharedComponents/RawEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/sharedComponents/RawEditor/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RawEditor renders as expected with content equal to null 1`] = `
-<Fragment>
+<div
+  style={
+    Object {
+      "width": "80%",
+    }
+  }
+>
   <Alert
     variant="danger"
   >
@@ -9,11 +15,13 @@ exports[`RawEditor renders as expected with content equal to null 1`] = `
     html
      editor.
   </Alert>
-</Fragment>
+</div>
 `;
 
 exports[`RawEditor renders as expected with default behavior 1`] = `
-<Fragment>
+<div
+  style={null}
+>
   <Alert
     variant="danger"
   >
@@ -32,11 +40,13 @@ exports[`RawEditor renders as expected with default behavior 1`] = `
     lang="html"
     value="eDiTablE Text"
   />
-</Fragment>
+</div>
 `;
 
 exports[`RawEditor renders as expected with lang equal to xml 1`] = `
-<Fragment>
+<div
+  style={null}
+>
   <injectIntl(ShimmedIntlComponent)
     innerRef={
       Object {
@@ -48,5 +58,5 @@ exports[`RawEditor renders as expected with lang equal to xml 1`] = `
     lang="xml"
     value="eDiTablE Text"
   />
-</Fragment>
+</div>
 `;

--- a/src/editors/sharedComponents/RawEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/sharedComponents/RawEditor/__snapshots__/index.test.jsx.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RawEditor renders as expected with content equal to null 1`] = `
-<div
-  style={
-    Object {
-      "width": "80%",
-    }
-  }
->
+<div>
   <Alert
     variant="danger"
   >
@@ -19,9 +13,7 @@ exports[`RawEditor renders as expected with content equal to null 1`] = `
 `;
 
 exports[`RawEditor renders as expected with default behavior 1`] = `
-<div
-  style={null}
->
+<div>
   <Alert
     variant="danger"
   >
@@ -44,9 +36,7 @@ exports[`RawEditor renders as expected with default behavior 1`] = `
 `;
 
 exports[`RawEditor renders as expected with lang equal to xml 1`] = `
-<div
-  style={null}
->
+<div>
   <injectIntl(ShimmedIntlComponent)
     innerRef={
       Object {

--- a/src/editors/sharedComponents/RawEditor/index.jsx
+++ b/src/editors/sharedComponents/RawEditor/index.jsx
@@ -14,12 +14,11 @@ export const RawEditor = ({
   editorRef,
   content,
   lang,
-  width,
 }) => {
   const value = getValue(content);
 
   return (
-    <div style={width}>
+    <div>
       {lang === 'xml' ? null : (
         <Alert variant="danger">
           You are using the raw {lang} editor.
@@ -40,7 +39,6 @@ RawEditor.defaultProps = {
   editorRef: null,
   content: null,
   lang: 'html',
-  width: null,
 };
 RawEditor.propTypes = {
   editorRef: PropTypes.oneOfType([
@@ -54,9 +52,6 @@ RawEditor.propTypes = {
     }),
   ]),
   lang: PropTypes.string,
-  width: PropTypes.shape({
-    width: PropTypes.string,
-  }),
 };
 
 export default RawEditor;

--- a/src/editors/sharedComponents/RawEditor/index.jsx
+++ b/src/editors/sharedComponents/RawEditor/index.jsx
@@ -14,11 +14,12 @@ export const RawEditor = ({
   editorRef,
   content,
   lang,
+  width,
 }) => {
   const value = getValue(content);
 
   return (
-    <>
+    <div style={width}>
       {lang === 'xml' ? null : (
         <Alert variant="danger">
           You are using the raw {lang} editor.
@@ -32,13 +33,14 @@ export const RawEditor = ({
         />
       ) : null}
 
-    </>
+    </div>
   );
 };
 RawEditor.defaultProps = {
   editorRef: null,
   content: null,
   lang: 'html',
+  width: null,
 };
 RawEditor.propTypes = {
   editorRef: PropTypes.oneOfType([
@@ -52,6 +54,9 @@ RawEditor.propTypes = {
     }),
   ]),
   lang: PropTypes.string,
+  width: PropTypes.shape({
+    width: PropTypes.string,
+  }),
 };
 
 export default RawEditor;

--- a/src/editors/sharedComponents/RawEditor/index.test.jsx
+++ b/src/editors/sharedComponents/RawEditor/index.test.jsx
@@ -30,6 +30,7 @@ describe('RawEditor', () => {
     },
     content: null,
     lang: 'html',
+    width: { width: '80%' },
   };
 
   test('renders as expected with default behavior', () => {


### PR DESCRIPTION
JIRA Ticket: [TNL-10402](https://2u-internal.atlassian.net/browse/TNL-10402)

This PR fixes the width of the settings column in the advanced problem editor view. The raw editor was overriding the `flex-grow-1` class and requires its own width styling.