### PR TITLE
feat: green radio+checkbox only for valid Checker

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
@@ -7,13 +7,13 @@
 // overrides paragon in order to make checked radio and checkboxes green
 $checked-color: '%230D7D4D';
 
-.pgn__form-radio-input {
+.pgn__form-radio.pgn__form-control-valid input {
   &:checked {
     background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$checked-color}'/></svg>")
   }
 }
 
-.pgn__form-checkbox-input {
+.pgn__form-checkbox.pgn__form-control-valid input {
   &:checked {
     background-image: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='#{$checked-color}'/></svg>");
   }


### PR DESCRIPTION
Fix to merged change https://github.com/openedx/frontend-lib-content-components/pull/234.

Advanced selection was showing green radio buttons. This PR will only apply green radio and checkboxes to radio and checkboxes with the isValid attribute set to true.