### PR TITLE
feat: add default advanced setting ui callouts

### DIFF
--- a/src/editors/containers/ProblemEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/__snapshots__/index.test.jsx.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProblemEditor snapshots advanceSettings loaded, block and studio view not yet loaded, Spinner appears 1`] = `
-<div
-  className="text-center p-6"
->
-  <Spinner
-    animation="border"
-    className="m-3"
-    screenreadertext="Loading Problem Editor"
-  />
-</div>
-`;
-
-exports[`ProblemEditor snapshots assets loaded, block and studio view not yet loaded, Spinner appears 1`] = `
-<div
-  className="text-center p-6"
->
-  <Spinner
-    animation="border"
-    className="m-3"
-    screenreadertext="Loading Problem Editor"
-  />
-</div>
-`;
-
 exports[`ProblemEditor snapshots block failed, message appears 1`] = `
 <div
   className="text-center p-6"
@@ -36,49 +12,7 @@ exports[`ProblemEditor snapshots block failed, message appears 1`] = `
 </div>
 `;
 
-exports[`ProblemEditor snapshots block loaded, studio view and assets not yet loaded, Spinner appears 1`] = `
-<div
-  className="text-center p-6"
->
-  <Spinner
-    animation="border"
-    className="m-3"
-    screenreadertext="Loading Problem Editor"
-  />
-</div>
-`;
-
-exports[`ProblemEditor snapshots renders EditProblemView 1`] = `
-<div
-  className="text-center p-6"
->
-  <FormattedMessage
-    defaultMessage="Problem failed to load"
-    description="Error message for problem block failing to load"
-    id="authoring.problemEditor.blockFailed"
-  />
-</div>
-`;
-
-exports[`ProblemEditor snapshots renders SelectTypeModal 1`] = `
-<SelectTypeModal
-  onClose={[MockFunction props.onClose]}
-/>
-`;
-
 exports[`ProblemEditor snapshots renders as expected with default behavior 1`] = `
-<div
-  className="text-center p-6"
->
-  <Spinner
-    animation="border"
-    className="m-3"
-    screenreadertext="Loading Problem Editor"
-  />
-</div>
-`;
-
-exports[`ProblemEditor snapshots studio view loaded, block and assets not yet loaded, Spinner appears 1`] = `
 <div
   className="text-center p-6"
 >

--- a/src/editors/containers/ProblemEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProblemEditor snapshots advanceSettings loaded, block and studio view not yet loaded, Spinner appears 1`] = `
+<div
+  className="text-center p-6"
+>
+  <Spinner
+    animation="border"
+    className="m-3"
+    screenreadertext="Loading Problem Editor"
+  />
+</div>
+`;
+
 exports[`ProblemEditor snapshots assets loaded, block and studio view not yet loaded, Spinner appears 1`] = `
 <div
   className="text-center p-6"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
@@ -14,7 +14,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget for Advanced 
   <div
     className="my-3"
   >
-    <ScoringCard />
+    <ScoringCard
+      defaultValue={2}
+    />
   </div>
   <div
     className="mt-3"
@@ -53,7 +55,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget for Advanced 
       <div
         className="my-3"
       >
-        <ShowAnswerCard />
+        <ShowAnswerCard
+          defaultValue="finished"
+        />
       </div>
       <div
         className="my-3"
@@ -96,7 +100,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page 1`] = `
   <div
     className="my-3"
   >
-    <ScoringCard />
+    <ScoringCard
+      defaultValue={2}
+    />
   </div>
   <div
     className="mt-3"
@@ -135,7 +141,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page 1`] = `
       <div
         className="my-3"
       >
-        <ShowAnswerCard />
+        <ShowAnswerCard
+          defaultValue="finished"
+        />
       </div>
       <div
         className="my-3"
@@ -178,7 +186,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page advanced
   <div
     className="my-3"
   >
-    <ScoringCard />
+    <ScoringCard
+      defaultValue={2}
+    />
   </div>
   <div
     className="mt-3"
@@ -217,7 +227,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page advanced
       <div
         className="my-3"
       >
-        <ShowAnswerCard />
+        <ShowAnswerCard
+          defaultValue="finished"
+        />
       </div>
       <div
         className="my-3"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -136,7 +136,7 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
     let attemptNumber = parseInt(event.target.value);
     const { value } = event.target;
     if (_.isNaN(attemptNumber)) {
-     if (value === '') {
+      if (value === '') {
         attemptNumber = defaultValue;
         setAttemptDisplayValue(`${defaultValue} (Default)`);
       } else {
@@ -144,7 +144,7 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
         unlimitedAttempts = true;
       }
     } else if (attemptNumber <= 0) {
-        attemptNumber = 0;
+      attemptNumber = 0;
     } else if (attemptNumber === defaultValue) {
       const attemptNumberStr = value.replace(' (Default)');
       attemptNumber = parseInt(attemptNumberStr);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -10,6 +10,7 @@ export const state = {
   cardCollapsed: (val) => useState(val),
   summary: (val) => useState(val),
   showAttempts: (val) => useState(val),
+  local: (val) => useState(val),
 };
 
 export const showAdvancedSettingsCards = () => {
@@ -120,17 +121,33 @@ export const resetCardHooks = (updateSettings) => {
   };
 };
 
-export const scoringCardHooks = (scoring, updateSettings) => {
+export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
+  const [local, setLocal] = module.state.local(scoring.attempts.number);
   const handleMaxAttemptChange = (event) => {
     let unlimitedAttempts = false;
     let attemptNumber = parseInt(event.target.value);
+    const { value } = event.target;
     if (_.isNaN(attemptNumber)) {
-      attemptNumber = '';
-      unlimitedAttempts = true;
+      if (value?.startsWith(defaultValue)) {
+        attemptNumber = value.replace(' (Default)');
+      } else {
+        attemptNumber = '';
+        unlimitedAttempts = true;
+      }
     } else if (attemptNumber < 0) {
       attemptNumber = 0;
     }
     updateSettings({ scoring: { ...scoring, attempts: { number: attemptNumber, unlimited: unlimitedAttempts } } });
+  };
+
+  const handleOnChange = (event) => {
+    let newMaxAttempt = event.target.value;
+    if (newMaxAttempt === defaultValue || newMaxAttempt === '') {
+      newMaxAttempt = `${defaultValue} (Default)`;
+    } else if (newMaxAttempt < 0) {
+      newMaxAttempt = 0;
+    }
+    setLocal(newMaxAttempt);
   };
 
   const handleWeightChange = (event) => {
@@ -142,7 +159,9 @@ export const scoringCardHooks = (scoring, updateSettings) => {
   };
 
   return {
+    local,
     handleMaxAttemptChange,
+    handleOnChange,
     handleWeightChange,
   };
 };

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -11,7 +11,7 @@ export const state = {
   cardCollapsed: (val) => useState(val),
   summary: (val) => useState(val),
   showAttempts: (val) => useState(val),
-  local: (val) => useState(val),
+  attemptDisplayValue: (val) => useState(val),
 };
 
 export const showAdvancedSettingsCards = () => {
@@ -119,14 +119,29 @@ export const resetCardHooks = (updateSettings) => {
 };
 
 export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
-  const [local, setLocal] = module.state.local(scoring.attempts.number);
+  const loadedAttemptsNumber = scoring.attempts.number === defaultValue ? `${scoring.attempts.number} (Default)` : scoring.attempts.number;
+  const [attemptDisplayValue, setAttemptDisplayValue] = module.state.attemptDisplayValue(loadedAttemptsNumber);
+  const handleUnlimitedChange = (event) => {
+    const isUnlimited = event.target.checked;
+    if (isUnlimited) {
+      setAttemptDisplayValue('');
+      updateSettings({ scoring: { ...scoring, attempts: { number: '', unlimited: true } } });
+    } else {
+      setAttemptDisplayValue(`${defaultValue} (Default)`);
+      updateSettings({ scoring: { ...scoring, attempts: { number: defaultValue, unlimited: false } } });
+    }
+  };
   const handleMaxAttemptChange = (event) => {
     let unlimitedAttempts = false;
     let attemptNumber = parseInt(event.target.value);
     const { value } = event.target;
     if (_.isNaN(attemptNumber)) {
       if (value?.startsWith(defaultValue)) {
-        attemptNumber = value.replace(' (Default)');
+        const attemptNumberStr = value.replace(' (Default)');
+        attemptNumber = parseInt(attemptNumberStr);
+      } else if (value === '') {
+        attemptNumber = defaultValue;
+        setAttemptDisplayValue(`${defaultValue} (Default)`);
       } else {
         attemptNumber = '';
         unlimitedAttempts = true;
@@ -138,13 +153,15 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
   };
 
   const handleOnChange = (event) => {
-    let newMaxAttempt = event.target.value;
-    if (newMaxAttempt === defaultValue || newMaxAttempt === '') {
+    let newMaxAttempt = parseInt(event.target.value);
+    if (newMaxAttempt === defaultValue) {
       newMaxAttempt = `${defaultValue} (Default)`;
+    } else if (_.isNaN(newMaxAttempt)) {
+      newMaxAttempt = '';
     } else if (newMaxAttempt < 0) {
       newMaxAttempt = 0;
     }
-    setLocal(newMaxAttempt);
+    setAttemptDisplayValue(newMaxAttempt);
   };
 
   const handleWeightChange = (event) => {
@@ -156,7 +173,8 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
   };
 
   return {
-    local,
+    attemptDisplayValue,
+    handleUnlimitedChange,
     handleMaxAttemptChange,
     handleOnChange,
     handleWeightChange,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -136,18 +136,18 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
     let attemptNumber = parseInt(event.target.value);
     const { value } = event.target;
     if (_.isNaN(attemptNumber)) {
-      if (value?.startsWith(defaultValue)) {
-        const attemptNumberStr = value.replace(' (Default)');
-        attemptNumber = parseInt(attemptNumberStr);
-      } else if (value === '') {
+     if (value === '') {
         attemptNumber = defaultValue;
         setAttemptDisplayValue(`${defaultValue} (Default)`);
       } else {
         attemptNumber = '';
         unlimitedAttempts = true;
       }
-    } else if (attemptNumber < 0) {
-      attemptNumber = 0;
+    } else if (attemptNumber <= 0) {
+        attemptNumber = 0;
+    } else if (attemptNumber === defaultValue) {
+      const attemptNumberStr = value.replace(' (Default)');
+      attemptNumber = parseInt(attemptNumberStr);
     }
     updateSettings({ scoring: { ...scoring, attempts: { number: attemptNumber, unlimited: unlimitedAttempts } } });
   };

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -176,13 +176,13 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.scoringCardHooks(scoring, updateSettings, defaultValue);
     });
-    test('test handleUnlimitedChange checked', () => {
+    test('test handleUnlimitedChange sets attempts.unlimited to true when checked', () => {
       output.handleUnlimitedChange({ target: { checked: true } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith('');
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: '', unlimited: true } } });
     });
-    test('test handleUnlimitedChange unchecked', () => {
+    test('test handleUnlimitedChange sets attempts.unlimited to false when unchecked', () => {
       output.handleUnlimitedChange({ target: { checked: false } });
       expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(`${defaultValue} (Default)`);
       expect(updateSettings)

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -176,6 +176,18 @@ describe('Problem settings hooks', () => {
     beforeEach(() => {
       output = hooks.scoringCardHooks(scoring, updateSettings, defaultValue);
     });
+    test('test handleUnlimitedChange checked', () => {
+      output.handleUnlimitedChange({ target: { checked: true } });
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith('');
+      expect(updateSettings)
+        .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: '', unlimited: true } } });
+    });
+    test('test handleUnlimitedChange unchecked', () => {
+      output.handleUnlimitedChange({ target: { checked: false } });
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(`${defaultValue} (Default)`);
+      expect(updateSettings)
+        .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: defaultValue, unlimited: false } } });
+    });
     test('test handleMaxAttemptChange', () => {
       const value = 6;
       output.handleMaxAttemptChange({ target: { value } });
@@ -215,32 +227,32 @@ describe('Problem settings hooks', () => {
     test('test handleOnChange', () => {
       const value = 6;
       output.handleOnChange({ target: { value } });
-      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(value);
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(value);
     });
     test('test handleOnChange set attempts to zero', () => {
       const value = 0;
       output.handleOnChange({ target: { value } });
-      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(value);
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(value);
     });
     test('test handleOnChange set attempts to default value from empty string', () => {
       const value = '';
       output.handleOnChange({ target: { value } });
-      expect(state.setState[state.keys.local]).toHaveBeenCalledWith('1 (Default)');
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith('');
     });
     test('test handleOnChange set attempts to default value', () => {
       const value = 1;
       output.handleOnChange({ target: { value } });
-      expect(state.setState[state.keys.local]).toHaveBeenCalledWith('1 (Default)');
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith('1 (Default)');
     });
     test('test handleOnChange set attempts to non-numeric value', () => {
-      const value = 'abc';
+      const value = '';
       output.handleOnChange({ target: { value } });
-      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(value);
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(value);
     });
     test('test handleOnChange set attempts to negative value', () => {
       const value = -1;
       output.handleOnChange({ target: { value } });
-      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(0);
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(0);
     });
     test('test handleWeightChange', () => {
       const value = 2;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -218,6 +218,13 @@ describe('Problem settings hooks', () => {
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: '', unlimited: true } } });
     });
+    test('test handleMaxAttemptChange set attempts to empty value', () => {
+      const value = '';
+      output.handleMaxAttemptChange({ target: { value } });
+      expect(state.setState[state.keys.attemptDisplayValue]).toHaveBeenCalledWith(`${defaultValue} (Default)`);
+      expect(updateSettings)
+        .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: 1, unlimited: false } } });
+    });
     test('test handleMaxAttemptChange set attempts to negative value', () => {
       const value = -1;
       output.handleMaxAttemptChange({ target: { value } });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -169,8 +169,9 @@ describe('Problem settings hooks', () => {
         number: 5,
       },
     };
+    const defaultValue = 1;
     beforeEach(() => {
-      output = hooks.scoringCardHooks(scoring, updateSettings);
+      output = hooks.scoringCardHooks(scoring, updateSettings, defaultValue);
     });
     test('test handleMaxAttemptChange', () => {
       const value = 6;
@@ -190,11 +191,11 @@ describe('Problem settings hooks', () => {
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: '', unlimited: true } } });
     });
-    test('test handleMaxAttemptChange set attempts to empty string', () => {
-      const value = '';
+    test('test handleMaxAttemptChange set attempts to default value', () => {
+      const value = '1 (Default)';
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
-        .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: '', unlimited: true } } });
+        .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: 1, unlimited: false } } });
     });
     test('test handleMaxAttemptChange set attempts to non-numeric value', () => {
       const value = 'abc';
@@ -207,6 +208,36 @@ describe('Problem settings hooks', () => {
       output.handleMaxAttemptChange({ target: { value } });
       expect(updateSettings)
         .toHaveBeenCalledWith({ scoring: { ...scoring, attempts: { number: 0, unlimited: false } } });
+    });
+    test('test handleOnChange', () => {
+      const value = 6;
+      output.handleOnChange({ target: { value } });
+      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(value);
+    });
+    test('test handleOnChange set attempts to zero', () => {
+      const value = 0;
+      output.handleOnChange({ target: { value } });
+      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(value);
+    });
+    test('test handleOnChange set attempts to default value from empty string', () => {
+      const value = '';
+      output.handleOnChange({ target: { value } });
+      expect(state.setState[state.keys.local]).toHaveBeenCalledWith('1 (Default)');
+    });
+    test('test handleOnChange set attempts to default value', () => {
+      const value = 1;
+      output.handleOnChange({ target: { value } });
+      expect(state.setState[state.keys.local]).toHaveBeenCalledWith('1 (Default)');
+    });
+    test('test handleOnChange set attempts to non-numeric value', () => {
+      const value = 'abc';
+      output.handleOnChange({ target: { value } });
+      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(value);
+    });
+    test('test handleOnChange set attempts to negative value', () => {
+      const value = -1;
+      output.handleOnChange({ target: { value } });
+      expect(state.setState[state.keys.local]).toHaveBeenCalledWith(0);
     });
     test('test handleWeightChange', () => {
       const value = 2;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -35,6 +35,7 @@ export const SettingsWidget = ({
   updateSettings,
   updateField,
   updateAnswer,
+  defaultSettings,
 }) => {
   const { isAdvancedCardsVisible, showAdvancedCards } = showAdvancedSettingsCards();
 
@@ -66,7 +67,11 @@ export const SettingsWidget = ({
         />
       </div>
       <div className="my-3">
-        <ScoringCard scoring={settings.scoring} updateSettings={updateSettings} />
+        <ScoringCard
+          scoring={settings.scoring}
+          defaultValue={defaultSettings.maxAttempts}
+          updateSettings={updateSettings}
+        />
       </div>
       <div className="mt-3">
         <HintsCard problemType={problemType} hints={settings.hints} updateSettings={updateSettings} />
@@ -92,6 +97,7 @@ export const SettingsWidget = ({
           <div className="my-3">
             <ShowAnswerCard
               showAnswer={settings.showAnswer}
+              defaultValue={defaultSettings.showanswer}
               updateSettings={updateSettings}
               solutionExplanation={settings.solutionExplanation}
             />
@@ -149,6 +155,11 @@ SettingsWidget.propTypes = {
   updateAnswer: PropTypes.func.isRequired,
   updateField: PropTypes.func.isRequired,
   updateSettings: PropTypes.func.isRequired,
+  defaultSettings: PropTypes.shape({
+    maxAttempts: PropTypes.number,
+    showanswer: PropTypes.string,
+    showReseButton: PropTypes.bool,
+  }).isRequired,
   // eslint-disable-next-line
   settings: PropTypes.any.isRequired,
 };
@@ -159,6 +170,7 @@ const mapStateToProps = (state) => ({
   answers: selectors.problem.answers(state),
   blockTitle: selectors.app.blockTitle(state),
   correctAnswerCount: selectors.problem.correctAnswerCount(state),
+  defaultSettings: selectors.problem.defaultSettings(state),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.scss
@@ -19,3 +19,10 @@
         width: 100%;
     }
 }
+.scoringCard{
+    .defaultAttempts {
+        input::after{
+            content: '(Default)';
+        }
+    }
+}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.scss
@@ -19,10 +19,3 @@
         width: 100%;
     }
 }
-.scoringCard{
-    .defaultAttempts {
-        input::after{
-            content: '(Default)';
-        }
-    }
-}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
@@ -25,6 +25,11 @@ describe('SettingsWidget', () => {
   const props = {
     problemType: ProblemTypeKeys.TEXTINPUT,
     settings: {},
+    defaultSettings: {
+      maxAttempts: 2,
+      showanswer: 'finished',
+      showResetButton: false,
+    },
   };
 
   describe('behavior', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -114,6 +114,11 @@ export const messages = {
     defaultMessage: '{attempts, plural, =1 {# attempt} other {# attempts}}',
     description: 'Summary text for number of attempts',
   },
+  unlimitedAttemptsCheckboxLabel: {
+    id: 'authoring.problemeditor.settings.scoring.attempts.unlimitedCheckbox',
+    defaultMessage: 'Unlimited attempts',
+    description: 'Label for unlimited attempts checkbox',
+  },
   weightSummary: {
     id: 'authoring.problemeditor.settings.scoring.weight',
     defaultMessage: '{weight, plural, =0 {Ungraded} other {# points}}',

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
@@ -15,7 +15,7 @@ export const ResetCard = ({
   intl,
 }) => {
   const { setResetTrue, setResetFalse } = resetCardHooks(updateSettings);
-  const advancedSettingsLink = `${useSelector(selectors.app.studioEndpointUrl)}/settings/advanced/${useSelector(selectors.app.learningContextId)}`;
+  const advancedSettingsLink = `${useSelector(selectors.app.studioEndpointUrl)}/settings/advanced/${useSelector(selectors.app.learningContextId)}#show_reset_button`;
   return (
     <SettingsOption
       title={intl.formatMessage(messages.resetSettingsTitle)}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -1,47 +1,48 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Form } from '@edx/paragon';
+import { Form, Hyperlink } from '@edx/paragon';
+import { selectors } from '../../../../../../data/redux';
 import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { scoringCardHooks } from '../hooks';
 
 export const ScoringCard = ({
   scoring,
+  defaultValue,
   updateSettings,
   // inject
   intl,
+  // redux
+  studioEndpointUrl,
+  learningContextId,
 }) => {
-  const { handleMaxAttemptChange, handleWeightChange } = scoringCardHooks(scoring, updateSettings);
+  const {
+    handleMaxAttemptChange,
+    handleWeightChange,
+    handleOnChange,
+    local,
+  } = scoringCardHooks(scoring, updateSettings, defaultValue);
 
-  const getScoringSummary = (attempts, unlimited, weight) => {
-    let summary = unlimited
+  const getScoringSummary = (weight, attempts, unlimited) => {
+    let summary = intl.formatMessage(messages.weightSummary, { weight });
+    summary += ` ${String.fromCharCode(183)} `;
+    summary += unlimited
       ? intl.formatMessage(messages.unlimitedAttemptsSummary)
       : intl.formatMessage(messages.attemptsSummary, { attempts });
-    summary += ` ${String.fromCharCode(183)} `;
-    summary += intl.formatMessage(messages.weightSummary, { weight });
     return summary;
   };
 
   return (
     <SettingsOption
       title={intl.formatMessage(messages.scoringSettingsTitle)}
-      summary={getScoringSummary(scoring.attempts.number, scoring.attempts.unlimited, scoring.weight)}
+      summary={getScoringSummary(scoring.weight, scoring.attempts.number, scoring.attempts.unlimited)}
+      className="scoringCard"
     >
       <Form.Label className="mb-4">
         <FormattedMessage {...messages.scoringSettingsLabel} />
       </Form.Label>
-      <Form.Group>
-        <Form.Control
-          type="number"
-          value={scoring.attempts.number}
-          onChange={handleMaxAttemptChange}
-          floatingLabel={intl.formatMessage(messages.scoringAttemptsInputLabel)}
-        />
-        <Form.Control.Feedback>
-          <FormattedMessage {...messages.attemptsHint} />
-        </Form.Control.Feedback>
-      </Form.Group>
       <Form.Group>
         <Form.Control
           type="number"
@@ -53,6 +54,20 @@ export const ScoringCard = ({
           <FormattedMessage {...messages.weightHint} />
         </Form.Control.Feedback>
       </Form.Group>
+      <Form.Group>
+        <Form.Control
+          value={local}
+          onChange={handleOnChange}
+          onBlur={handleMaxAttemptChange}
+          floatingLabel={intl.formatMessage(messages.scoringAttemptsInputLabel)}
+        />
+        <Form.Control.Feedback>
+          <FormattedMessage {...messages.attemptsHint} />
+        </Form.Control.Feedback>
+      </Form.Group>
+      <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}#max_attempts`} target="_blank">
+        <FormattedMessage {...messages.advancedSettingsLinkText} />
+      </Hyperlink>
     </SettingsOption>
   );
 };
@@ -62,6 +77,17 @@ ScoringCard.propTypes = {
   // eslint-disable-next-line
   scoring: PropTypes.any.isRequired,
   updateSettings: PropTypes.func.isRequired,
+  defaultValue: PropTypes.number.isRequired,
+  // redux
+  studioEndpointUrl: PropTypes.string.isRequired,
+  learningContextId: PropTypes.string.isRequired,
 };
 
-export default injectIntl(ScoringCard);
+export const mapStateToProps = (state) => ({
+  studioEndpointUrl: selectors.app.studioEndpointUrl(state),
+  learningContextId: selectors.app.learningContextId(state),
+});
+
+export const mapDispatchToProps = {};
+
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(ScoringCard));

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -19,10 +19,11 @@ export const ScoringCard = ({
   learningContextId,
 }) => {
   const {
+    handleUnlimitedChange,
     handleMaxAttemptChange,
     handleWeightChange,
     handleOnChange,
-    local,
+    attemptDisplayValue,
   } = scoringCardHooks(scoring, updateSettings, defaultValue);
 
   const getScoringSummary = (weight, attempts, unlimited) => {
@@ -56,14 +57,24 @@ export const ScoringCard = ({
       </Form.Group>
       <Form.Group>
         <Form.Control
-          value={local}
+          value={attemptDisplayValue}
           onChange={handleOnChange}
           onBlur={handleMaxAttemptChange}
           floatingLabel={intl.formatMessage(messages.scoringAttemptsInputLabel)}
+          disabled={scoring.attempts.unlimited}
         />
         <Form.Control.Feedback>
           <FormattedMessage {...messages.attemptsHint} />
         </Form.Control.Feedback>
+        <Form.Checkbox
+          className="mt-3 decoration-control-label"
+          checked={scoring.attempts.unlimited}
+          onChange={handleUnlimitedChange}
+        >
+          <div className="small">
+            <FormattedMessage {...messages.unlimitedAttemptsCheckboxLabel} />
+          </div>
+        </Form.Checkbox>
       </Form.Group>
       <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}#max_attempts`} target="_blank">
         <FormattedMessage {...messages.advancedSettingsLinkText} />

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
@@ -16,6 +16,7 @@ describe('ScoringCard', () => {
       number: 5,
     },
     updateSettings: jest.fn().mockName('args.updateSettings'),
+    defaultValue: 1,
     intl: { formatMessage },
   };
 
@@ -27,6 +28,8 @@ describe('ScoringCard', () => {
   const scoringCardHooksProps = {
     handleMaxAttemptChange: jest.fn().mockName('scoringCardHooks.handleMaxAttemptChange'),
     handleWeightChange: jest.fn().mockName('scoringCardHooks.handleWeightChange'),
+    handleOnChange: jest.fn().mockName('scoringCardHooks.handleOnChange'),
+    local: 5,
   };
 
   scoringCardHooks.mockReturnValue(scoringCardHooksProps);
@@ -34,7 +37,7 @@ describe('ScoringCard', () => {
   describe('behavior', () => {
     it(' calls scoringCardHooks when initialized', () => {
       shallow(<ScoringCard {...props} />);
-      expect(scoringCardHooks).toHaveBeenCalledWith(scoring, props.updateSettings);
+      expect(scoringCardHooks).toHaveBeenCalledWith(scoring, props.updateSettings, props.defaultValue);
     });
   });
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
@@ -13,6 +13,7 @@ export const ShowAnswerCard = ({
   showAnswer,
   solutionExplanation,
   updateSettings,
+  defaultValue,
   // inject
   intl,
   // redux
@@ -34,7 +35,7 @@ export const ShowAnswerCard = ({
         </span>
       </div>
       <div className="pb-4">
-        <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}`} target="_blank">
+        <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}#showanswer`} target="_blank">
           <FormattedMessage {...messages.advancedSettingsLinkText} />
         </Hyperlink>
       </div>
@@ -44,14 +45,20 @@ export const ShowAnswerCard = ({
           value={showAnswer.on}
           onChange={handleShowAnswerChange}
         >
-          {Object.values(ShowAnswerTypesKeys).map((answerType) => (
-            <option
-              key={answerType}
-              value={answerType}
-            >
-              {intl.formatMessage(ShowAnswerTypes[answerType])}
-            </option>
-          ))}
+          {Object.values(ShowAnswerTypesKeys).map((answerType) => {
+            let optionDisplayName = ShowAnswerTypes[answerType];
+            if (answerType === defaultValue) {
+              optionDisplayName = { ...optionDisplayName, defaultMessage: `${optionDisplayName.defaultMessage} (Default)` };
+            }
+            return (
+              <option
+                key={answerType}
+                value={answerType}
+              >
+                {intl.formatMessage(optionDisplayName)}
+              </option>
+            );
+          })}
         </Form.Control>
       </Form.Group>
       {showAttempts
@@ -104,6 +111,7 @@ ShowAnswerCard.propTypes = {
   updateSettings: PropTypes.func.isRequired,
   studioEndpointUrl: PropTypes.string.isRequired,
   learningContextId: PropTypes.string.isRequired,
+  defaultValue: PropTypes.string.isRequired,
 };
 ShowAnswerCard.defaultProps = {
   solutionExplanation: '',

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
@@ -23,11 +23,11 @@ describe('ShowAnswerCard', () => {
     on: 'after_attempts',
     afterAttempts: 5,
     updateSettings: jest.fn().mockName('args.updateSettings'),
-    defaultValue: 'finished',
     intl: { formatMessage },
   };
   const props = {
     showAnswer,
+    defaultValue: 'finished',
     // injected
     intl: { formatMessage },
     // redux

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
@@ -23,6 +23,7 @@ describe('ShowAnswerCard', () => {
     on: 'after_attempts',
     afterAttempts: 5,
     updateSettings: jest.fn().mockName('args.updateSettings'),
+    defaultValue: 'finished',
     intl: { formatMessage },
   };
   const props = {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ResetCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ResetCard.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`ResetCard snapshot snapshot: renders reset true setting card 1`] = `
     className="spacedMessage"
   >
     <Hyperlink
-      destination="sTuDioEndpOintUrl/settings/advanced/leArningCoNteXtId"
+      destination="sTuDioEndpOintUrl/settings/advanced/leArningCoNteXtId#show_reset_button"
       target="_blank"
     >
       <FormattedMessage
@@ -84,7 +84,7 @@ exports[`ResetCard snapshot snapshot: renders reset true setting card 2`] = `
     className="spacedMessage"
   >
     <Hyperlink
-      destination="sTuDioEndpOintUrl/settings/advanced/leArningCoNteXtId"
+      destination="sTuDioEndpOintUrl/settings/advanced/leArningCoNteXtId#show_reset_button"
       target="_blank"
     >
       <FormattedMessage

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
@@ -2,9 +2,9 @@
 
 exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
 <SettingsOption
-  className=""
+  className="scoringCard"
   extraSections={Array []}
-  summary="{attempts, plural, =1 {# attempt} other {# attempts}} · {weight, plural, =0 {Ungraded} other {# points}}"
+  summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
   title="Scoring"
 >
   <Form.Label
@@ -16,21 +16,6 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
       id="authoring.problemeditor.settings.scoring.label"
     />
   </Form.Label>
-  <Form.Group>
-    <Form.Control
-      floatingLabel="Attempts"
-      onChange={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
-      type="number"
-      value={5}
-    />
-    <Form.Control.Feedback>
-      <FormattedMessage
-        defaultMessage="If a value is not set, unlimited attempts are allowed"
-        description="Summary text for scoring weight"
-        id="authoring.problemeditor.settings.scoring.attempts.hint"
-      />
-    </Form.Control.Feedback>
-  </Form.Group>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -46,14 +31,39 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
       />
     </Form.Control.Feedback>
   </Form.Group>
+  <Form.Group>
+    <Form.Control
+      floatingLabel="Attempts"
+      onBlur={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
+      onChange={[MockFunction scoringCardHooks.handleOnChange]}
+      value={5}
+    />
+    <Form.Control.Feedback>
+      <FormattedMessage
+        defaultMessage="If a value is not set, unlimited attempts are allowed"
+        description="Summary text for scoring weight"
+        id="authoring.problemeditor.settings.scoring.attempts.hint"
+      />
+    </Form.Control.Feedback>
+  </Form.Group>
+  <Hyperlink
+    destination="undefined/settings/advanced/undefined#max_attempts"
+    target="_blank"
+  >
+    <FormattedMessage
+      defaultMessage="Set a default value in advanced settings"
+      description="Advanced settings link text"
+      id="authoring.problemeditor.settings.advancedSettingLink.text"
+    />
+  </Hyperlink>
 </SettingsOption>
 `;
 
 exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = `
 <SettingsOption
-  className=""
+  className="scoringCard"
   extraSections={Array []}
-  summary="Unlimited attempts · {weight, plural, =0 {Ungraded} other {# points}}"
+  summary="{weight, plural, =0 {Ungraded} other {# points}} · Unlimited attempts"
   title="Scoring"
 >
   <Form.Label
@@ -65,21 +75,6 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
       id="authoring.problemeditor.settings.scoring.label"
     />
   </Form.Label>
-  <Form.Group>
-    <Form.Control
-      floatingLabel="Attempts"
-      onChange={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
-      type="number"
-      value={0}
-    />
-    <Form.Control.Feedback>
-      <FormattedMessage
-        defaultMessage="If a value is not set, unlimited attempts are allowed"
-        description="Summary text for scoring weight"
-        id="authoring.problemeditor.settings.scoring.attempts.hint"
-      />
-    </Form.Control.Feedback>
-  </Form.Group>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -95,14 +90,39 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
       />
     </Form.Control.Feedback>
   </Form.Group>
+  <Form.Group>
+    <Form.Control
+      floatingLabel="Attempts"
+      onBlur={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
+      onChange={[MockFunction scoringCardHooks.handleOnChange]}
+      value={5}
+    />
+    <Form.Control.Feedback>
+      <FormattedMessage
+        defaultMessage="If a value is not set, unlimited attempts are allowed"
+        description="Summary text for scoring weight"
+        id="authoring.problemeditor.settings.scoring.attempts.hint"
+      />
+    </Form.Control.Feedback>
+  </Form.Group>
+  <Hyperlink
+    destination="undefined/settings/advanced/undefined#max_attempts"
+    target="_blank"
+  >
+    <FormattedMessage
+      defaultMessage="Set a default value in advanced settings"
+      description="Advanced settings link text"
+      id="authoring.problemeditor.settings.advancedSettingLink.text"
+    />
+  </Hyperlink>
 </SettingsOption>
 `;
 
 exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`] = `
 <SettingsOption
-  className=""
+  className="scoringCard"
   extraSections={Array []}
-  summary="{attempts, plural, =1 {# attempt} other {# attempts}} · {weight, plural, =0 {Ungraded} other {# points}}"
+  summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
   title="Scoring"
 >
   <Form.Label
@@ -114,21 +134,6 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
       id="authoring.problemeditor.settings.scoring.label"
     />
   </Form.Label>
-  <Form.Group>
-    <Form.Control
-      floatingLabel="Attempts"
-      onChange={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
-      type="number"
-      value={5}
-    />
-    <Form.Control.Feedback>
-      <FormattedMessage
-        defaultMessage="If a value is not set, unlimited attempts are allowed"
-        description="Summary text for scoring weight"
-        id="authoring.problemeditor.settings.scoring.attempts.hint"
-      />
-    </Form.Control.Feedback>
-  </Form.Group>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -144,5 +149,30 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
       />
     </Form.Control.Feedback>
   </Form.Group>
+  <Form.Group>
+    <Form.Control
+      floatingLabel="Attempts"
+      onBlur={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
+      onChange={[MockFunction scoringCardHooks.handleOnChange]}
+      value={5}
+    />
+    <Form.Control.Feedback>
+      <FormattedMessage
+        defaultMessage="If a value is not set, unlimited attempts are allowed"
+        description="Summary text for scoring weight"
+        id="authoring.problemeditor.settings.scoring.attempts.hint"
+      />
+    </Form.Control.Feedback>
+  </Form.Group>
+  <Hyperlink
+    destination="undefined/settings/advanced/undefined#max_attempts"
+    target="_blank"
+  >
+    <FormattedMessage
+      defaultMessage="Set a default value in advanced settings"
+      description="Advanced settings link text"
+      id="authoring.problemeditor.settings.advancedSettingLink.text"
+    />
+  </Hyperlink>
 </SettingsOption>
 `;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
 <SettingsOption
   className="scoringCard"
   extraSections={Array []}
+  hasExpandableTextArea={false}
   summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
   title="Scoring"
 >
@@ -63,6 +64,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
 <SettingsOption
   className="scoringCard"
   extraSections={Array []}
+  hasExpandableTextArea={false}
   summary="{weight, plural, =0 {Ungraded} other {# points}} · Unlimited attempts"
   title="Scoring"
 >
@@ -122,6 +124,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
 <SettingsOption
   className="scoringCard"
   extraSections={Array []}
+  hasExpandableTextArea={false}
   summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
   title="Scoring"
 >

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
@@ -34,10 +34,10 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
   </Form.Group>
   <Form.Group>
     <Form.Control
+      disabled={false}
       floatingLabel="Attempts"
       onBlur={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
       onChange={[MockFunction scoringCardHooks.handleOnChange]}
-      value={5}
     />
     <Form.Control.Feedback>
       <FormattedMessage
@@ -46,6 +46,20 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
         id="authoring.problemeditor.settings.scoring.attempts.hint"
       />
     </Form.Control.Feedback>
+    <Form.Checkbox
+      checked={false}
+      className="mt-3 decoration-control-label"
+    >
+      <div
+        className="small"
+      >
+        <FormattedMessage
+          defaultMessage="Unlimited attempts"
+          description="Label for unlimited attempts checkbox"
+          id="authoring.problemeditor.settings.scoring.attempts.unlimitedCheckbox"
+        />
+      </div>
+    </Form.Checkbox>
   </Form.Group>
   <Hyperlink
     destination="undefined/settings/advanced/undefined#max_attempts"
@@ -94,10 +108,10 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
   </Form.Group>
   <Form.Group>
     <Form.Control
+      disabled={true}
       floatingLabel="Attempts"
       onBlur={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
       onChange={[MockFunction scoringCardHooks.handleOnChange]}
-      value={5}
     />
     <Form.Control.Feedback>
       <FormattedMessage
@@ -106,6 +120,20 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
         id="authoring.problemeditor.settings.scoring.attempts.hint"
       />
     </Form.Control.Feedback>
+    <Form.Checkbox
+      checked={true}
+      className="mt-3 decoration-control-label"
+    >
+      <div
+        className="small"
+      >
+        <FormattedMessage
+          defaultMessage="Unlimited attempts"
+          description="Label for unlimited attempts checkbox"
+          id="authoring.problemeditor.settings.scoring.attempts.unlimitedCheckbox"
+        />
+      </div>
+    </Form.Checkbox>
   </Form.Group>
   <Hyperlink
     destination="undefined/settings/advanced/undefined#max_attempts"
@@ -154,10 +182,10 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
   </Form.Group>
   <Form.Group>
     <Form.Control
+      disabled={false}
       floatingLabel="Attempts"
       onBlur={[MockFunction scoringCardHooks.handleMaxAttemptChange]}
       onChange={[MockFunction scoringCardHooks.handleOnChange]}
-      value={5}
     />
     <Form.Control.Feedback>
       <FormattedMessage
@@ -166,6 +194,20 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
         id="authoring.problemeditor.settings.scoring.attempts.hint"
       />
     </Form.Control.Feedback>
+    <Form.Checkbox
+      checked={false}
+      className="mt-3 decoration-control-label"
+    >
+      <div
+        className="small"
+      >
+        <FormattedMessage
+          defaultMessage="Unlimited attempts"
+          description="Label for unlimited attempts checkbox"
+          id="authoring.problemeditor.settings.scoring.attempts.unlimitedCheckbox"
+        />
+      </div>
+    </Form.Checkbox>
   </Form.Group>
   <Hyperlink
     destination="undefined/settings/advanced/undefined#max_attempts"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
@@ -48,7 +48,7 @@ exports[`ShowAnswerCard snapshot snapshot: show answer setting card 1`] = `
     className="pb-4"
   >
     <Hyperlink
-      destination="SoMEeNDpOinT/settings/advanced/sOMEcouRseId"
+      destination="SoMEeNDpOinT/settings/advanced/sOMEcouRseId#showanswer"
       target="_blank"
     >
       <FormattedMessage

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ShowAnswerCard.test.jsx.snap
@@ -94,7 +94,7 @@ exports[`ShowAnswerCard snapshot snapshot: show answer setting card 1`] = `
         key="finished"
         value="finished"
       >
-        Finished
+        Finished (Default)
       </option>
       <option
         key="correct_or_past_due"

--- a/src/editors/containers/ProblemEditor/index.jsx
+++ b/src/editors/containers/ProblemEditor/index.jsx
@@ -19,6 +19,7 @@ export const ProblemEditor = ({
   blockValue,
   initializeProblemEditor,
   assetsFinished,
+  advanceSettingsFinished,
 }) => {
   React.useEffect(() => {
     if (blockFinished && studioViewFinished && assetsFinished && !blockFailed) {
@@ -26,7 +27,7 @@ export const ProblemEditor = ({
     }
   }, [blockFinished, studioViewFinished, assetsFinished, blockFailed]);
 
-  if (!blockFinished || !studioViewFinished || !assetsFinished) {
+  if (!blockFinished || !studioViewFinished || !assetsFinished || !advanceSettingsFinished) {
     return (
       <div className="text-center p-6">
         <Spinner
@@ -59,6 +60,7 @@ ProblemEditor.propTypes = {
   onClose: PropTypes.func.isRequired,
   // redux
   assetsFinished: PropTypes.bool,
+  advanceSettingsFinished: PropTypes.bool.isRequired,
   blockFinished: PropTypes.bool.isRequired,
   blockFailed: PropTypes.bool.isRequired,
   studioViewFinished: PropTypes.bool.isRequired,
@@ -74,6 +76,7 @@ export const mapStateToProps = (state) => ({
   problemType: selectors.problem.problemType(state),
   blockValue: selectors.app.blockValue(state),
   assetsFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAssets }),
+  advanceSettingsFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAdvanceSettings }),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/ProblemEditor/index.jsx
+++ b/src/editors/containers/ProblemEditor/index.jsx
@@ -19,7 +19,7 @@ export const ProblemEditor = ({
   blockValue,
   initializeProblemEditor,
   assetsFinished,
-  advanceSettingsFinished,
+  advancedSettingsFinished,
 }) => {
   React.useEffect(() => {
     if (blockFinished && studioViewFinished && assetsFinished && !blockFailed) {
@@ -27,7 +27,7 @@ export const ProblemEditor = ({
     }
   }, [blockFinished, studioViewFinished, assetsFinished, blockFailed]);
 
-  if (!blockFinished || !studioViewFinished || !assetsFinished || !advanceSettingsFinished) {
+  if (!blockFinished || !studioViewFinished || !assetsFinished || !advancedSettingsFinished) {
     return (
       <div className="text-center p-6">
         <Spinner
@@ -60,7 +60,7 @@ ProblemEditor.propTypes = {
   onClose: PropTypes.func.isRequired,
   // redux
   assetsFinished: PropTypes.bool,
-  advanceSettingsFinished: PropTypes.bool.isRequired,
+  advancedSettingsFinished: PropTypes.bool.isRequired,
   blockFinished: PropTypes.bool.isRequired,
   blockFailed: PropTypes.bool.isRequired,
   studioViewFinished: PropTypes.bool.isRequired,
@@ -76,7 +76,7 @@ export const mapStateToProps = (state) => ({
   problemType: selectors.problem.problemType(state),
   blockValue: selectors.app.blockValue(state),
   assetsFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAssets }),
-  advanceSettingsFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAdvanceSettings }),
+  advancedSettingsFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchAdvancedSettings }),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/ProblemEditor/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/index.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
+import { Spinner } from '@edx/paragon';
 import { thunkActions, selectors } from '../../data/redux';
 import { RequestKeys } from '../../data/constants/requests';
 import { ProblemEditor, mapStateToProps, mapDispatchToProps } from '.';
@@ -48,53 +48,59 @@ describe('ProblemEditor', () => {
     studioViewFinished: false,
     initializeProblemEditor: jest.fn().mockName('args.intializeProblemEditor'),
     assetsFinished: false,
-    advanceSettingsFinished: false,
+    advancedSettingsFinished: false,
   };
   describe('snapshots', () => {
     test('renders as expected with default behavior', () => {
       expect(shallow(<ProblemEditor {...props} />)).toMatchSnapshot();
     });
     test('block loaded, studio view and assets not yet loaded, Spinner appears', () => {
-      expect(shallow(<ProblemEditor {...props} blockFinished />)).toMatchSnapshot();
+      const wrapper = shallow(<ProblemEditor {...props} blockFinished />);
+      expect(wrapper.containsMatchingElement(<Spinner />)).toEqual(true);
     });
     test('studio view loaded, block and assets not yet loaded, Spinner appears', () => {
-      expect(shallow(<ProblemEditor {...props} studioViewFinished />)).toMatchSnapshot();
+      const wrapper = shallow(<ProblemEditor {...props} studioViewFinished />);
+      expect(wrapper.containsMatchingElement(<Spinner />)).toEqual(true);
     });
     test('assets loaded, block and studio view not yet loaded, Spinner appears', () => {
-      expect(shallow(<ProblemEditor {...props} assetsFinished />)).toMatchSnapshot();
+      const wrapper = shallow(<ProblemEditor {...props} assetsFinished />);
+      expect(wrapper.containsMatchingElement(<Spinner />)).toEqual(true);
     });
     test('advanceSettings loaded, block and studio view not yet loaded, Spinner appears', () => {
-      expect(shallow(<ProblemEditor {...props} advanceSettingsFinished />)).toMatchSnapshot();
+      const wrapper = shallow(<ProblemEditor {...props} advancedSettingsFinished />);
+      expect(wrapper.containsMatchingElement(<Spinner />)).toEqual(true);
     });
     test('block failed, message appears', () => {
-      expect(shallow(<ProblemEditor
+      const wrapper = shallow(<ProblemEditor
         {...props}
         blockFinished
         studioViewFinished
         assetsFinished
-        advanceSettingsFinished
+        advancedSettingsFinished
         blockFailed
-      />)).toMatchSnapshot();
+      />);
+      expect(wrapper).toMatchSnapshot();
     });
     test('renders SelectTypeModal', () => {
-      expect(shallow(<ProblemEditor
+      const wrapper = shallow(<ProblemEditor
         {...props}
         blockFinished
         studioViewFinished
         assetsFinished
-        advanceSettingsFinished
-      />)).toMatchSnapshot();
+        advancedSettingsFinished
+      />);
+      expect(wrapper.find('SelectTypeModal')).toHaveLength(1);
     });
     test('renders EditProblemView', () => {
-      expect(shallow(<ProblemEditor
+      const wrapper = shallow(<ProblemEditor
         {...props}
         problemType="multiplechoiceresponse"
         blockFinished
-        blockFailed
         studioViewFinished
         assetsFinished
-        advanceSettingsFinished
-      />)).toMatchSnapshot();
+        advancedSettingsFinished
+      />);
+      expect(wrapper.find('EditProblemView')).toHaveLength(1);
     });
   });
 
@@ -125,10 +131,10 @@ describe('ProblemEditor', () => {
         mapStateToProps(testState).assetsFinished,
       ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAssets }));
     });
-    test('advanceSettingsFinished from requests.isFinished', () => {
+    test('advancedSettingsFinished from requests.isFinished', () => {
       expect(
-        mapStateToProps(testState).advanceSettingsFinished,
-      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAdvanceSettings }));
+        mapStateToProps(testState).advancedSettingsFinished,
+      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAdvancedSettings }));
     });
   });
   describe('mapDispatchToProps', () => {

--- a/src/editors/containers/ProblemEditor/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/index.test.jsx
@@ -48,6 +48,7 @@ describe('ProblemEditor', () => {
     studioViewFinished: false,
     initializeProblemEditor: jest.fn().mockName('args.intializeProblemEditor'),
     assetsFinished: false,
+    advanceSettingsFinished: false,
   };
   describe('snapshots', () => {
     test('renders as expected with default behavior', () => {
@@ -62,17 +63,27 @@ describe('ProblemEditor', () => {
     test('assets loaded, block and studio view not yet loaded, Spinner appears', () => {
       expect(shallow(<ProblemEditor {...props} assetsFinished />)).toMatchSnapshot();
     });
+    test('advanceSettings loaded, block and studio view not yet loaded, Spinner appears', () => {
+      expect(shallow(<ProblemEditor {...props} advanceSettingsFinished />)).toMatchSnapshot();
+    });
     test('block failed, message appears', () => {
       expect(shallow(<ProblemEditor
         {...props}
         blockFinished
         studioViewFinished
         assetsFinished
+        advanceSettingsFinished
         blockFailed
       />)).toMatchSnapshot();
     });
     test('renders SelectTypeModal', () => {
-      expect(shallow(<ProblemEditor {...props} blockFinished studioViewFinished assetsFinished />)).toMatchSnapshot();
+      expect(shallow(<ProblemEditor
+        {...props}
+        blockFinished
+        studioViewFinished
+        assetsFinished
+        advanceSettingsFinished
+      />)).toMatchSnapshot();
     });
     test('renders EditProblemView', () => {
       expect(shallow(<ProblemEditor
@@ -82,6 +93,7 @@ describe('ProblemEditor', () => {
         blockFailed
         studioViewFinished
         assetsFinished
+        advanceSettingsFinished
       />)).toMatchSnapshot();
     });
   });
@@ -112,6 +124,11 @@ describe('ProblemEditor', () => {
       expect(
         mapStateToProps(testState).assetsFinished,
       ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAssets }));
+    });
+    test('advanceSettingsFinished from requests.isFinished', () => {
+      expect(
+        mapStateToProps(testState).advanceSettingsFinished,
+      ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchAdvanceSettings }));
     });
   });
   describe('mapDispatchToProps', () => {

--- a/src/editors/data/constants/requests.js
+++ b/src/editors/data/constants/requests.js
@@ -25,6 +25,6 @@ export const RequestKeys = StrictDict({
   checkTranscriptsForImport: 'checkTranscriptsForImport',
   importTranscript: 'importTranscript',
   uploadImage: 'uploadImage',
-  fetchAdvanceSettings: 'fetchAdvanceSettings',
+  fetchAdvancedSettings: 'fetchAdvancedSettings',
   fetchVideoFeatures: 'fetchVideoFeatures',
 });

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -14,6 +14,7 @@ const initialState = {
   groupFeedbackList: [],
   generalFeedback: '',
   additionalAttributes: {},
+  defaultSettings: {},
   settings: {
     randomization: null,
     scoring: {
@@ -142,10 +143,23 @@ const problem = createSlice({
       },
       ...payload,
     }),
-    setEnableTypeSelection: (state) => ({
-      ...state,
-      problemType: null,
-    }),
+    setEnableTypeSelection: (state, { payload }) => {
+      const { maxAttempts, showanswer, showResetButton } = payload;
+      const attempts = { number: maxAttempts, unlimited: false };
+      if (!maxAttempts) {
+        attempts.unlimited = true;
+      }
+      return {
+        ...state,
+        settings: {
+          ...state.settings,
+          scoring: { ...state.settings.scoring, attempts },
+          showAnswer: { ...state.settings.showAnswer, on: showanswer },
+          ...showResetButton,
+        },
+        problemType: null,
+      };
+    },
   },
 });
 

--- a/src/editors/data/redux/problem/reducers.test.js
+++ b/src/editors/data/redux/problem/reducers.test.js
@@ -29,8 +29,22 @@ describe('problem reducer', () => {
     ].map(args => setterTest(...args));
     describe('setEnableTypeSelection', () => {
       it('sets given problemType to null', () => {
-        expect(reducer(testingState, actions.setEnableTypeSelection())).toEqual({
+        const payload = {
+          maxAttempts: 1,
+          showanswer: 'finished',
+          showResetButton: false,
+        };
+        expect(reducer(testingState, actions.setEnableTypeSelection(payload))).toEqual({
           ...testingState,
+          settings: {
+            ...testingState.settings,
+            scoring: {
+              ...testingState.settings.scoring,
+              attempts: { number: 1, unlimited: false },
+            },
+            showAnswer: { ...testingState.settings.showAnswer, on: payload.showanswer },
+            ...payload.showResetButton,
+          },
           problemType: null,
         });
       });

--- a/src/editors/data/redux/problem/selectors.js
+++ b/src/editors/data/redux/problem/selectors.js
@@ -11,6 +11,7 @@ export const simpleSelectors = {
   correctAnswerCount: mkSimpleSelector(problemData => problemData.correctAnswerCount),
   settings: mkSimpleSelector(problemData => problemData.settings),
   question: mkSimpleSelector(problemData => problemData.question),
+  defaultSettings: mkSimpleSelector(problemData => problemData.defaultSettings),
   completeState: mkSimpleSelector(problemData => problemData),
 };
 

--- a/src/editors/data/redux/problem/selectors.test.js
+++ b/src/editors/data/redux/problem/selectors.test.js
@@ -35,6 +35,7 @@ describe('problem selectors unit tests', () => {
         simpleKeys.correctAnswerCount,
         simpleKeys.settings,
         simpleKeys.question,
+        simpleKeys.defaultSettings,
       ].map(testSimpleSelector);
     });
     test('simple selector completeState equals the entire state', () => {

--- a/src/editors/data/redux/requests/reducer.js
+++ b/src/editors/data/redux/requests/reducer.js
@@ -19,6 +19,7 @@ const initialState = {
   [RequestKeys.checkTranscriptsForImport]: { status: RequestStates.inactive },
   [RequestKeys.importTranscript]: { status: RequestStates.inactive },
   [RequestKeys.fetchVideoFeatures]: { status: RequestStates.inactive },
+  [RequestKeys.fetchAdvanceSettings]: { status: RequestStates.inactive },
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/src/editors/data/redux/requests/reducer.js
+++ b/src/editors/data/redux/requests/reducer.js
@@ -19,7 +19,7 @@ const initialState = {
   [RequestKeys.checkTranscriptsForImport]: { status: RequestStates.inactive },
   [RequestKeys.importTranscript]: { status: RequestStates.inactive },
   [RequestKeys.fetchVideoFeatures]: { status: RequestStates.inactive },
-  [RequestKeys.fetchAdvanceSettings]: { status: RequestStates.inactive },
+  [RequestKeys.fetchAdvancedSettings]: { status: RequestStates.inactive },
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -53,9 +53,9 @@ export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispat
   }
 };
 
-export const fetchAdvanceSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
+export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
   const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button'];
-  dispatch(requests.fetchAdvanceSettings({
+  dispatch(requests.fetchAdvancedSettings({
     onSuccess: (response) => {
       const defaultSettings = {};
       Object.entries(response.data).forEach(([key, value]) => {
@@ -73,7 +73,7 @@ export const fetchAdvanceSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
 export const initializeProblem = (blockValue) => (dispatch) => {
   const rawOLX = _.get(blockValue, 'data.data', {});
   const rawSettings = _.get(blockValue, 'data.metadata', {});
-  dispatch(fetchAdvanceSettings({ rawOLX, rawSettings }));
+  dispatch(fetchAdvancedSettings({ rawOLX, rawSettings }));
 };
 
-export default { initializeProblem, switchToAdvancedEditor, fetchAdvanceSettings };
+export default { initializeProblem, switchToAdvancedEditor, fetchAdvancedSettings };

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -7,7 +7,6 @@ import { ProblemTypeKeys } from '../../constants/problem';
 import ReactStateOLXParser from '../../../containers/ProblemEditor/data/ReactStateOLXParser';
 import { blankProblemOLX } from '../../../containers/ProblemEditor/data/mockData/olxTestData';
 import { camelizeKeys } from '../../../utils';
-import * as module from './problem';
 import { fetchEditorContent } from '../../../containers/ProblemEditor/components/EditProblemView/hooks';
 
 export const switchToAdvancedEditor = () => (dispatch, getState) => {
@@ -47,15 +46,15 @@ export const getDataFromOlx = ({ rawOLX, rawSettings }) => {
 };
 
 export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispatch) => {
-  if (module.isBlankProblem({ rawOLX })) {
+  if (isBlankProblem({ rawOLX })) {
     dispatch(actions.problem.setEnableTypeSelection(camelizeKeys(defaultSettings)));
   } else {
-    dispatch(actions.problem.load(module.getDataFromOlx({ rawOLX, rawSettings })));
+    dispatch(actions.problem.load(getDataFromOlx({ rawOLX, rawSettings })));
   }
 };
 
 export const fetchAdvanceSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
-  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', ' matlab_api_key'];
+  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button'];
   dispatch(requests.fetchAdvanceSettings({
     onSuccess: (response) => {
       const defaultSettings = {};
@@ -65,16 +64,16 @@ export const fetchAdvanceSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
         }
       });
       dispatch(actions.problem.updateField({ defaultSettings: camelizeKeys(defaultSettings) }));
-      module.loadProblem({ rawOLX, rawSettings, defaultSettings })(dispatch);
+      loadProblem({ rawOLX, rawSettings, defaultSettings })(dispatch);
     },
-    onFailure: () => { module.loadProblem({ rawOLX, rawSettings, defaultSettings: {} })(dispatch); },
+    onFailure: () => { loadProblem({ rawOLX, rawSettings, defaultSettings: {} })(dispatch); },
   }));
 };
 
 export const initializeProblem = (blockValue) => (dispatch) => {
   const rawOLX = _.get(blockValue, 'data.data', {});
   const rawSettings = _.get(blockValue, 'data.metadata', {});
-  dispatch(module.fetchAdvanceSettings({ rawOLX, rawSettings }));
+  dispatch(fetchAdvanceSettings({ rawOLX, rawSettings }));
 };
 
 export default { initializeProblem, switchToAdvancedEditor, fetchAdvanceSettings };

--- a/src/editors/data/redux/thunkActions/problem.test.js
+++ b/src/editors/data/redux/thunkActions/problem.test.js
@@ -18,7 +18,7 @@ jest.mock('..', () => ({
 }));
 
 jest.mock('./requests', () => ({
-  fetchAdvanceSettings: (args) => ({ fetchAdvanceSettings: args }),
+  fetchAdvancedSettings: (args) => ({ fetchAdvanceSettings: args }),
 }));
 
 const blockValue = {
@@ -59,20 +59,20 @@ describe('problem thunkActions', () => {
   });
   describe('fetchAdvanceSettings', () => {
     it('dispatches fetchAdvanceSettings action', () => {
-      module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
+      module.fetchAdvancedSettings({ rawOLX, rawSettings })(dispatch);
       [[dispatchedAction]] = dispatch.mock.calls;
       expect(dispatchedAction.fetchAdvanceSettings).not.toEqual(undefined);
     });
     it('dispatches actions.problem.updateField and loadProblem on success', () => {
       dispatch.mockClear();
-      module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
+      module.fetchAdvancedSettings({ rawOLX, rawSettings })(dispatch);
       [[dispatchedAction]] = dispatch.mock.calls;
       dispatchedAction.fetchAdvanceSettings.onSuccess({ data: { key: 'test', max_attempts: 1 } });
       expect(dispatch).toHaveBeenCalledWith(actions.problem.load());
     });
     it('calls loadProblem on failure', () => {
       dispatch.mockClear();
-      module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
+      module.fetchAdvancedSettings({ rawOLX, rawSettings })(dispatch);
       [[dispatchedAction]] = dispatch.mock.calls;
       dispatchedAction.fetchAdvanceSettings.onFailure();
       expect(dispatch).toHaveBeenCalledWith(actions.problem.load());

--- a/src/editors/data/redux/thunkActions/problem.test.js
+++ b/src/editors/data/redux/thunkActions/problem.test.js
@@ -1,7 +1,8 @@
 import { actions } from '..';
-import { initializeProblem, switchToAdvancedEditor } from './problem';
+import * as module from './problem';
 import { checkboxesOLXWithFeedbackAndHintsOLX, advancedProblemOlX, blankProblemOLX } from '../../../containers/ProblemEditor/data/mockData/olxTestData';
 import { ProblemTypeKeys } from '../../constants/problem';
+import { keyStore } from '../../../utils';
 
 const mockOlx = 'SOmEVALue';
 const mockBuildOlx = jest.fn(() => mockOlx);
@@ -17,9 +18,27 @@ jest.mock('..', () => ({
   },
 }));
 
+jest.mock('./requests', () => ({
+  fetchAdvanceSettings: (args) => ({ fetchAdvanceSettings: args }),
+}));
+
+const moduleKeys = keyStore(module);
+
+const blockValue = {
+  data: {
+    data: checkboxesOLXWithFeedbackAndHintsOLX.rawOLX,
+    metadata: {},
+  },
+};
+
+let rawOLX = blockValue.data.data;
+const rawSettings = {};
+const defaultSettings = { max_attempts: 1 };
+
 describe('problem thunkActions', () => {
   let dispatch;
   let getState;
+  let dispatchedAction;
   beforeEach(() => {
     dispatch = jest.fn((action) => ({ dispatch: action }));
     getState = jest.fn(() => ({
@@ -27,25 +46,56 @@ describe('problem thunkActions', () => {
       },
     }));
   });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   test('initializeProblem visual Problem :', () => {
-    const blockValue = { data: { data: checkboxesOLXWithFeedbackAndHintsOLX.rawOLX } };
-    initializeProblem(blockValue)(dispatch);
-    expect(dispatch).toHaveBeenCalledWith(actions.problem.load());
-  });
-  test('initializeProblem advanced Problem', () => {
-    const blockValue = { data: { data: advancedProblemOlX.rawOLX } };
-    initializeProblem(blockValue)(dispatch);
-    expect(dispatch).toHaveBeenCalledWith(actions.problem.load());
-  });
-  test('initializeProblem blank Problem', () => {
-    const blockValue = { data: { data: blankProblemOLX.rawOLX } };
-    initializeProblem(blockValue)(dispatch);
-    expect(dispatch).toHaveBeenCalledWith(actions.problem.setEnableTypeSelection());
+    jest.spyOn(module, moduleKeys.fetchAdvanceSettings)
+      .mockImplementation(jest.fn());
+    module.initializeProblem(blockValue)(dispatch);
+    expect(dispatch).toHaveBeenCalledWith(module.fetchAdvanceSettings({
+      rawOLX,
+      rawSettings,
+    }));
   });
   test('switchToAdvancedEditor visual Problem', () => {
-    switchToAdvancedEditor()(dispatch, getState);
+    module.switchToAdvancedEditor()(dispatch, getState);
     expect(dispatch).toHaveBeenCalledWith(
       actions.problem.updateField({ problemType: ProblemTypeKeys.ADVANCED, rawOlx: mockOlx }),
     );
+  });
+  describe('fetchAdvanceSettings', () => {
+    it('dispatches fetchAdvanceSettings action', () => {
+      module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
+      [[dispatchedAction]] = dispatch.mock.calls;
+      expect(dispatchedAction.fetchAdvanceSettings).not.toEqual(undefined);
+    });
+    it('dispatches actions.problem.updateField and loadProblem on success', () => {
+      dispatch.mockClear();
+      const loadProblem = jest.spyOn(module, moduleKeys.loadProblem);
+      module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
+      [[dispatchedAction]] = dispatch.mock.calls;
+      dispatchedAction.fetchAdvanceSettings.onSuccess({ data: { key: 'test', max_attempts: 1 } });
+      expect(loadProblem).toHaveBeenCalled();
+    });
+    it('calls loadProblem on failure', () => {
+      const loadProblem = jest.spyOn(module, moduleKeys.loadProblem);
+      module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
+      dispatchedAction.fetchAdvanceSettings.onFailure();
+      expect(loadProblem).toHaveBeenCalled();
+    });
+  });
+  describe('loadProblem', () => {
+    test('initializeProblem advanced Problem', () => {
+      rawOLX = advancedProblemOlX.rawOLX;
+      module.loadProblem({ rawOLX, rawSettings, defaultSettings })(dispatch);
+      expect(dispatch).toHaveBeenCalledWith(actions.problem.load());
+    });
+    test('initializeProblem blank Problem', () => {
+      rawOLX = blankProblemOLX.rawOLX;
+      module.loadProblem({ rawOLX, rawSettings, defaultSettings })(dispatch);
+      expect(dispatch).toHaveBeenCalledWith(actions.problem.setEnableTypeSelection());
+    });
   });
 });

--- a/src/editors/data/redux/thunkActions/problem.test.js
+++ b/src/editors/data/redux/thunkActions/problem.test.js
@@ -2,7 +2,6 @@ import { actions } from '..';
 import * as module from './problem';
 import { checkboxesOLXWithFeedbackAndHintsOLX, advancedProblemOlX, blankProblemOLX } from '../../../containers/ProblemEditor/data/mockData/olxTestData';
 import { ProblemTypeKeys } from '../../constants/problem';
-import { keyStore } from '../../../utils';
 
 const mockOlx = 'SOmEVALue';
 const mockBuildOlx = jest.fn(() => mockOlx);
@@ -21,8 +20,6 @@ jest.mock('..', () => ({
 jest.mock('./requests', () => ({
   fetchAdvanceSettings: (args) => ({ fetchAdvanceSettings: args }),
 }));
-
-const moduleKeys = keyStore(module);
 
 const blockValue = {
   data: {
@@ -51,13 +48,8 @@ describe('problem thunkActions', () => {
     jest.restoreAllMocks();
   });
   test('initializeProblem visual Problem :', () => {
-    jest.spyOn(module, moduleKeys.fetchAdvanceSettings)
-      .mockImplementation(jest.fn());
     module.initializeProblem(blockValue)(dispatch);
-    expect(dispatch).toHaveBeenCalledWith(module.fetchAdvanceSettings({
-      rawOLX,
-      rawSettings,
-    }));
+    expect(dispatch).toHaveBeenCalled();
   });
   test('switchToAdvancedEditor visual Problem', () => {
     module.switchToAdvancedEditor()(dispatch, getState);
@@ -73,17 +65,17 @@ describe('problem thunkActions', () => {
     });
     it('dispatches actions.problem.updateField and loadProblem on success', () => {
       dispatch.mockClear();
-      const loadProblem = jest.spyOn(module, moduleKeys.loadProblem);
       module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
       [[dispatchedAction]] = dispatch.mock.calls;
       dispatchedAction.fetchAdvanceSettings.onSuccess({ data: { key: 'test', max_attempts: 1 } });
-      expect(loadProblem).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(actions.problem.load());
     });
     it('calls loadProblem on failure', () => {
-      const loadProblem = jest.spyOn(module, moduleKeys.loadProblem);
+      dispatch.mockClear();
       module.fetchAdvanceSettings({ rawOLX, rawSettings })(dispatch);
+      [[dispatchedAction]] = dispatch.mock.calls;
       dispatchedAction.fetchAdvanceSettings.onFailure();
-      expect(loadProblem).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(actions.problem.load());
     });
   });
   describe('loadProblem', () => {

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -261,10 +261,10 @@ export const fetchCourseDetails = ({ ...rest }) => (dispatch, getState) => {
   }));
 };
 
-export const fetchAdvanceSettings = ({ ...rest }) => (dispatch, getState) => {
+export const fetchAdvancedSettings = ({ ...rest }) => (dispatch, getState) => {
   dispatch(module.networkRequest({
-    requestKey: RequestKeys.fetchAdvanceSettings,
-    promise: api.fetchAdvanceSettings({
+    requestKey: RequestKeys.fetchAdvancedSettings,
+    promise: api.fetchAdvancedSettings({
       studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
       learningContextId: selectors.app.learningContextId(getState()),
     }),
@@ -299,6 +299,6 @@ export default StrictDict({
   getTranscriptFile,
   checkTranscriptsForImport,
   importTranscript,
-  fetchAdvanceSettings,
+  fetchAdvancedSettings,
   fetchVideoFeatures,
 });

--- a/src/editors/data/services/cms/api.js
+++ b/src/editors/data/services/cms/api.js
@@ -21,7 +21,7 @@ export const apiMethods = {
   fetchCourseDetails: ({ studioEndpointUrl, learningContextId }) => get(
     urls.courseDetailsUrl({ studioEndpointUrl, learningContextId }),
   ),
-  fetchAdvanceSettings: ({ studioEndpointUrl, learningContextId }) => get(
+  fetchAdvancedSettings: ({ studioEndpointUrl, learningContextId }) => get(
     urls.courseAdvanceSettings({ studioEndpointUrl, learningContextId }),
   ),
   uploadAsset: ({

--- a/src/editors/data/services/cms/types.js
+++ b/src/editors/data/services/cms/types.js
@@ -61,6 +61,11 @@ export const problemDataProps = {
       afterAtempts: PropTypes.number,
     }),
     showResetButton: PropTypes.bool,
+    defaultSettings: PropTypes.shape({
+      max_attempts: PropTypes.number,
+      showanswer: PropTypes.string,
+      show_reset_button: PropTypes.bool,
+    }),
   }),
 };
 


### PR DESCRIPTION
JIRA Ticket: [TNL-10429](https://2u-internal.atlassian.net/browse/TNL-10429)

This PR adds "(Default)" to the attempt field and show answer field when the user selects/enters the default value defined in the courses advanced settings. Additionally this PR sets the attempt field, show answer field, and show reset button value to the course's default value when creating a new problem.