### PR TITLE
feat: update switch to Advanced Editor warning

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -181,7 +181,8 @@ export const messages = {
   },
   ConfirmSwitchMessage: {
     id: 'authoring.problemeditor.settings.switchtoadvancededitor.message',
-    defaultMessage: 'If you use the advanced editor, this problem will be converted to OLX and you will not be able to return to the simple editor.',
+    defaultMessage: `If you use the advanced editor, this problem will be converted to OLX and you will not be able to return to the simple editor.
+      Any changes made after the last Save action will be lost when converting to OLX.`,
     description: 'message to confirm that a user wants to use the advanced editor',
   },
   ConfirmSwitchMessageTitle: {


### PR DESCRIPTION
This PR updates the switch to advanced editor warning with this additional text: "Any changes made after the last Save action will be lost when converting to OLX."

https://2u-internal.atlassian.net/browse/TNL-10444