### PR TITLE
feat: correct answer feedback widget

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -10,13 +10,13 @@ import {
 import { FeedbackOutline, DeleteOutline } from '@edx/paragon/icons';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
-import messages from './messages';
 import { selectors } from '../../../../../data/redux';
+import { ProblemTypeKeys } from '../../../../../data/constants/problem';
 import { answerOptionProps } from '../../../../../data/services/cms/types';
 import Checker from './components/Checker';
 import { FeedbackBox } from './components/Feedback';
 import * as hooks from './hooks';
-import { ProblemTypeKeys } from '../../../../../data/constants/problem';
+import messages from './messages';
 
 export const AnswerOption = ({
   answer,
@@ -57,25 +57,33 @@ export const AnswerOption = ({
           onChange={(e) => { setAnswer({ title: e.target.value }); }}
           placeholder={intl.formatMessage(messages.answerTextboxPlaceholder)}
         />
-        <Collapsible.Body>
-          <FeedbackBox
-            problemType={problemType}
-            answer={answer}
-            setSelectedFeedback={setSelectedFeedback}
-            setUnselectedFeedback={setUnselectedFeedback}
-            intl={intl}
-          />
-        </Collapsible.Body>
+        {problemType !== ProblemTypeKeys.NUMERIC
+          ? (
+            <Collapsible.Body>
+              <FeedbackBox
+                problemType={problemType}
+                answer={answer}
+                setSelectedFeedback={setSelectedFeedback}
+                setUnselectedFeedback={setUnselectedFeedback}
+                intl={intl}
+              />
+            </Collapsible.Body>
+          )
+          : null}
       </div>
       <div className="d-flex flex-row flex-nowrap">
-        <Collapsible.Trigger>
-          <IconButton
-            src={FeedbackOutline}
-            iconAs={Icon}
-            alt={intl.formatMessage(messages.feedbackToggleIconAltText)}
-            variant="primary"
-          />
-        </Collapsible.Trigger>
+        {problemType !== ProblemTypeKeys.NUMERIC
+          ? (
+            <Collapsible.Trigger>
+              <IconButton
+                src={FeedbackOutline}
+                iconAs={Icon}
+                alt={intl.formatMessage(messages.feedbackToggleIconAltText)}
+                variant="primary"
+              />
+            </Collapsible.Trigger>
+          )
+          : null}
         <IconButton
           src={DeleteOutline}
           iconAs={Icon}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/__snapshots__/AnswerOption.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/__snapshots__/AnswerOption.test.jsx.snap
@@ -111,37 +111,10 @@ exports[`AnswerOption render snapshot: renders correct option with numeric input
       rows={1}
       value="Answer 1"
     />
-    <Body>
-      <injectIntl(ShimmedIntlComponent)
-        answer={
-          Object {
-            "correct": true,
-            "id": "A",
-            "selectedFeedback": "some feedback",
-            "title": "Answer 1",
-          }
-        }
-        intl={
-          Object {
-            "formatMessage": [Function],
-          }
-        }
-        problemType="numericalresponse"
-        setSelectedFeedback={[Function]}
-        setUnselectedFeedback={[Function]}
-      />
-    </Body>
   </div>
   <div
     className="d-flex flex-row flex-nowrap"
   >
-    <Trigger>
-      <IconButton
-        alt="Toggle feedback"
-        iconAs="Icon"
-        variant="primary"
-      />
-    </Trigger>
     <IconButton
       alt="Delete answer"
       iconAs="Icon"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
@@ -87,6 +87,93 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget for Advanced 
 </div>
 `;
 
+exports[`SettingsWidget snapshot snapshot: renders Settings widget for Numeric Input with correct widgets 1`] = `
+<div
+  className="settingsWidget ml-4"
+>
+  <div
+    className="mb-3"
+  >
+    <TypeCard
+      problemType="stringresponse"
+    />
+  </div>
+  <div
+    className="my-3"
+  >
+    <ScoringCard />
+  </div>
+  <div
+    className="mt-3"
+  >
+    <HintsCard
+      problemType="stringresponse"
+    />
+  </div>
+  <div
+    className="mt-3"
+  >
+    <GroupFeedback />
+  </div>
+  <div>
+    <Advanced
+      open={true}
+    >
+      <Body
+        className="collapsible-body small"
+      >
+        <Button
+          className="my-3 px-0 text-info-500"
+          size="inline"
+          variant="link"
+        >
+          <FormattedMessage
+            defaultMessage="Show advanced settings"
+            description="Button text to show advanced settings"
+            id="authoring.problemeditor.settings.showAdvancedButton"
+          />
+        </Button>
+      </Body>
+    </Advanced>
+  </div>
+  <Advanced
+    open={false}
+  >
+    <Body
+      className="collapsible-body"
+    >
+      <div
+        className="my-3"
+      >
+        <ShowAnswerCard />
+      </div>
+      <div
+        className="my-3"
+      >
+        <ResetCard />
+      </div>
+      <div
+        className="my-3"
+      >
+        <TimerCard />
+      </div>
+      <div
+        className="my-3"
+      >
+        <MatlabCard />
+      </div>
+      <div
+        className="my-3"
+      >
+        <SwitchToAdvancedEditorCard
+          problemType="stringresponse"
+        />
+      </div>
+    </Body>
+  </Advanced>
+</div>
+`;
+
 exports[`SettingsWidget snapshot snapshot: renders Settings widget page 1`] = `
 <div
   className="settingsWidget ml-4"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -28,6 +28,27 @@ export const showFullCard = () => {
   };
 };
 
+export const correctAnswerFeedbackHooks = (correctAnswerFeedback, updateSettings) => {
+  const [summary, setSummary] = module.state.summary({ message: '', values: {}, intl: false });
+
+  useEffect(() => {
+    if (_.isEmpty(correctAnswerFeedback)) {
+      setSummary({ message: messages.noCorrectAnswerFeedbackSummary, values: {}, intl: true });
+    } else {
+      setSummary({ message: correctAnswerFeedback, values: {}, intl: false });
+    }
+  }, [correctAnswerFeedback]);
+
+  const handleChange = (event) => {
+    updateSettings({ correctAnswerFeedback: event.target.value });
+  };
+
+  return {
+    summary,
+    handleChange,
+  };
+};
+
 export const hintsCardHooks = (hints, updateSettings) => {
   const [summary, setSummary] = module.state.summary({ message: messages.noHintSummary, values: {} });
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -62,6 +62,35 @@ describe('Problem settings hooks', () => {
     });
   });
 
+  describe('Correct Answer Feedback card hooks', () => {
+    test('test useEffect triggers set summary', () => {
+      const feedback = 'cORrECtAnSWerfeEdBacK';
+      hooks.correctAnswerFeedbackHooks(feedback, updateSettings);
+      expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
+      const [cb, prereqs] = useEffect.mock.calls[0];
+      expect(prereqs).toStrictEqual([feedback]);
+      cb();
+      expect(state.setState[state.keys.summary])
+        .toHaveBeenCalledWith({ message: feedback, values: {}, intl: false });
+    });
+    test('test useEffect triggers set summary no key', () => {
+      hooks.correctAnswerFeedbackHooks('', updateSettings);
+      expect(state.setState[state.keys.summary]).not.toHaveBeenCalled();
+      const [cb, prereqs] = useEffect.mock.calls[0];
+      expect(prereqs).toStrictEqual(['']);
+      cb();
+      expect(state.setState[state.keys.summary])
+        .toHaveBeenCalledWith({ message: messages.noCorrectAnswerFeedbackSummary, values: {}, intl: true });
+    });
+    test('test handleChange', () => {
+      const feedback = 'CORrECtanSWerfEEdBacK';
+      const value = 'nEwFeeDBAck';
+      output = hooks.correctAnswerFeedbackHooks(feedback, updateSettings);
+      output.handleChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ correctAnswerFeedback: value });
+    });
+  });
+
   describe('Hint card hooks', () => {
     test('test useEffect triggers set hints summary no hint', () => {
       const hints = [];

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -15,6 +15,7 @@ import TimerCard from './settingsComponents/TimerCard';
 import TypeCard from './settingsComponents/TypeCard';
 import GeneralFeedbackCard from './settingsComponents/GeneralFeedback/index';
 import GroupFeedbackCard from './settingsComponents/GroupFeedback/index';
+import CorrectAnswerFeedbackCard from './settingsComponents/CorrectAnswerFeedbackCard';
 import SwitchToAdvancedEditorCard from './settingsComponents/SwitchToAdvancedEditorCard';
 import messages from './messages';
 import { showAdvancedSettingsCards } from './hooks';
@@ -30,6 +31,7 @@ export const SettingsWidget = ({
   answers,
   generalFeedback,
   groupFeedbackList,
+  correctAnswerFeedback,
   blockTitle,
   correctAnswerCount,
   settings,
@@ -43,6 +45,17 @@ export const SettingsWidget = ({
   const feedbackCard = () => {
     if (problemType === ProblemTypeKeys.ADVANCED) {
       return (<></>);
+    }
+    if (problemType === ProblemTypeKeys.NUMERIC) {
+      return (
+        <div className="mt-3">
+          <CorrectAnswerFeedbackCard
+            correctAnswerFeedback={correctAnswerFeedback}
+            updateSettings={updateField}
+            answers={answers}
+          />
+        </div>
+      );
     }
     if ([ProblemTypeKeys.MULTISELECT, ProblemTypeKeys.TEXTINPUT, ProblemTypeKeys.NUMERIC].includes(problemType)) {
       return (
@@ -154,6 +167,7 @@ SettingsWidget.propTypes = {
       },
     ),
   ).isRequired,
+  correctAnswerFeedback: PropTypes.string.isRequired,
   blockTitle: PropTypes.string.isRequired,
   correctAnswerCount: PropTypes.number.isRequired,
   problemType: PropTypes.string.isRequired,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
@@ -64,6 +64,14 @@ describe('SettingsWidget', () => {
       showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
       expect(shallow(<SettingsWidget problemType={ProblemTypeKeys.ADVANCED} {...props} />)).toMatchSnapshot();
     });
+    test('snapshot: renders Settings widget for Numeric Input with correct widgets', () => {
+      const showAdvancedSettingsCardsProps = {
+        isAdvancedCardsVisible: false,
+        setResetTrue: jest.fn().mockName('showAdvancedSettingsCards.setResetTrue'),
+      };
+      showAdvancedSettingsCards.mockReturnValue(showAdvancedSettingsCardsProps);
+      expect(shallow(<SettingsWidget problemType={ProblemTypeKeys.NUMERIC} {...props} />)).toMatchSnapshot();
+    });
   });
 
   describe('mapDispatchToProps', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -19,6 +19,26 @@ export const messages = {
     defaultMessage: 'Set a default value in advanced settings',
     description: 'Advanced settings link text',
   },
+  correctAnswerFeedbackSettingTitle: {
+    id: 'authoring.problemeditor.settings.correctAnswerFeedback.title',
+    defaultMessage: 'Correct Answer Feedback',
+    description: 'Correct Answer Feedback settings card title',
+  },
+  correctAnswerFeedbackSettingText: {
+    id: 'authoring.problemeditor.settings.correctAnswerFeedback.text',
+    defaultMessage: 'Enter the feedback to appear when a student submits a correct answer.',
+    description: 'Correct Answer Feedback settings card text',
+  },
+  correctAnswerFeedbackInputLabel: {
+    id: 'authoring.problemeditor.settings.correctAnswerFeedback.inputLabel',
+    defaultMessage: 'Feedback message',
+    description: 'Correct Answer Feedback text input label',
+  },
+  noCorrectAnswerFeedbackSummary: {
+    id: 'authoring.problemeditor.settings.correctAnswerFeedback.noSummary',
+    defaultMessage: 'None',
+    description: 'Summary text for no correct answer feedback',
+  },
   hintSettingTitle: {
     id: 'authoring.problemeditor.settings.hint.title',
     defaultMessage: 'Hints',

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/CorrectAnswerFeedbackCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/CorrectAnswerFeedbackCard.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
+import { Form } from '@edx/paragon';
+
+import SettingsOption from '../SettingsOption';
+import messages from '../messages';
+import { correctAnswerFeedbackHooks } from '../hooks';
+
+export const CorrectAnswerFeedbackCard = ({
+  correctAnswerFeedback,
+  updateSettings,
+  // inject
+  intl,
+}) => {
+  const { summary, handleChange } = correctAnswerFeedbackHooks(correctAnswerFeedback, updateSettings);
+  return (
+    <SettingsOption
+      title={intl.formatMessage(messages.correctAnswerFeedbackSettingTitle)}
+      summary={summary.intl ? intl.formatMessage(summary.message) : summary.message}
+      none={!correctAnswerFeedback}
+    >
+      <div className="halfSpacedMessage">
+        <span>
+          <FormattedMessage {...messages.correctAnswerFeedbackSettingText} />
+        </span>
+      </div>
+      <Form.Group>
+        <Form.Control
+          value={correctAnswerFeedback}
+          onChange={handleChange}
+          floatingLabel={intl.formatMessage(messages.correctAnswerFeedbackInputLabel)}
+        />
+      </Form.Group>
+    </SettingsOption>
+  );
+};
+
+CorrectAnswerFeedbackCard.propTypes = {
+  correctAnswerFeedback: PropTypes.string.isRequired,
+  updateSettings: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(CorrectAnswerFeedbackCard);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/CorrectAnswerFeedbackCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/CorrectAnswerFeedbackCard.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { formatMessage } from '../../../../../../../testUtils';
+import { correctAnswerFeedbackHooks } from '../hooks';
+import { CorrectAnswerFeedbackCard } from './CorrectAnswerFeedbackCard';
+import messages from '../messages';
+
+jest.mock('../hooks', () => ({
+  correctAnswerFeedbackHooks: jest.fn(),
+}));
+
+describe('CorrectAnswerFeedbackCard', () => {
+  const correctAnswerFeedback = 'SomEFeEdbacK';
+  const props = {
+    correctAnswerFeedback,
+    updateSettings: jest.fn().mockName('args.updateSettings'),
+    intl: { formatMessage },
+  };
+
+  describe('behavior', () => {
+    it(' calls correctAnswerFeedbackHooks when initialized', () => {
+      const correctAnswerFeedbackProps = {
+        summary: { message: correctAnswerFeedback, values: {}, intl: false },
+        handleChange: jest.fn().mockName('correctAnswerFeedbackHooks.handleChange'),
+      };
+      correctAnswerFeedbackHooks.mockReturnValue(correctAnswerFeedbackProps);
+      shallow(<CorrectAnswerFeedbackCard {...props} />);
+      expect(correctAnswerFeedbackHooks).toHaveBeenCalledWith(correctAnswerFeedback, props.updateSettings);
+    });
+  });
+
+  describe('snapshot', () => {
+    test('snapshot: renders correct answer feedback setting card', () => {
+      const correctAnswerFeedbackProps = {
+        summary: { message: correctAnswerFeedback, values: {}, intl: false },
+        handleChange: jest.fn().mockName('correctAnswerFeedbackHooks.handleChange'),
+      };
+      correctAnswerFeedbackHooks.mockReturnValue(correctAnswerFeedbackProps);
+      expect(shallow(<CorrectAnswerFeedbackCard {...props} />)).toMatchSnapshot();
+    });
+    test('snapshot: renders correct answer feedback setting card no key', () => {
+      const correctAnswerFeedbackProps = {
+        summary: { message: messages.noCorrectAnswerFeedbackSummary, values: {}, intl: true },
+        handleChange: jest.fn().mockName('correctAnswerFeedbackHooks.handleChange'),
+      };
+      correctAnswerFeedbackHooks.mockReturnValue(correctAnswerFeedbackProps);
+      expect(shallow(<CorrectAnswerFeedbackCard {...props} correctAnswerFeedback="" />)).toMatchSnapshot();
+    });
+  });
+});

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/CorrectAnswerFeedbackCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/CorrectAnswerFeedbackCard.test.jsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CorrectAnswerFeedbackCard snapshot snapshot: renders correct answer feedback setting card 1`] = `
+<SettingsOption
+  className=""
+  extraSections={Array []}
+  none={false}
+  summary="SomEFeEdbacK"
+  title="Correct Answer Feedback"
+>
+  <div
+    className="halfSpacedMessage"
+  >
+    <span>
+      <FormattedMessage
+        defaultMessage="Enter the feedback to appear when a student submits a correct answer."
+        description="Correct Answer Feedback settings card text"
+        id="authoring.problemeditor.settings.correctAnswerFeedback.text"
+      />
+    </span>
+  </div>
+  <Form.Group>
+    <Form.Control
+      floatingLabel="Feedback message"
+      onChange={[MockFunction correctAnswerFeedbackHooks.handleChange]}
+      value="SomEFeEdbacK"
+    />
+  </Form.Group>
+</SettingsOption>
+`;
+
+exports[`CorrectAnswerFeedbackCard snapshot snapshot: renders correct answer feedback setting card no key 1`] = `
+<SettingsOption
+  className=""
+  extraSections={Array []}
+  none={true}
+  summary="None"
+  title="Correct Answer Feedback"
+>
+  <div
+    className="halfSpacedMessage"
+  >
+    <span>
+      <FormattedMessage
+        defaultMessage="Enter the feedback to appear when a student submits a correct answer."
+        description="Correct Answer Feedback settings card text"
+        id="authoring.problemeditor.settings.correctAnswerFeedback.text"
+      />
+    </span>
+  </div>
+  <Form.Group>
+    <Form.Control
+      floatingLabel="Feedback message"
+      onChange={[MockFunction correctAnswerFeedbackHooks.handleChange]}
+      value=""
+    />
+  </Form.Group>
+</SettingsOption>
+`;

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -226,7 +226,6 @@ export class OLXParser {
 
   parseNumericResponse() {
     const { numericalresponse } = this.problem;
-    let answerFeedback = '';
     const answers = [];
     let responseParam = {};
     // TODO: UI needs to be added to support adding tolerence in numeric response.
@@ -242,7 +241,6 @@ export class OLXParser {
       id: indexToLetterMap[answers.length],
       title: numericalresponse['@_answer'],
       correct: true,
-      selectedFeedback: feedback,
       ...responseParam,
     });
 
@@ -250,24 +248,20 @@ export class OLXParser {
     const additionalAnswer = _.get(numericalresponse, 'additional_answer', []);
     if (_.isArray(additionalAnswer)) {
       additionalAnswer.forEach((newAnswer) => {
-        answerFeedback = this.getFeedback(newAnswer);
         answers.push({
           id: indexToLetterMap[answers.length],
           title: newAnswer['@_answer'],
           correct: true,
-          selectedFeedback: answerFeedback,
         });
       });
     } else {
-      answerFeedback = this.getFeedback(additionalAnswer);
       answers.push({
         id: indexToLetterMap[answers.length],
         title: additionalAnswer['@_answer'],
         correct: true,
-        selectedFeedback: answerFeedback,
       });
     }
-    return { answers };
+    return { answers, correctAnswerFeedback: feedback };
   }
 
   parseQuestions(problemType) {
@@ -400,6 +394,7 @@ export class OLXParser {
     let answersObject = {};
     let additionalAttributes = {};
     let groupFeedbackList = [];
+    let correctAnswerFeedback = '';
     const problemType = this.getProblemType();
     const hints = this.getHints();
     const question = this.parseQuestions(problemType);
@@ -434,9 +429,11 @@ export class OLXParser {
     if (_.has(answersObject, 'additionalStringAttributes')) {
       additionalAttributes = { ...answersObject.additionalStringAttributes };
     }
-
     if (_.has(answersObject, 'groupFeedbackList')) {
       groupFeedbackList = answersObject.groupFeedbackList;
+    }
+    if (_.has(answersObject, 'correctAnswerFeedback')) {
+      correctAnswerFeedback = answersObject.correctAnswerFeedback;
     }
     const { answers } = answersObject;
     const settings = { hints };
@@ -450,6 +447,7 @@ export class OLXParser {
       additionalAttributes,
       generalFeedback,
       groupFeedbackList,
+      correctAnswerFeedback,
     };
   }
 }

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -274,8 +274,8 @@ class ReactStateOLXParser {
     let answerObject = {};
     const additionalAnswers = [];
     let firstCorrectAnswerParsed = false;
+    const correcthint = this.problemState?.correctAnswerFeedback;
     answers.forEach((answer) => {
-      const correcthint = this.getAnswerHints(answer);
       if (this.hasAttributeWithValue(answer, 'title')) {
         if (answer.correct && !firstCorrectAnswerParsed) {
           firstCorrectAnswerParsed = true;
@@ -291,12 +291,10 @@ class ReactStateOLXParser {
           answerObject = {
             '@_answer': answer.title,
             ...responseParam,
-            ...correcthint,
           };
         } else if (answer.correct && firstCorrectAnswerParsed) {
           additionalAnswers.push({
             '@_answer': answer.title,
-            ...correcthint,
           });
         }
       }
@@ -307,6 +305,7 @@ class ReactStateOLXParser {
       formulaequationinput: {
         '#text': '',
       },
+      correcthint,
     };
     return answerObject;
   }

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -314,8 +314,8 @@ export const numericInputWithFeedbackAndHintsOLX = {
 <description>You can add an optional tip or note related to the prompt like this. </description>
 <responseparam type="tolerance" default="5"/>
   <formulaequationinput/>
+  <additional_answer answer="200"></additional_answer>
   <correcthint>You can specify optional feedback like this, which appears after this answer is submitted.</correcthint>
-  <additional_answer answer="200"><correcthint>You can specify optional feedback like this, which appears after this answer is submitted.</correcthint></additional_answer>
 </numericalresponse>
 <demandhint>
   <hint>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</hint>
@@ -337,16 +337,15 @@ export const numericInputWithFeedbackAndHintsOLX = {
         id: 'A',
         title: '100',
         correct: true,
-        selectedFeedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
         tolerance: '5',
       },
       {
         id: 'B',
         title: '200',
         correct: true,
-        selectedFeedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
       },
     ],
+    correctAnswerFeedback: 'You can specify optional feedback like this, which appears after this answer is submitted.',
   },
   question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
   buildOLX: `<problem>
@@ -355,11 +354,9 @@ export const numericInputWithFeedbackAndHintsOLX = {
   <em>You can add an optional tip or note related to the prompt like this.</em>
   <numericalresponse answer="100">
     <responseparam type="tolerance" default="5"></responseparam>
-    <correcthint>You can specify optional feedback like this, which appears after this answer is submitted.</correcthint>
-    <additional_answer answer="200">
-      <correcthint>You can specify optional feedback like this, which appears after this answer is submitted.</correcthint>
-    </additional_answer>
+    <additional_answer answer="200"></additional_answer>
     <formulaequationinput></formulaequationinput>
+    <correcthint>You can specify optional feedback like this, which appears after this answer is submitted.</correcthint>
   </numericalresponse>
   <demandhint>
     <hint>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</hint>

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -13,6 +13,7 @@ const initialState = {
   correctAnswerCount: 0,
   groupFeedbackList: [],
   generalFeedback: '',
+  correctAnswerFeedback: '',
   additionalAttributes: {},
   settings: {
     randomization: null,


### PR DESCRIPTION
OLX for numeric input problem type only accepts one feedback for correct answers. This PR makes changes to the problem editor to follow this behavior by making these changes for the Numeric Input problem type:

- Creating a Correct Answer Feedback widget in the widget settings
- Ensuring OLX → react state parses correctly
- Ensuring react state → OLX parses correctly
- Removing inline selected feedback and general feedback widget

Feedback functionality for Numeric Input problem type is detailed in RTDocs: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/numerical_input.html#adding-feedback-to-a-numerical-input-problem

https://2u-internal.atlassian.net/browse/TNL-10524