### PR TITLE
fix: parse explanation data correctly.

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -330,10 +330,12 @@ export class OLXParser {
     return { text, children };
   }
 
-  getSolutionExplanation() {
-    if (!_.has(this.problem, 'solution')) { return null; }
+  getSolutionExplanation(problemType) {
+    if (!_.has(this.problem, `${problemType}.solution`)) { return null; }
 
-    const stack = [this.problem.solution];
+    const solution = _.get(this.problem, `${problemType}.solution`);
+
+    const stack = [solution];
     const texts = [];
     let currentNode;
 
@@ -401,7 +403,7 @@ export class OLXParser {
     const problemType = this.getProblemType();
     const hints = this.getHints();
     const question = this.parseQuestions(problemType);
-    const solutionExplanation = this.getSolutionExplanation();
+    const solutionExplanation = this.getSolutionExplanation(problemType);
 
     switch (problemType) {
       case ProblemTypeKeys.DROPDOWN:

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -181,13 +181,15 @@ describe('OLXParser for problem with solution tag', () => {
   describe('for checkbox questions', () => {
     test('should parse simple text', () => {
       const olxparser = new OLXParser(checkboxesOLXWithFeedbackAndHintsOLX.rawOLX);
-      const explanation = olxparser.getSolutionExplanation();
+      const problemType = olxparser.getProblemType();
+      const explanation = olxparser.getSolutionExplanation(problemType);
       expect(explanation).toEqual(checkboxesOLXWithFeedbackAndHintsOLX.solutionExplanation);
     });
     test('should parse text in p tags', () => {
       const { rawOLX } = getCheckboxesOLXWithFeedbackAndHintsOLX({ solution: 'html' });
       const olxparser = new OLXParser(rawOLX);
-      const explanation = olxparser.getSolutionExplanation();
+      const problemType = olxparser.getProblemType();
+      const explanation = olxparser.getSolutionExplanation(problemType);
       const expected = getCheckboxesOLXWithFeedbackAndHintsOLX({ solution: 'html' }).solutionExplanation;
       expect(explanation.replace(/\s/g, '')).toBe(expected.replace(/\s/g, ''));
     });

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -18,24 +18,24 @@ export const getCheckboxesOLXWithFeedbackAndHintsOLX = ({ solution = 'simple' })
       <compoundhint value="A B D">You can specify optional feedback for a combination of answers which appears after the specified set of answers is submitted.</compoundhint>
       <compoundhint value="A B C D">You can specify optional feedback for one, several, or all answer combinations.</compoundhint>
     </checkboxgroup>
+    ${solution === 'simple' ? '<solution>This is a detailed explanation of the solution.</solution>' : (
+    `<solution>
+        <div class="detailed-solution">
+            <p>Explanation</p>
+            <p>
+                You can form a voltage divider that evenly divides the input
+                voltage with two identically valued resistors, with the sampled
+                voltage taken in between the two.
+            </p>
+            <p><img src="/static/images/voltage_divider.png" alt=""/></p>
+         </div>
+      </solution>`
+  )}
   </choiceresponse>
   <demandhint>
     <hint>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</hint>
     <hint>If you add more than one hint, a different hint appears each time learners select the hint button.</hint>
   </demandhint>
-  ${solution === 'simple' ? '<solution>This is a detailed explanation of the solution.</solution>' : (
-    `<solution>
-      <div class="detailed-solution">
-          <p>Explanation</p>
-          <p>
-              You can form a voltage divider that evenly divides the input
-              voltage with two identically valued resistors, with the sampled
-              voltage taken in between the two.
-          </p>
-          <p><img src="/static/images/voltage_divider.png" alt=""/></p>
-       </div>
-    </solution>`
-  )}
   </problem>`,
   hints: [
     {


### PR DESCRIPTION
Explanation data was not being parsed because the test data was malformed-- the explanation actually goes INSIDE the input tag. This PR solves this issue in the parser, as well as it's test data.

https://2u-internal.atlassian.net/browse/TNL-10501
and https://2u-internal.atlassian.net/browse/TNL-10504

