### PR TITLE
feat: offer to import youtube transcripts dynamically

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
@@ -1,7 +1,27 @@
 import { actions } from '../../../../../../data/redux';
+import { parseYoutubeId } from '../../../../../../data/services/cms/api';
+import * as requests from '../../../../../../data/redux/thunkActions/requests';
 
 export const sourceHooks = ({ dispatch }) => ({
-  updateVideoURL: (e) => dispatch(actions.video.updateField({ videoSource: e.target.value })),
+  updateVideoURL: (e, videoId) => {
+    const videoUrl = e.target.value;
+    dispatch(actions.video.updateField({ videoSource: videoUrl }));
+
+    const youTubeId = parseYoutubeId(videoUrl);
+    if (youTubeId) {
+      dispatch(requests.checkTranscriptsForImport({
+        videoId,
+        youTubeId,
+        onSuccess: (response) => {
+          if (response.data.command === 'import') {
+            dispatch(actions.video.updateField({
+              allowTranscriptImport: true,
+            }));
+          }
+        },
+      }));
+    }
+  },
   updateVideoId: (e) => dispatch(actions.video.updateField({ videoId: e.target.value })),
 });
 

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.jsx
@@ -77,7 +77,7 @@ export const VideoSourceWidget = ({
           <Form.Control
             floatingLabel={intl.formatMessage(messages.videoUrlLabel)}
             onChange={source.onChange}
-            onBlur={updateVideoURL}
+            onBlur={(e) => updateVideoURL(e, videoId.local)}
             value={source.local}
           />
           <FormControlFeedback className="text-primary-300">

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.test.jsx
@@ -34,7 +34,7 @@ jest.mock('../hooks', () => ({
 jest.mock('./hooks', () => ({
   sourceHooks: jest.fn().mockReturnValue({
     updateVideoId: (args) => ({ updateVideoId: args }),
-    updateVideoURL: (args) => ({ updateVideoURL: args }),
+    updateVideoURL: jest.fn().mockName('updateVideoURL'),
   }),
   fallbackHooks: jest.fn().mockReturnValue({
     addFallbackVideo: jest.fn().mockName('addFallbackVideo'),
@@ -92,11 +92,11 @@ describe('VideoSourceWidget', () => {
         .props().onBlur).toEqual(expected);
     });
     test('updateVideoURL is tied to url field onBlur', () => {
-      const expected = hook.updateVideoURL;
-      expect(el
+      const { onBlur } = el
         // eslint-disable-next-line
-        .children().at(0).children().at(0).children().at(2)
-        .props().onBlur).toEqual(expected);
+        .children().at(0).children().at(0).children().at(2).props();
+      onBlur('onBlur event');
+      expect(hook.updateVideoURL).toHaveBeenCalledWith('onBlur event', '');
     });
   });
 });


### PR DESCRIPTION
## Description

When a course author is editing a video XBlock in the new video editor, for YouTube videos the option to import transcripts only appears after adding the URL, saving the XBlock and opening it for editing again. This PR makes the popup appear as soon as the YouTube URL is added and certain validations have passed, without having to save the and enter the editor again.

## Testing instructions

### Setup
If you're going to test on devstack, here are the setup steps:
1. Setup `master` devstack
2. Enable new video editor following [these instructions](https://github.com/openedx/frontend-app-course-authoring/blob/ad47bfacd4a4033572fd98e81ec16b51379f8325/README.rst#feature-new-react-xblock-editors):
    * You don't need to set `COURSE_AUTHORING_MICROFRONTEND_URL`, as it's already set on devstack
    * You can set `ENABLE_NEW_EDITOR_PAGES=true` in `<devstack parrent dir>/devstack/microfrontend.yml` (remember to restart the MFE containers).
3. Setup this repo following [these steps](https://github.com/openedx/frontend-lib-content-components#how-to-set-up-development-workflow-of-v2-content-editors-in-studio-and-course-authoring-mfe), checkout the branch, and run `make build`. 

### Steps to test
Examples:
* YouTube video with English transcripts: https://www.youtube.com/watch?v=3_yD_cEKoCk
* YouTube video without transcripts: https://www.youtube.com/watch?v=N3oCS85HvpY

1. Open a course in Studio, create new Section, Subsection and Unit.
4. Create new Video XBlock (click "Video", not "Advanced -> Video").
5. Enter a YouTube video URL into URL field and click out (update is triggered on `onBlur` event, i.e. when the field loses focus).
6. Check:
    1. If YouTube video has transcripts, you should be able to see the popup offering to import the transcripts.
    2. If YouTube video doesn't have transcripts, the popup should not appear.

## Deadline

"None"

## Other information

`Private-ref`: [BB-7148](https://tasks.opencraft.com/browse/BB-7148)