### PR TITLE
fix: add empty answer to problem without answers

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -59,7 +59,15 @@ export class OLXParser {
     let data = {};
     const widget = _.get(this.problem, `${problemType}.${widgetName}`);
     const choice = _.get(widget, option);
-    if (_.isArray(choice)) {
+    if (_.isEmpty(choice)) {
+      answers.push(
+        {
+          id: indexToLetterMap[answers.length],
+          title: '',
+          correct: true,
+        },
+      );
+    } else if (_.isArray(choice)) {
       choice.forEach((element, index) => {
         const title = element['#text'];
         const correct = eval(element['@_correct'].toLowerCase());

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -6,6 +6,7 @@ import {
   numericInputWithFeedbackAndHintsOLX,
   numericInputWithFeedbackAndHintsOLXException,
   textInputWithFeedbackAndHintsOLX,
+  multipleChoiceWithoutAnswers,
   multipleChoiceWithFeedbackAndHintsOLX,
   textInputWithFeedbackAndHintsOLXWithMultipleAnswers,
   advancedProblemOlX,
@@ -88,6 +89,11 @@ describe('Check OLXParser hints', () => {
 });
 
 describe('Check OLXParser for answer parsing', () => {
+  test('Test check single select with empty answers', () => {
+    const olxparser = new OLXParser(multipleChoiceWithoutAnswers.rawOLX);
+    const answer = olxparser.parseMultipleChoiceAnswers('multiplechoiceresponse', 'choicegroup', 'choice');
+    expect(answer).toEqual(multipleChoiceWithoutAnswers.data);
+  });
   test('Test checkbox answer', () => {
     const olxparser = new OLXParser(checkboxesOLXWithFeedbackAndHintsOLX.rawOLX);
     const answer = olxparser.parseMultipleChoiceAnswers('choiceresponse', 'checkboxgroup', 'choice');

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -138,6 +138,26 @@ an incorrect answer        <choicehint selected="true">You can specify optional 
 
 export const checkboxesOLXWithFeedbackAndHintsOLX = getCheckboxesOLXWithFeedbackAndHintsOLX({});
 
+export const multipleChoiceWithoutAnswers = {
+  rawOLX: `<problem>
+  <multiplechoiceresponse>
+    <choicegroup>
+  </choicegroup>
+  </multiplechoiceresponse>
+  <demandhint></demandhint>
+  <solution></solution>
+  </problem>`,
+  data: {
+    answers: [
+      {
+        id: 'A',
+        title: '',
+        correct: true,
+      },
+    ],
+  },
+};
+
 export const dropdownOLXWithFeedbackAndHintsOLX = {
   rawOLX: `<problem>
 <optionresponse>


### PR DESCRIPTION
JIRA Ticket: [TNL-10428](https://2u-internal.atlassian.net/browse/TNL-10428)

Previously, when a user created a problem and saved it without adding an answer, they would be redirected to the advanced editor page because the parser did not check for an empty answer array. Now if a problem does not have answers, the parser adds an empty answer to the problem and takes the user to the visual editor.