### PR TITLE
feat: fix checkbox colors for feedback

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/GroupFeedbackRow.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/GroupFeedbackRow.jsx
@@ -43,7 +43,7 @@ export const GroupFeedbackRow = ({
             className="mr-4 mt-1"
             value={letter.id}
             checked={value.answers.indexOf(letter.id)}
-            isValid={value.answers.indexOf(letter.id)}
+            isValid={value.answers.indexOf(letter.id) >= 0}
           >{letter.id}
           </Form.Checkbox>
         ))}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/__snapshots__/GroupFeedbackRow.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/__snapshots__/GroupFeedbackRow.test.jsx.snap
@@ -37,22 +37,22 @@ exports[`GroupFeedbackRow snapshot snapshot: renders hints row 1`] = `
       <Form.Checkbox
         checked={-1}
         className="mr-4 mt-1"
-        isValid={-1}
+        isValid={false}
       />
       <Form.Checkbox
         checked={-1}
         className="mr-4 mt-1"
-        isValid={-1}
+        isValid={false}
       />
       <Form.Checkbox
         checked={-1}
         className="mr-4 mt-1"
-        isValid={-1}
+        isValid={false}
       />
       <Form.Checkbox
         checked={-1}
         className="mr-4 mt-1"
-        isValid={-1}
+        isValid={false}
       />
     </Row>
   </Component>


### PR DESCRIPTION
This PR makes this:

<img width="263" alt="image" src="https://user-images.githubusercontent.com/56318341/218592791-560c9740-dcef-48ca-b212-6378869fc66f.png">

look like this:

<img width="263" alt="image" src="https://user-images.githubusercontent.com/56318341/218592906-1a79fc0b-04d0-4efc-8642-aeba7044db04.png">

It specifically address the Group Feedback widget's checkbox coloring.