### PR TITLE
feat: remove Hints widget from advanced editor

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
@@ -19,7 +19,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page 1`] = `
   <div
     className="mt-3"
   >
-    <HintsCard />
+    <HintsCard
+      problemType="stringresponse"
+    />
   </div>
   <div
     className="mt-3"
@@ -104,7 +106,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page advanced
   <div
     className="mt-3"
   >
-    <HintsCard />
+    <HintsCard
+      problemType="stringresponse"
+    />
   </div>
   <div
     className="mt-3"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -80,7 +80,7 @@ export const SettingsWidget = ({
         <ScoringCard scoring={settings.scoring} updateSettings={updateSettings} />
       </div>
       <div className="mt-3">
-        <HintsCard hints={settings.hints} updateSettings={updateSettings} />
+        <HintsCard problemType={problemType} hints={settings.hints} updateSettings={updateSettings} />
       </div>
       {feedbackCard()}
       <div>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintsCard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
 import SettingsOption from '../SettingsOption';
+import { ProblemTypeKeys } from '../../../../../../data/constants/problem';
 import messages from '../messages';
 import { hintsCardHooks, hintsRowHooks } from '../hooks';
 import HintRow from './HintRow';
@@ -9,11 +10,15 @@ import Button from '../../../../../../sharedComponents/Button';
 
 export const HintsCard = ({
   hints,
+  problemType,
   updateSettings,
   // inject
   intl,
 }) => {
   const { summary, handleAdd } = hintsCardHooks(hints, updateSettings);
+
+  if (problemType === ProblemTypeKeys.ADVANCED) { return null; }
+
   return (
     <SettingsOption
       title={intl.formatMessage(messages.hintSettingTitle)}
@@ -46,6 +51,7 @@ HintsCard.propTypes = {
     id: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
   })).isRequired,
+  problemType: PropTypes.string.isRequired,
   updateSettings: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
This PR removes the Hints widget from the advanced editor. Hints shows up as a tag in the OLX so it should not be a widget.

https://2u-internal.atlassian.net/browse/TNL-10457