### PR TITLE
fix: let `make extract_translations` find messages

### DIFF
--- a/src/editors/containers/EditorContainer/components/EditorFooter/messages.js
+++ b/src/editors/containers/EditorContainer/components/EditorFooter/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   contentSaveFailed: {
     id: 'authoring.editorfooter.save.error',
     defaultMessage: 'Error: Content save failed. Try again later.',
@@ -24,6 +27,6 @@ export const messages = {
     defaultMessage: 'Save',
     description: 'Label for Save button',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/EditorContainer/components/TitleHeader/messages.js
+++ b/src/editors/containers/EditorContainer/components/TitleHeader/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   loading: {
     id: 'authoring.texteditor.title.loading',
     defaultMessage: 'Loading...',
@@ -24,6 +27,6 @@ export const messages = {
     defaultMessage: 'Save',
     description: 'Screen reader label title for icon button to edit the xblock title',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/EditorContainer/messages.js
+++ b/src/editors/containers/EditorContainer/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   cancelConfirmTitle: {
     id: 'authoring.editorContainer.cancelConfirm.title',
     defaultMessage: 'Exit the editor?',
@@ -14,6 +17,6 @@ export const messages = {
     defaultMessage: 'OK',
     description: 'Label for OK button',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswersContainer.test.jsx
@@ -11,8 +11,10 @@ import { AnswersContainer as AnswersContainerWithoutHOC } from './AnswersContain
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
   FormattedMessage: ({ defaultMessage }) => (<p>{defaultMessage}</p>),
+  defineMessages: m => m,
   injectIntl: (args) => args,
   intlShape: {},
+  getLocale: jest.fn(),
 }));
 
 jest.mock('./AnswerOption', () => () => <div>MockAnswerOption</div>);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/FeedbackBox.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/FeedbackBox.jsx
@@ -4,7 +4,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import { answerOptionProps } from '../../../../../../../data/services/cms/types';
 import FeedbackControl from './FeedbackControl';
-import { messages } from './messages';
+import messages from './messages';
 import { ProblemTypeKeys } from '../../../../../../../data/constants/problem';
 
 export const FeedbackBox = ({

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/components/Feedback/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   feedbackPlaceholder: {
     id: 'authoring.answerwidget.feedback.placeholder',
     defaultMessage: 'Feedback message',
@@ -29,6 +32,6 @@ export const messages = {
     defaultMessage: 'is not selected',
     description: 'Bold & underlined text for feedback if option is not selected',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
@@ -9,11 +9,14 @@ import * as module from './hooks';
 jest.mock('react', () => {
   const updateState = jest.fn();
   return {
-    updateState,
     useEffect: jest.fn(),
     useState: jest.fn(val => ([{ state: val }, (newVal) => updateState({ val, newVal })])),
   };
 });
+
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  defineMessages: m => m,
+}));
 
 jest.mock('../../../../../data/redux', () => ({
   actions: {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/messages.js
@@ -1,4 +1,6 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
   answerWidgetTitle: {
     id: 'authoring.answerwidget.answer.answerWidgetTitle',
     defaultMessage: 'Answers',
@@ -54,6 +56,5 @@ export const messages = {
     defaultMessage: 'is not selected',
     description: 'Bold & underlined text for feedback if option is not selected',
   },
-};
-
+});
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/ExplanationWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/ExplanationWidget/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
 import { selectors } from '../../../../../data/redux';
-import { messages } from './messages';
+import messages from './messages';
 
 import TinyMceWidget from '../../../../../sharedComponents/TinyMceWidget';
 import { prepareEditorRef } from '../../../../../sharedComponents/TinyMceWidget/hooks';

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/ExplanationWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/ExplanationWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   solutionWidgetTitle: {
     id: 'authoring.problemEditor.explanationwidget.explanationWidgetTitle',
     defaultMessage: 'Explanation',
@@ -14,6 +17,6 @@ export const messages = {
     defaultMessage: 'Enter your explanation',
     description: 'Placeholder text for tinyMCE editor',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
 import { selectors } from '../../../../../data/redux';
-import { messages } from './messages';
+import messages from './messages';
 
 import TinyMceWidget from '../../../../../sharedComponents/TinyMceWidget';
 import { prepareEditorRef } from '../../../../../sharedComponents/TinyMceWidget/hooks';

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/QuestionWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   questionWidgetTitle: {
     id: 'authoring.questionwidget.question.questionWidgetTitle',
     defaultMessage: 'Question',
@@ -9,6 +12,6 @@ export const messages = {
     defaultMessage: 'Enter your question',
     description: 'Placeholder text for tinyMCE editor',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -15,6 +15,10 @@ jest.mock('react', () => {
   };
 });
 
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  defineMessages: m => m,
+}));
+
 jest.mock('../../../../../data/redux', () => ({
   actions: {
     problem: {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   settingsWidgetTitle: {
     id: 'authoring.problemeditor.settings.settingsWidgetTitle',
     defaultMessage: 'Settings',
@@ -185,17 +188,17 @@ export const messages = {
     description: 'button to switch to the advanced mode of the editor.',
   },
   ConfirmSwitchMessage: {
-    id: 'authoring.problemeditor.settings.switchtoadvancededitor.message',
+    id: 'authoring.problemeditor.settings.switchtoadvancededitor.ConfirmSwitchMessage',
     defaultMessage: 'If you use the advanced editor, this problem will be converted to OLX and you will not be able to return to the simple editor.',
     description: 'message to confirm that a user wants to use the advanced editor',
   },
   ConfirmSwitchMessageTitle: {
-    id: 'authoring.problemeditor.settings.switchtoadvancededitor.message',
+    id: 'authoring.problemeditor.settings.switchtoadvancededitor.ConfirmSwitchMessageTitle',
     defaultMessage: 'Convert to OLX?',
     description: 'message to confirm that a user wants to use the advanced editor',
   },
   ConfirmSwitchButtonLabel: {
-    id: 'authoring.problemeditor.settings.switchtoadvancededitor.message',
+    id: 'authoring.problemeditor.settings.switchtoadvancededitor.ConfirmSwitchButtonLabel',
     defaultMessage: 'Switch to advanced editor',
     description: 'message to confirm that a user wants to use the advanced editor',
   },
@@ -209,5 +212,6 @@ export const messages = {
     defaultMessage: 'Provide an explanation for the correct answer.',
     description: 'Solution Explanation text',
   },
-};
+});
+
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GeneralFeedback/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GeneralFeedback/hooks.test.js
@@ -12,6 +12,10 @@ jest.mock('react', () => {
   };
 });
 
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  defineMessages: m => m,
+}));
+
 const state = new MockUseState(hooks);
 
 describe('Problem settings hooks', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GeneralFeedback/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GeneralFeedback/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   generalFeebackSettingTitle: {
     id: 'authoring.problemeditor.settings.generalFeebackSettingTitle',
     defaultMessage: 'General Feedback',
@@ -19,5 +22,5 @@ export const messages = {
     defaultMessage: 'None',
     description: 'message which informs use there is no general feedback set.',
   },
-};
+});
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/hooks.test.js
@@ -12,6 +12,10 @@ jest.mock('react', () => {
   };
 });
 
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  defineMessages: m => m,
+}));
+
 const state = new MockUseState(hooks);
 
 describe('groupFeedbackCardHooks', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/messages.js
@@ -1,6 +1,9 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   noGroupFeedbackSummary: {
-    id: 'authoring.problemeditor.settings.GroupFeedbackSummary.message',
+    id: 'authoring.problemeditor.settings.GroupFeedbackSummary.nonMessage',
     defaultMessage: 'None',
     description: 'message to confirm that a user wants to use the advanced editor',
   },
@@ -24,5 +27,6 @@ export const messages = {
     defaultMessage: 'Group Feedback',
     description: 'label for group feedback setting',
   },
-};
+});
+
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.test.js
@@ -12,6 +12,10 @@ jest.mock('react', () => {
   };
 });
 
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  defineMessages: m => m,
+}));
+
 const state = new MockUseState(hooks);
 
 describe('Problem settings hooks', () => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   randomizationSettingTitle: {
     id: 'authoring.problemeditor.settings.randomization.SettingTitle',
     defaultMessage: 'Randomization',
@@ -14,5 +17,6 @@ export const messages = {
     defaultMessage: 'No Python based randomization is present in this problem.',
     description: 'text shown when no randomization option is given',
   },
-};
+});
+
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/messages.js
@@ -1,4 +1,6 @@
-const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
   toleranceSettingTitle: {
     id: 'problemEditor.settings.tolerance.title',
     defaultMessage: 'Tolerance',
@@ -42,5 +44,6 @@ const messages = {
     description: 'A possible value type for a tolerance',
   },
 
-};
+});
+
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/SwitchToAdvancedEditorCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/SwitchToAdvancedEditorCard.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`SwitchToAdvancedEditorCard snapshot snapshot: SwitchToAdvancedEditorCar
         <FormattedMessage
           defaultMessage="Switch to advanced editor"
           description="message to confirm that a user wants to use the advanced editor"
-          id="authoring.problemeditor.settings.switchtoadvancededitor.message"
+          id="authoring.problemeditor.settings.switchtoadvancededitor.ConfirmSwitchButtonLabel"
         />
       </Button>
     }
@@ -27,14 +27,14 @@ exports[`SwitchToAdvancedEditorCard snapshot snapshot: SwitchToAdvancedEditorCar
       <FormattedMessage
         defaultMessage="Convert to OLX?"
         description="message to confirm that a user wants to use the advanced editor"
-        id="authoring.problemeditor.settings.switchtoadvancededitor.message"
+        id="authoring.problemeditor.settings.switchtoadvancededitor.ConfirmSwitchMessageTitle"
       />
     }
   >
     <FormattedMessage
       defaultMessage="If you use the advanced editor, this problem will be converted to OLX and you will not be able to return to the simple editor."
       description="message to confirm that a user wants to use the advanced editor"
-      id="authoring.problemeditor.settings.switchtoadvancededitor.message"
+      id="authoring.problemeditor.settings.switchtoadvancededitor.ConfirmSwitchMessage"
     />
   </BaseModal>
   <Button

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/messages.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/SelectTypeWrapper/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   selectTypeTitle: {
     id: 'authoring.problemEditor.selectType.title',
     defaultMessage: 'Select problem type',
@@ -24,6 +27,6 @@ export const messages = {
     defaultMessage: 'Select',
     description: 'Screen reader label for select button.',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/messages.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/content/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   advanceProblemButtonLabel: {
     id: 'authoring.problemEditor.problemSelect.advanceButton.label',
     defaultMessage: 'Advanced problem types',
@@ -69,6 +72,6 @@ export const messages = {
     defaultMessage: 'Learn more about advanced problem types',
     description: 'Label for Learn more about advanced problem types button',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/ProblemEditor/messages.js
+++ b/src/editors/containers/ProblemEditor/messages.js
@@ -1,9 +1,12 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   blockFailed: {
     id: 'authoring.problemEditor.blockFailed',
     defaultMessage: 'Problem failed to load',
     description: 'Error message for problem block failing to load',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/TextEditor/messages.js
+++ b/src/editors/containers/TextEditor/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   couldNotLoadTextContext: {
     id: 'authoring.texteditor.load.error',
     defaultMessage: 'Error: Could Not Load Text Content',
@@ -9,6 +12,6 @@ export const messages = {
     defaultMessage: 'loading',
     description: 'Loading message for spinner screenreader text.',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/HandoutWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   titleLabel: {
     id: 'authoring.videoeditor.handout.title.label',
     defaultMessage: 'Handout',
@@ -45,6 +48,6 @@ export const messages = {
     defaultMessage: 'Download',
     description: 'Message Presented To user for action to download handout',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
@@ -21,7 +21,7 @@ import {
 
 import { actions } from '../../../../../../data/redux';
 import { LicenseLevel, LicenseTypes } from '../../../../../../data/constants/licenses';
-import { messages } from './messages';
+import messages from './messages';
 
 export const LicenseDetails = ({
   license,

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDisplay.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDisplay.jsx
@@ -13,7 +13,7 @@ import {
 import { LicenseTypes } from '../../../../../../data/constants/licenses';
 
 import LicenseBlurb from './LicenseBlurb';
-import { messages } from './messages';
+import messages from './messages';
 
 export const LicenseDisplay = ({
   license,

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/hooks.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/hooks.test.jsx
@@ -2,7 +2,7 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { actions } from '../../../../../../data/redux';
 import { LicenseTypes } from '../../../../../../data/constants/licenses';
 import * as module from './hooks';
-import { messages } from './messages';
+import messages from './messages';
 
 jest.mock('../../../../../../data/redux', () => ({
   actions: {

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   title: {
     id: 'authoring.videoeditor.license.title',
     defaultMessage: 'License',
@@ -119,6 +122,6 @@ export const messages = {
     defaultMessage: 'You reserve all rights for your work.',
     description: 'All Rights Reserved section message',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   title: {
     id: 'authoring.videoeditor.thumbnail.title',
     defaultMessage: 'Thumbnail',
@@ -56,6 +59,6 @@ export const messages = {
     description:
       ' Message presented to user when file size of image is less than 2 KB or larger than 2 MB',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   title: {
     id: 'authoring.videoeditor.transcripts.title',
     defaultMessage: 'Transcripts',
@@ -114,6 +117,6 @@ export const messages = {
     defaultMessage: 'We found transcript for this video on YouTube. Would you like to import it now?',
     description: 'Message for import transcript card asking user if they want to import transcript',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   titleLabel: {
     id: 'authoring.videoeditor.videoSource.title.label',
     defaultMessage: 'Video source',
@@ -78,6 +81,6 @@ export const messages = {
     defaultMessage: 'Add a video URL',
     description: 'Label for add a video URL button',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   expandAltText: {
     id: 'authoring.videoeditor.expand',
     defaultMessage: 'Expand',
@@ -77,6 +80,6 @@ export const messages = {
     defaultMessage: 'Other video',
     description: 'Shown on the preview card if the video source could not be identified.',
   },
-};
+});
 
 export default messages;

--- a/src/editors/containers/VideoEditor/index.jsx
+++ b/src/editors/containers/VideoEditor/index.jsx
@@ -13,7 +13,7 @@ import { RequestKeys } from '../../data/constants/requests';
 import EditorContainer from '../EditorContainer';
 import VideoEditorModal from './components/VideoEditorModal';
 import { ErrorContext, errorsHook, fetchVideoContent } from './hooks';
-import { messages } from './messages';
+import messages from './messages';
 
 export const VideoEditor = ({
   onClose,

--- a/src/editors/containers/VideoEditor/messages.js
+++ b/src/editors/containers/VideoEditor/messages.js
@@ -1,9 +1,12 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   spinnerScreenReaderText: {
     id: 'authoring.videoEditor.spinnerScreenReaderText',
     defaultMessage: 'loading',
     description: 'Loading message for spinner screenreader text.',
   },
-};
+});
 
 export default messages;

--- a/src/editors/messages.js
+++ b/src/editors/messages.js
@@ -1,9 +1,12 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   couldNotFindEditor: {
     id: 'authoring.editorpage.selecteditor.error',
     defaultMessage: 'Error: Could Not find Editor',
     description: 'Error Message Dispayed When An unsopported Editor is desired in V2',
   },
-};
+});
 
 export default messages;

--- a/src/editors/sharedComponents/BaseModal/messages.js
+++ b/src/editors/sharedComponents/BaseModal/messages.js
@@ -1,9 +1,12 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   cancelButtonLabel: {
     id: 'authoring.baseModal.cancelButtonLabel',
     defaultMessage: 'Cancel',
     description: 'Label for cancel button.',
   },
-};
+});
 
 export default messages;

--- a/src/editors/sharedComponents/CodeEditor/messages.js
+++ b/src/editors/sharedComponents/CodeEditor/messages.js
@@ -1,9 +1,12 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   escapeHTMLButtonLabel: {
     id: 'authoring.texteditor.codeEditor.escapeHTMLButton',
     defaultMessage: 'Unescape HTML Literals',
     description: 'Label For escape special html charectars button',
   },
-};
+});
 
 export default messages;

--- a/src/editors/sharedComponents/ErrorAlerts/messages.js
+++ b/src/editors/sharedComponents/ErrorAlerts/messages.js
@@ -1,9 +1,12 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   errorTitle: {
     id: 'authoring.texteditor.selectimagemodal.error.errorTitle',
     defaultMessage: 'Error',
     description: 'Title of message presented to user when something goes wrong',
   },
-};
+});
 
 export default messages;

--- a/src/editors/sharedComponents/ErrorBoundary/messages.js
+++ b/src/editors/sharedComponents/ErrorBoundary/messages.js
@@ -1,4 +1,6 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
   unexpectedError: {
     id: 'unexpected.error.message.text',
     defaultMessage: 'An unexpected error occurred. Please click the button below to refresh the page.',
@@ -9,5 +11,6 @@ export const messages = {
     defaultMessage: 'Try again',
     description: 'text for button that tries to reload the app by refreshing the page',
   },
-};
+});
+
 export default messages;

--- a/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/messages.js
+++ b/src/editors/sharedComponents/ImageUploadModal/ImageSettingsModal/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   // index
   titleLabel: {
     id: 'authoring.texteditor.imagesettingsmodal.titleLabel',
@@ -86,6 +89,6 @@ export const messages = {
     defaultMessage: 'Enter a value less than or equal to 100.',
     description: 'Message feedback for user below the dimension fields.',
   },
-};
+});
 
 export default messages;

--- a/src/editors/sharedComponents/ImageUploadModal/SelectImageModal/messages.js
+++ b/src/editors/sharedComponents/ImageUploadModal/SelectImageModal/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   nextButtonLabel: {
     id: 'authoring.texteditor.selectimagemodal.next.label',
     defaultMessage: 'Next',
@@ -89,6 +92,6 @@ export const messages = {
     description:
       'Message presented to user when clicking Next without selecting an image',
   },
-};
+});
 
 export default messages;

--- a/src/editors/sharedComponents/SourceCodeModal/messages.js
+++ b/src/editors/sharedComponents/SourceCodeModal/messages.js
@@ -1,4 +1,7 @@
-export const messages = {
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+
   saveButtonLabel: {
     id: 'authoring.texteditor.sourcecodemodal.next.label',
     defaultMessage: 'Save',
@@ -9,5 +12,6 @@ export const messages = {
     defaultMessage: 'Edit Source Code',
     description: 'Title for the source code editor',
   },
-};
+});
+
 export default messages;


### PR DESCRIPTION
Otherwise it'll complain for not finding any message and breaks the in-progress [openedx-translation build](https://github.com/brian-smith-tcril/openedx-translations/actions/runs/4546989109/jobs/8016322867#step:5:92). This is not a production-critical build yet, but we're working on making it so.

`defineMessage` ensures that React i18n static code collector is able to find the messages.

### Reviewers
 - [ ] @connorhaugh Would you mind taking a look at the pull request? The Open edX team asked me to tag you.
 - [ ] @kenclary and/or @KristinAoki I'd like if inform you about the changes since our work is overlapping.

### Testing
 - [ ] I need help in testing. I have _not_ tested the string in the UI. I don't know how. 
 - [ ] ~Automated tests are currently failing, I'm not so sure how to fix them.~ now they're fixed.

The upside is that `make extract_translations` produces a correct count of generated messages:

```shell
# Count the number of unique message IDs
frontend-lib-content-components $ git grep -h 'id:' -- '**messages.js' | sort | uniq | wc -l
246
```

```shell
# Count the number of extracted messages
frontend-lib-content-components $ make extract_translations
frontend-lib-content-components $ grep -e ':' -- src/i18n/transifex_input.json | wc -l
246
```

<details><summary>Sample from the generated `transifex_input.json` file</summary>
<p>

```
{
  "authoring.editorfooter.save.error": "Error: Content save failed. Try again later.",
  "authoring.editorfooter.cancelButton.ariaLabel": "Discard changes and return to learning context",
  "authoring.editorfooter.cancelButton.label": "Cancel",
  "authoring.editorfooter.savebutton.ariaLabel": "Save changes and return to learning context",
  "authoring.editorfooter.savebutton.label": "Save",
  "authoring.texteditor.title.loading": "Loading...",
  "authoring.texteditor.header.cancelChangesLabel": "Cancel Changes and Return to Learning Context",
  "authoring.texteditor.header.editTitleLabel": "Edit Title",
  "authoring.texteditor.header.cancelTitleEdit": "Cancel",
  "authoring.texteditor.header.saveTitleEdit": "Save",
  "authoring.editorContainer.cancelConfirm.title": "Exit the editor?",
  "authoring.editorContainer.cancelConfirm.description": "Are you sure you want to exit the editor? Any unsaved changes will be lost.",
  "authoring.editorContainer.okButton.label": "OK",
  "authoring.answerwidget.feedback.placeholder": "Feedback message",
  "authoring.answerwidget.feedback.icon.alt": "Toggle feedback",
  "authoring.answerwidget.feedback.selected.label": "Show following feedback when {answerId} {boldunderline}:",
  "authoring.answerwidget.feedback.selected.label.boldunderline": "is selected",
  "authoring.answerwidget.feedback.unselected.label": "Show following feedback when {answerId} {boldunderline}:",
  "authoring.answerwidget.feedback.unselected.label.boldunderline": "is not selected",
  "authoring.answerwidget.answer.answerWidgetTitle": "Answers",
  "authoring.problemEditor.answerWidget.answer.answerHelperText": "{helperText}",
  "authoring.answerwidget.answer.addAnswerButton": "Add answer",
  "authoring.answerwidget.answer.placeholder": "Enter an answer",
  "authoring.answerwidget.answer.delete.icon.alt": "Delete answer",
  "authoring.problemEditor.explanationwidget.explanationWidgetTitle": "Explanation",
  "authoring.problemEditor.solutionwidget.solutionDescriptionText": "Provide an explantion for the correct answer",
  "authoring.problemEditor.questionwidget.placeholder": "Enter your question",
  "authoring.questionwidget.question.questionWidgetTitle": "Question",
  "authoring.problemeditor.settings.settingsWidgetTitle": "Settings",
  "authoring.problemeditor.settings.showAdvancedButton": "Show advanced settings",
  "authoring.problemeditor.settings.delete.icon.alt": "Delete answer",
  "authoring.problemeditor.settings.advancedSettingLink.text": "Set a default value in advanced settings",
  "authoring.problemeditor.settings.hint.title": "Hints",
  "authoring.problemeditor.settings.hint.inputLabel": "Hint",
  "authoring.problemeditor.settings.hint.addHintButton": "Add hint",
```

</p>
</details> 

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitectured in Open edX Python, XBlock, Micro-frontend and other projects. There's a number of immediate visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standarized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

