### PR TITLE
feat: reset card link works

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Button, ButtonGroup, Hyperlink } from '@edx/paragon';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { resetCardHooks } from '../hooks';
+import { selectors } from '../../../../../../data/redux';
 
 export const ResetCard = ({
   showResetButton,
@@ -13,6 +15,7 @@ export const ResetCard = ({
   intl,
 }) => {
   const { setResetTrue, setResetFalse } = resetCardHooks(updateSettings);
+  const advancedSettingsLink = `${useSelector(selectors.app.studioEndpointUrl)}/settings/advanced/${useSelector(selectors.app.learningContextId)}`;
   return (
     <SettingsOption
       title={intl.formatMessage(messages.resetSettingsTitle)}
@@ -26,7 +29,7 @@ export const ResetCard = ({
         </span>
       </div>
       <div className="spacedMessage">
-        <Hyperlink destination="#" target="_blank">
+        <Hyperlink destination={advancedSettingsLink} target="_blank">
           <FormattedMessage {...messages.advancedSettingsLinkText} />
         </Hyperlink>
       </div>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.test.jsx
@@ -8,6 +8,19 @@ jest.mock('../hooks', () => ({
   resetCardHooks: jest.fn(),
 }));
 
+jest.mock('../../../../../../data/redux', () => ({
+  selectors: {
+    app: {
+      studioEndpointUrl: 'sTuDioEndpOintUrl',
+      learningContextId: 'leArningCoNteXtId',
+    },
+  },
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn().mockImplementation((args) => args),
+}));
+
 describe('ResetCard', () => {
   const props = {
     showResetButton: false,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ResetCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ResetCard.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`ResetCard snapshot snapshot: renders reset true setting card 1`] = `
     className="spacedMessage"
   >
     <Hyperlink
-      destination="#"
+      destination="sTuDioEndpOintUrl/settings/advanced/leArningCoNteXtId"
       target="_blank"
     >
       <FormattedMessage
@@ -84,7 +84,7 @@ exports[`ResetCard snapshot snapshot: renders reset true setting card 2`] = `
     className="spacedMessage"
   >
     <Hyperlink
-      destination="#"
+      destination="sTuDioEndpOintUrl/settings/advanced/leArningCoNteXtId"
       target="_blank"
     >
       <FormattedMessage


### PR DESCRIPTION
ACs: Clicking the hyperlink in the reset card brings you to the course's advanced settings.