### PR TITLE
Feat  allow not select feedback for only multi select problem type

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/FeedbackBox.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/FeedbackBox.jsx
@@ -20,18 +20,7 @@ export const FeedbackBox = ({
     intl,
   };
 
-  return ((problemType === ProblemTypeKeys.NUMERIC || problemType === ProblemTypeKeys.TEXTINPUT) ? (
-    <div className="bg-light-300 p-4 mt-3 rounded text-primary-500">
-      <FeedbackControl
-        key={`selectedfeedback-${answer.id}`}
-        feedback={answer.selectedFeedback}
-        labelMessage={messages.selectedFeedbackLabel}
-        labelMessageBoldUnderline={messages.selectedFeedbackLabelBoldUnderlineText}
-        onChange={setSelectedFeedback}
-        {...props}
-      />
-    </div>
-  ) : (
+  return ((problemType === ProblemTypeKeys.MULTISELECT) ? (
     <div className="bg-light-300 p-4 mt-3 rounded text-primary-500">
       <FeedbackControl
         key={`selectedfeedback-${answer.id}`}
@@ -47,6 +36,17 @@ export const FeedbackBox = ({
         labelMessage={messages.unSelectedFeedbackLabel}
         labelMessageBoldUnderline={messages.unSelectedFeedbackLabelBoldUnderlineText}
         onChange={setUnselectedFeedback}
+        {...props}
+      />
+    </div>
+  ) : (
+    <div className="bg-light-300 p-4 mt-3 rounded text-primary-500">
+      <FeedbackControl
+        key={`selectedfeedback-${answer.id}`}
+        feedback={answer.selectedFeedback}
+        labelMessage={messages.selectedFeedbackLabel}
+        labelMessageBoldUnderline={messages.selectedFeedbackLabelBoldUnderlineText}
+        onChange={setSelectedFeedback}
         {...props}
       />
     </div>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/FeedbackBox.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/FeedbackBox.test.jsx
@@ -22,7 +22,7 @@ describe('FeedbackBox component', () => {
   test('renders as expected with a numeric input problem', () => {
     expect(shallow(<FeedbackBox {...props} problemType="numericalresponse" />)).toMatchSnapshot();
   });
-  test('renders as expected with a text input problem', () => {
-    expect(shallow(<FeedbackBox {...props} problemType="stringresponse" />)).toMatchSnapshot();
+  test('renders as expected with a multi select problem', () => {
+    expect(shallow(<FeedbackBox {...props} problemType="choiceresponse" />)).toMatchSnapshot();
   });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/__snapshots__/FeedbackBox.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/__snapshots__/FeedbackBox.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FeedbackBox component renders as expected with a numeric input problem 1`] = `
+exports[`FeedbackBox component renders as expected with a multi select problem 1`] = `
 <div
   className="bg-light-300 p-4 mt-3 rounded text-primary-500"
 >
@@ -33,10 +33,39 @@ exports[`FeedbackBox component renders as expected with a numeric input problem 
       }
     }
   />
+  <FeedbackControl
+    answer={
+      Object {
+        "correct": true,
+        "id": "A",
+        "problemType": "sOMepRObleM",
+        "selectedFeedback": "some feedback",
+        "title": "Answer 1",
+        "unselectedFeedback": "unselectedFeedback",
+      }
+    }
+    feedback="unselectedFeedback"
+    intl={Object {}}
+    key="unselectedfeedback-A"
+    labelMessage={
+      Object {
+        "defaultMessage": "Show following feedback when {answerId} {boldunderline}:",
+        "description": "Label text for feedback if option is not selected",
+        "id": "authoring.answerwidget.feedback.unselected.label",
+      }
+    }
+    labelMessageBoldUnderline={
+      Object {
+        "defaultMessage": "is not selected",
+        "description": "Bold & underlined text for feedback if option is not selected",
+        "id": "authoring.answerwidget.feedback.unselected.label.boldunderline",
+      }
+    }
+  />
 </div>
 `;
 
-exports[`FeedbackBox component renders as expected with a text input problem 1`] = `
+exports[`FeedbackBox component renders as expected with a numeric input problem 1`] = `
 <div
   className="bg-light-300 p-4 mt-3 rounded text-primary-500"
 >
@@ -102,35 +131,6 @@ exports[`FeedbackBox component renders as expected with default props 1`] = `
         "defaultMessage": "is selected",
         "description": "Bold & underlined text for feedback if option is selected",
         "id": "authoring.answerwidget.feedback.selected.label.boldunderline",
-      }
-    }
-  />
-  <FeedbackControl
-    answer={
-      Object {
-        "correct": true,
-        "id": "A",
-        "problemType": "sOMepRObleM",
-        "selectedFeedback": "some feedback",
-        "title": "Answer 1",
-        "unselectedFeedback": "unselectedFeedback",
-      }
-    }
-    feedback="unselectedFeedback"
-    intl={Object {}}
-    key="unselectedfeedback-A"
-    labelMessage={
-      Object {
-        "defaultMessage": "Show following feedback when {answerId} {boldunderline}:",
-        "description": "Label text for feedback if option is not selected",
-        "id": "authoring.answerwidget.feedback.unselected.label",
-      }
-    }
-    labelMessageBoldUnderline={
-      Object {
-        "defaultMessage": "is not selected",
-        "description": "Bold & underlined text for feedback if option is not selected",
-        "id": "authoring.answerwidget.feedback.unselected.label.boldunderline",
       }
     }
   />

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -132,14 +132,8 @@ const problem = createSlice({
         ...payload,
       },
     }),
-    load: (state, { payload: { settings: { scoring, showAnswer, ...settings }, ...payload } }) => ({
+    load: (state, { payload }) => ({
       ...state,
-      settings: {
-        ...state.settings,
-        scoring: { ...state.settings.scoring, ...scoring },
-        showAnswer: { ...state.settings.showAnswer, ...showAnswer },
-        ...settings,
-      },
       ...payload,
     }),
     setEnableTypeSelection: (state) => ({

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -132,8 +132,14 @@ const problem = createSlice({
         ...payload,
       },
     }),
-    load: (state, { payload }) => ({
+    load: (state, { payload: { settings: { scoring, showAnswer, ...settings }, ...payload } }) => ({
       ...state,
+      settings: {
+        ...state.settings,
+        scoring: { ...state.settings.scoring, ...scoring },
+        showAnswer: { ...state.settings.showAnswer, ...showAnswer },
+        ...settings,
+      },
       ...payload,
     }),
     setEnableTypeSelection: (state) => ({


### PR DESCRIPTION
Based on how OLX works, only Multi-select problem types use not-select feedback. This can be seen in chapter 10 of Read the Docs: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/checkbox.html#configure-individual-option-feedback

This PR limits not-select feedback to only Multi-select problem types.