### PR TITLE
chore: add missing maintainership files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# The following users are the maintainers of all frontend-app-library-authoring files
+*       @openedx/teaching-and-learning

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'frontend-lib-content-components'
+  description: "The frontend library for Open edX Content Authoring Editors"
+  links:
+    - url: "https://github.com/openedx/frontend-lib-content-components"
+      title: "Frontend lib content components"
+      icon: "Library"
+  annotations:
+    openedx.org/arch-interest-groups: ""
+spec:
+  owner: group:teaching-and-learning
+  type: 'website'
+  lifecycle: 'production'


### PR DESCRIPTION
This is related to Maintainership Pilot expectations. 

- CODEOWNERS file will notify teaching-and-learning team members of PR submissions, but there are currently no additional branch protections related to this ownership.
- catalog-info.yaml populates Backstage info for the Open edX community. It helps identify that tnl is the owner of this component. This is in relation to Maintainership OEP-55.