### PR TITLE
feat: error on funky multiple choice tags.

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -72,6 +72,10 @@ export class OLXParser {
     const answers = [];
     let data = {};
     const widget = _.get(this.problem, `${problemType}.${widgetName}`);
+    const permissableTags = ['choice', '@_type', 'compoundhint', 'option', '#text'];
+    if (_.keys(widget).some((tag) => !permissableTags.includes(tag))) {
+      throw new Error('Misc Tags, reverting to Advanced Editor');
+    }
     const choice = _.get(widget, option);
     const isComplexAnswer = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT].includes(problemType);
     if (_.isEmpty(choice)) {

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -123,6 +123,7 @@ describe('Check OLXParser for answer parsing', () => {
     try {
       olxparser.parseMultipleChoiceAnswers('choiceresponse', 'checkboxgroup', 'choice');
     } catch (e) {
+      expect(e).toBeInstanceOf(Error);
       expect(e.message).toBe('Misc Tags, reverting to Advanced Editor');
     }
   });

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -15,6 +15,7 @@ import {
   blankProblemOLX,
   blankQuestionOLX,
   styledQuestionOLX,
+  shuffleProblemOLX,
 } from './mockData/olxTestData';
 import { ProblemTypeKeys } from '../../../data/constants/problem';
 
@@ -110,6 +111,22 @@ describe('Check OLXParser for answer parsing', () => {
     const answer = olxparser.parseMultipleChoiceAnswers('choiceresponse', 'checkboxgroup', 'choice');
     expect(answer).toEqual(checkboxesOLXWithFeedbackAndHintsOLX.data);
   });
+
+  test('Test checkbox answer', () => {
+    const olxparser = new OLXParser(checkboxesOLXWithFeedbackAndHintsOLX.rawOLX);
+    const answer = olxparser.parseMultipleChoiceAnswers('choiceresponse', 'checkboxgroup', 'choice');
+    expect(answer).toEqual(checkboxesOLXWithFeedbackAndHintsOLX.data);
+  });
+
+  test('Test checkboxs with extraneous tags error out', () => {
+    const olxparser = new OLXParser(shuffleProblemOLX.rawOLX);
+    try {
+      olxparser.parseMultipleChoiceAnswers('choiceresponse', 'checkboxgroup', 'choice');
+    } catch (e) {
+      expect(e.message).toBe('Misc Tags, reverting to Advanced Editor');
+    }
+  });
+
   test('Test dropdown answer', () => {
     const olxparser = new OLXParser(dropdownOLXWithFeedbackAndHintsOLX.rawOLX);
     const answer = olxparser.parseMultipleChoiceAnswers('optionresponse', 'optioninput', 'option');

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -607,3 +607,17 @@ export const styledQuestionOLX = {
 </problem>`,
   question: '<p><strong><span style="background-color: #e03e2d;">test</span></strong></p>',
 };
+
+export const shuffleProblemOLX = {
+  rawOLX: `<problem>
+  <multiplechoiceresponse>
+    <label>What Apple device competed with the portable CD player?</label>
+    <choicegroup type="MultipleChoice" shuffle="true">
+      <choice correct="false">The iPad</choice>
+      <choice correct="false">Napster</choice>
+      <choice correct="true">The iPod</choice>
+      <choice correct="false">The vegetable peeler</choice>
+    </choicegroup>
+  </multiplechoiceresponse>
+</problem>`,
+};


### PR DESCRIPTION
This change increases the frequency at which odd tags (like shuffle) on multiple choice problems don't go to the visual editor.
Instead, they will now divert to the advanced editor. There might be other places where we need to follow a similar pattern, but we don't know those yet.

Testing instructions:
- Follow the process of creating a shuffle problem in advanced editor using this olx: (edit this Q to get the xml)

```
<problem>
  <multiplechoiceresponse>
    <label>What Apple device competed with the portable CD player?</label>
    <choicegroup type="MultipleChoice" shuffle="true">
      <choice correct="false">The iPad</choice>
      <choice correct="false">Napster</choice>
      <choice correct="true">The iPod</choice>
      <choice correct="false">The vegetable peeler</choice>
    </choicegroup>
  </multiplechoiceresponse>
</problem>

```

It should save, and open again in the advanced editor.

In addition, all the other, normal, uses of problems should still work.
