### PR TITLE
fix: answer button accessibility

### DIFF
--- a/src/editors/sharedComponents/Button/index.scss
+++ b/src/editors/sharedComponents/Button/index.scss
@@ -3,10 +3,6 @@
     &:not(.disabled) {
       &:hover, &:active, &:focus {
         background-color: transparent;
-
-        &:before {
-          display: none;
-        }
       }
     }
   }


### PR DESCRIPTION
The add answer button was missing an outline, which is bad for accessibility.
https://2u-internal.atlassian.net/browse/TNL-10510