### PR TITLE
feat: multiple numericalresponse tags no longer special-cased against going to the advanced editor. TNL-10426.

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -226,28 +226,6 @@ export class OLXParser {
 
   parseNumericResponse() {
     const { numericalresponse } = this.problem;
-    let answers = [];
-    let subAnswers = [];
-    let data = {};
-    // TODO: Find a way to add answers using additional_answers v/s numericalresponse
-    if (_.isArray(numericalresponse)) {
-      numericalresponse.forEach((numericalAnswer) => {
-        subAnswers = this.parseNumericResponseObject(numericalAnswer, answers.length);
-        answers = _.concat(answers, subAnswers);
-      });
-    } else {
-      subAnswers = this.parseNumericResponseObject(numericalresponse, answers.length);
-      answers = _.concat(answers, subAnswers);
-    }
-
-    data = {
-      answers,
-    };
-
-    return data;
-  }
-
-  parseNumericResponseObject(numericalresponse, answerOffset) {
     let answerFeedback = '';
     const answers = [];
     let responseParam = {};
@@ -261,7 +239,7 @@ export class OLXParser {
       };
     }
     answers.push({
-      id: indexToLetterMap[answers.length + answerOffset],
+      id: indexToLetterMap[answers.length],
       title: numericalresponse['@_answer'],
       correct: true,
       selectedFeedback: feedback,
@@ -274,7 +252,7 @@ export class OLXParser {
       additionalAnswer.forEach((newAnswer) => {
         answerFeedback = this.getFeedback(newAnswer);
         answers.push({
-          id: indexToLetterMap[answers.length + answerOffset],
+          id: indexToLetterMap[answers.length],
           title: newAnswer['@_answer'],
           correct: true,
           selectedFeedback: answerFeedback,
@@ -283,13 +261,13 @@ export class OLXParser {
     } else {
       answerFeedback = this.getFeedback(additionalAnswer);
       answers.push({
-        id: indexToLetterMap[answers.length + answerOffset],
+        id: indexToLetterMap[answers.length],
         title: additionalAnswer['@_answer'],
         correct: true,
         selectedFeedback: answerFeedback,
       });
     }
-    return answers;
+    return { answers };
   }
 
   parseQuestions(problemType) {
@@ -386,10 +364,8 @@ export class OLXParser {
       return ProblemTypeKeys.ADVANCED;
     }
     // make sure compound problems are treated as advanced
-    // TODO: Find a way to add answers using additional_answers v/s numericalresponse
     if ((problemTypeKeys.length > 1)
-      || (problemTypeKeys[0] !== ProblemTypeKeys.NUMERIC // multiple numeric problems are really just multiple answers
-        && _.isArray(this.problem[problemTypeKeys[0]])
+      || (_.isArray(this.problem[problemTypeKeys[0]])
         && this.problem[problemTypeKeys[0]].length > 1)) {
       return ProblemTypeKeys.ADVANCED;
     }

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -4,13 +4,14 @@ import {
   getCheckboxesOLXWithFeedbackAndHintsOLX,
   dropdownOLXWithFeedbackAndHintsOLX,
   numericInputWithFeedbackAndHintsOLX,
-  numericInputWithFeedbackAndHintsOLXException,
   textInputWithFeedbackAndHintsOLX,
   multipleChoiceWithoutAnswers,
   multipleChoiceWithFeedbackAndHintsOLX,
   textInputWithFeedbackAndHintsOLXWithMultipleAnswers,
   advancedProblemOlX,
   multipleProblemOlX,
+  multipleProblemTwoOlX,
+  multipleProblemThreeOlX,
   blankProblemOLX,
   blankQuestionOLX,
   styledQuestionOLX,
@@ -50,6 +51,16 @@ describe('Check OLXParser problem type', () => {
   });
   test('Test Advanced Problem Type by multiples', () => {
     const olxparser = new OLXParser(multipleProblemOlX.rawOLX);
+    const problemType = olxparser.getProblemType();
+    expect(problemType).toBe(ProblemTypeKeys.ADVANCED);
+  });
+  test('Test Advanced Problem Type by multiples, second example', () => {
+    const olxparser = new OLXParser(multipleProblemTwoOlX.rawOLX);
+    const problemType = olxparser.getProblemType();
+    expect(problemType).toBe(ProblemTypeKeys.ADVANCED);
+  });
+  test('Test Advanced Problem Type by multiples, third example', () => {
+    const olxparser = new OLXParser(multipleProblemThreeOlX.rawOLX);
     const problemType = olxparser.getProblemType();
     expect(problemType).toBe(ProblemTypeKeys.ADVANCED);
   });
@@ -124,11 +135,6 @@ describe('Check OLXParser for answer parsing', () => {
     const answer = olxparser.parseNumericResponse();
     expect(answer).toEqual(numericInputWithFeedbackAndHintsOLX.data);
   });
-  test('Test numerical response answers exception', () => {
-    const olxparser = new OLXParser(numericInputWithFeedbackAndHintsOLXException.rawOLX);
-    const answer = olxparser.parseNumericResponse();
-    expect(answer).toEqual(numericInputWithFeedbackAndHintsOLXException.data);
-  });
 });
 
 describe('Check OLXParser for question parsing', () => {
@@ -156,11 +162,6 @@ describe('Check OLXParser for question parsing', () => {
     const olxparser = new OLXParser(numericInputWithFeedbackAndHintsOLX.rawOLX);
     const question = olxparser.parseQuestions('numericalresponse');
     expect(question).toEqual(numericInputWithFeedbackAndHintsOLX.question);
-  });
-  test('Test numerical response question exception', () => {
-    const olxparser = new OLXParser(numericInputWithFeedbackAndHintsOLXException.rawOLX);
-    const question = olxparser.parseQuestions('numericalresponse');
-    expect(question).toEqual(numericInputWithFeedbackAndHintsOLXException.question);
   });
   test('Test OLX with no question content should have empty string for question', () => {
     const olxparser = new OLXParser(blankQuestionOLX.rawOLX);

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -258,11 +258,6 @@ class ReactStateOLXParser {
     let answerObject = {};
     const additionalAnswers = [];
     let firstCorrectAnswerParsed = false;
-    /*
-    TODO: Need to figure out how to add multiple numericalresponse,
-    the parser right now converts all the other right answers into
-    additional answers.
-    */
     answers.forEach((answer) => {
       const correcthint = this.getAnswerHints(answer);
       if (this.hasAttributeWithValue(answer, 'title')) {

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
@@ -3,7 +3,6 @@ import {
   checkboxesOLXWithFeedbackAndHintsOLX,
   dropdownOLXWithFeedbackAndHintsOLX,
   numericInputWithFeedbackAndHintsOLX,
-  numericInputWithFeedbackAndHintsOLXException,
   textInputWithFeedbackAndHintsOLX,
   multipleChoiceWithFeedbackAndHintsOLX,
   textInputWithFeedbackAndHintsOLXWithMultipleAnswers,
@@ -45,13 +44,6 @@ describe('Check React Sate OLXParser problem', () => {
     const stateParser = new ReactStateOLXParser({ problem });
     const buildOLX = stateParser.buildOLX();
     expect(buildOLX.replace(/\s/g, '')).toEqual(numericInputWithFeedbackAndHintsOLX.buildOLX.replace(/\s/g, ''));
-  });
-  test('Test numerical response with feedback and hints problem type with exception', () => {
-    const olxparser = new OLXParser(numericInputWithFeedbackAndHintsOLXException.rawOLX);
-    const problem = olxparser.getParsedOLXData();
-    const stateParser = new ReactStateOLXParser({ problem });
-    const buildOLX = stateParser.buildOLX();
-    expect(buildOLX.replace(/\s/g, '')).toEqual(numericInputWithFeedbackAndHintsOLXException.buildOLX.replace(/\s/g, ''));
   });
   test('Test string response with feedback and hints, multiple answers', () => {
     const olxparser = new OLXParser(textInputWithFeedbackAndHintsOLXWithMultipleAnswers.rawOLX);

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -523,83 +523,6 @@ export const textInputWithFeedbackAndHintsOLXWithMultipleAnswers = {
 `,
 };
 
-export const numericInputWithFeedbackAndHintsOLXException = {
-  rawOLX: `<problem>
-  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
-
-  <label>Add the question text, or prompt, here. This text is required.</label>
-  <description>You can add an optional tip or note related to the prompt like this. </description>
-  <numericalresponse answer="300">
-    <formulaequationinput />
-  </numericalresponse>
-  <numericalresponse answer="100">
-    <responseparam type="tolerance" default="5" />
-    <formulaequationinput />
-    <correcthint>You can specify optional feedback like this, which appears after this answer is submitted.</correcthint>
-  </numericalresponse>
-  <numericalresponse answer="200">
-    <responseparam type="tolerance" default="4" />
-    <additional_answer answer="500"><correcthint>This is one feedback!</correcthint></additional_answer>
-    <formulaequationinput />
-  </numericalresponse>
-
-  <demandhint>
-    <hint>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</hint>
-    <hint>If you add more than one hint, a different hint appears each time learners select the hint button.</hint>
-  </demandhint>
-  </problem>`,
-  data: {
-    answers: [
-      {
-        id: 'A',
-        title: '300',
-        correct: true,
-        selectedFeedback: '',
-      },
-      {
-        id: 'B',
-        title: '100',
-        correct: true,
-        selectedFeedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
-        tolerance: '5',
-      },
-      {
-        id: 'C',
-        title: '200',
-        correct: true,
-        selectedFeedback: '',
-        tolerance: '4',
-      },
-      {
-        id: 'D',
-        title: '500',
-        correct: true,
-        selectedFeedback: 'This is one feedback!',
-      },
-    ],
-  },
-  question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
-  buildOLX: `<problem>
-  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
-  <label>Add the question text, or prompt, here. This text is required.</label>
-  <em>You can add an optional tip or note related to the prompt like this.</em>
-  <numericalresponse answer="300">
-    <additional_answer answer="100">
-      <correcthint>You can specify optional feedback like this, which appears after this answer is submitted.</correcthint>
-    </additional_answer>
-    <additional_answer answer="200"></additional_answer>
-    <additional_answer answer="500">
-      <correcthint>This is one feedback!</correcthint>
-    </additional_answer>
-    <formulaequationinput></formulaequationinput>
-  </numericalresponse>
-  <demandhint>
-    <hint>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</hint>
-    <hint>If you add more than one hint, a different hint appears each time learners select the hint button.</hint>
-  </demandhint>
-</problem>
-`,
-};
 export const advancedProblemOlX = {
   rawOLX: `<problem>
   <formularesponse type="ci" samples="R_1,R_2,R_3@1,2,3:3,4,5#10" answer="R_1*R_2/R_3">
@@ -619,6 +542,26 @@ export const multipleProblemOlX = {
   <stringresponse answer="other correct answer">
     <textline size="20"/>
   </stringresponse>
+</problem>`,
+};
+export const multipleProblemTwoOlX = {
+  rawOLX: `<problem>
+  <numericalresponse answer="100">
+    <formulaequationinput></formulaequationinput>
+  </numericalresponse>
+  <numericalresponse answer="200">
+    <formulaequationinput></formulaequationinput>
+  </numericalresponse>
+</problem>`,
+};
+export const multipleProblemThreeOlX = {
+  rawOLX: `<problem>
+  <stringresponse answer="correct answer">
+    <textline size="20"/>
+  </stringresponse>
+  <numericalresponse answer="200">
+    <formulaequationinput></formulaequationinput>
+  </numericalresponse>
 </problem>`,
 };
 export const blankProblemOLX = {


### PR DESCRIPTION
feat: multiple numericalresponse tags no longer special-cased against going to the advanced editor. TNL-10426.