### PR TITLE
Feat  allow singleselect to accept multiple correct answers

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -55,7 +55,7 @@ export const useFeedback = (answer) => {
 };
 
 export const isSingleAnswerProblem = (problemType) => (
-  problemType === ProblemTypeKeys.DROPDOWN || problemType === ProblemTypeKeys.SINGLESELECT
+  problemType === ProblemTypeKeys.DROPDOWN
 );
 
 export const useAnswerContainer = ({ answers, updateField }) => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
@@ -110,7 +110,7 @@ describe('Answer Options Hooks', () => {
   });
   describe('isSingleAnswerProblem()', () => {
     test('singleSelect', () => {
-      expect(module.isSingleAnswerProblem(ProblemTypeKeys.SINGLESELECT)).toBe(true);
+      expect(module.isSingleAnswerProblem(ProblemTypeKeys.SINGLESELECT)).toBe(false);
     });
     test('multiSelect', () => {
       expect(module.isSingleAnswerProblem(ProblemTypeKeys.MULTISELECT)).toBe(false);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -207,7 +207,7 @@ export const typeRowHooks = ({
   updateAnswer,
 }) => {
   const onClick = () => {
-    if (typeKey === ProblemTypeKeys.SINGLESELECT || typeKey === ProblemTypeKeys.DROPDOWN) {
+    if (typeKey === ProblemTypeKeys.DROPDOWN) {
       if (correctAnswerCount > 1) {
         answers.forEach(answer => {
           updateAnswer({ ...answer, correct: false });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -276,8 +276,7 @@ describe('Problem settings hooks', () => {
       });
       output.onClick();
       expect(setBlockTitle).toHaveBeenCalledWith('Single select');
-      expect(updateAnswer).toHaveBeenNthCalledWith(1, { ...answers[0], correct: false });
-      expect(updateAnswer).toHaveBeenNthCalledWith(2, { ...answers[1], correct: false });
+      expect(updateAnswer).not.toHaveBeenCalled();
       expect(updateField).toHaveBeenCalledWith({ problemType: typekey });
     });
   });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -250,7 +250,7 @@ describe('Problem settings hooks', () => {
 
   describe('Type row hooks', () => {
     test('test onClick', () => {
-      const typekey = 'multiplechoiceresponse';
+      const typekey = 'optionresponse';
       const problemType = 'choiceresponse';
       const blockTitle = 'Multi-select';
       const setBlockTitle = jest.fn();
@@ -275,8 +275,9 @@ describe('Problem settings hooks', () => {
         updateAnswer,
       });
       output.onClick();
-      expect(setBlockTitle).toHaveBeenCalledWith('Single select');
-      expect(updateAnswer).not.toHaveBeenCalled();
+      expect(setBlockTitle).toHaveBeenCalledWith('Dropdown');
+      expect(updateAnswer).toHaveBeenNthCalledWith(1, { ...answers[0], correct: false });
+      expect(updateAnswer).toHaveBeenNthCalledWith(2, { ...answers[1], correct: false });
       expect(updateField).toHaveBeenCalledWith({ problemType: typekey });
     });
   });

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -125,8 +125,14 @@ const problem = createSlice({
         ...payload,
       },
     }),
-    load: (state, { payload }) => ({
+    load: (state, { payload: { settings: { scoring, showAnswer, ...settings }, ...payload } }) => ({
       ...state,
+      settings: {
+        ...state.settings,
+        scoring: { ...state.settings.scoring, ...scoring },
+        showAnswer: { ...state.settings.showAnswer, ...showAnswer },
+        ...settings,
+      },
       ...payload,
     }),
     setEnableTypeSelection: (state) => ({

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -125,14 +125,8 @@ const problem = createSlice({
         ...payload,
       },
     }),
-    load: (state, { payload: { settings: { scoring, showAnswer, ...settings }, ...payload } }) => ({
+    load: (state, { payload }) => ({
       ...state,
-      settings: {
-        ...state.settings,
-        scoring: { ...state.settings.scoring, ...scoring },
-        showAnswer: { ...state.settings.showAnswer, ...showAnswer },
-        ...settings,
-      },
       ...payload,
     }),
     setEnableTypeSelection: (state) => ({


### PR DESCRIPTION
This PR allows multiple correct answers to be selected in problem editor's single select type. This is due to feedback that course authors may want multiple correct answers even though learners can only select one answer to respond with.

https://2u-internal.atlassian.net/browse/TNL-10430