### PR TITLE
fix: check for if an answer changes to false

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -210,7 +210,9 @@ export const typeRowHooks = ({
     if (typeKey === ProblemTypeKeys.DROPDOWN) {
       if (correctAnswerCount > 1) {
         answers.forEach(answer => {
-          updateAnswer({ ...answer, correct: false });
+          if (answer.correct) {
+            updateAnswer({ ...answer, correct: false });
+          }
         });
       }
     }

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -207,9 +207,13 @@ export const typeRowHooks = ({
   updateAnswer,
 }) => {
   const onClick = () => {
+    // Dropdown problems can only have one correct answer. When there is more than one correct answer
+    // from a previous problem type, the correct attribute for selected answers need to be set to false.
     if (typeKey === ProblemTypeKeys.DROPDOWN) {
+      // Check that previous problem had greater than one correct answer
       if (correctAnswerCount > 1) {
         answers.forEach(answer => {
+          // Check that the answer.correct is true and update answer.correct to false
           if (answer.correct) {
             updateAnswer({ ...answer, correct: false });
           }

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -206,18 +206,19 @@ export const typeRowHooks = ({
   updateField,
   updateAnswer,
 }) => {
+  const clearPreviouslySelectedAnswers = () => {
+    answers.forEach(answer => {
+      if (answer.correct) {
+        updateAnswer({ ...answer, correct: false });
+      }
+    });
+  };
   const onClick = () => {
     // Dropdown problems can only have one correct answer. When there is more than one correct answer
     // from a previous problem type, the correct attribute for selected answers need to be set to false.
     if (typeKey === ProblemTypeKeys.DROPDOWN) {
-      // Check that previous problem had greater than one correct answer
       if (correctAnswerCount > 1) {
-        answers.forEach(answer => {
-          // Check that the answer.correct is true and update answer.correct to false
-          if (answer.correct) {
-            updateAnswer({ ...answer, correct: false });
-          }
-        });
+        clearPreviouslySelectedAnswers();
       }
     }
     if (blockTitle === ProblemTypes[problemType].title) {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -263,6 +263,10 @@ describe('Problem settings hooks', () => {
       {
         correct: true,
         id: 'b',
+      },
+      {
+        correct: false,
+        id: 'c',
       }];
       output = hooks.typeRowHooks({
         answers,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -282,6 +282,7 @@ describe('Problem settings hooks', () => {
       expect(setBlockTitle).toHaveBeenCalledWith('Dropdown');
       expect(updateAnswer).toHaveBeenNthCalledWith(1, { ...answers[0], correct: false });
       expect(updateAnswer).toHaveBeenNthCalledWith(2, { ...answers[1], correct: false });
+      expect(updateAnswer).not.toHaveBeenNthCalledWith(3, { ...answers[2], correct: false });
       expect(updateField).toHaveBeenCalledWith({ problemType: typekey });
     });
   });


### PR DESCRIPTION
JIRA Ticket: [TNL-10445](https://2u-internal.atlassian.net/browse/TNL-10445)

This PR addresses a bug that prevented answers from clearing out for dropdown problems when multiple answers were selected a second time. Previously, the answers cleared out as expected when a user first changed from a multi-answer problem to a single answer problem. However, if the user reselected multiple answers and went back to a single answer problem, the answers were not deselected. Now, the user can go back and forth between the problem types with multiple answers selected and problem types with single answers with the answers clearing out when necessary.