### PR TITLE
fix: getGeneralFeedback selectedFeedback error

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -379,7 +379,7 @@ export class OLXParser {
     2. All the problem's incorrect, if Selected answers are equivalent strings, and there is no other feedback.
     */
     if (problemType === ProblemTypeKeys.SINGLESELECT || problemType === ProblemTypeKeys.DROPDOWN) {
-      const firstIncorrectAnswerText = answers.find(answer => answer.correct === false).selectedFeedback;
+      const firstIncorrectAnswerText = answers.find(answer => answer.correct === false)?.selectedFeedback;
       const isAllIncorrectSelectedFeedbackTheSame = answers.every(answer => (answer.correct
         ? true
         : answer?.selectedFeedback === firstIncorrectAnswerText


### PR DESCRIPTION
This PR resolves the bug in the OLXParser inside the `getGeneralFeedback` function. The function expected that all answers would have `selectedFeedback` defined. However, when a single select or dropdown problem are opened without answers, `selectedFeedback` is not defined. This caused these problems to be rendered in the Advanced Editor when they should be rendered in the visual editor.