### PR TITLE
feat: add catch for script tags in question

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -323,6 +323,9 @@ export class OLXParser {
     problemArray.forEach(tag => {
       const tagName = Object.keys(tag)[0];
       if (!nonQuestionKeys.includes(tagName)) {
+        if (tagName === 'script') {
+          throw new Error('Script Tag, reverting to Advanced Editor');
+        }
         questionArray.push(tag);
       }
     });

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -16,6 +16,7 @@ import {
   blankQuestionOLX,
   styledQuestionOLX,
   shuffleProblemOLX,
+  scriptProblemOlX,
 } from './mockData/olxTestData';
 import { ProblemTypeKeys } from '../../../data/constants/problem';
 
@@ -180,6 +181,10 @@ describe('Check OLXParser for question parsing', () => {
     const olxparser = new OLXParser(numericInputWithFeedbackAndHintsOLX.rawOLX);
     const question = olxparser.parseQuestions('numericalresponse');
     expect(question).toEqual(numericInputWithFeedbackAndHintsOLX.question);
+  });
+  test('Test Advanced Problem Type by script tag', () => {
+    const olxparser = new OLXParser(scriptProblemOlX.rawOLX);
+    expect(() => olxparser.parseQuestions('numericalresponse')).toThrow(new Error('Script Tag, reverting to Advanced Editor'));
   });
   test('Test OLX with no question content should have empty string for question', () => {
     const olxparser = new OLXParser(blankQuestionOLX.rawOLX);

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -551,6 +551,22 @@ export const advancedProblemOlX = {
   </formularesponse>
 </problem>`,
 };
+export const scriptProblemOlX = {
+  rawOLX: `<problem>
+    <script>
+      some code
+    </script>
+  <numericalresponse answer="100">
+  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+<label>Add the question text, or prompt, here. This text is required.</label>
+<description>You can add an optional tip or note related to the prompt like this. </description>
+<responseparam type="tolerance" default="5"/>
+  <formulaequationinput/>
+  <correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint>
+  <additional_answer answer="200"><correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint></additional_answer>
+</numericalresponse>
+</problem>`,
+};
 export const multipleProblemOlX = {
   rawOLX: `<problem>
   <stringresponse answer="correct answer">


### PR DESCRIPTION
JIRA Ticket: [TNL-10601](https://2u-internal.atlassian.net/browse/TNL-10601)

This ticket fixes the routing of simple problems with `<script>` tags. When a problem has the tags of one of the common problem types (numeric, text, single select, multiple select, or dropdown), the editor is set to the visual editor. However, in some cases, these common problems will be accompanied by a python script. In this case, the problem should be rendered in the advanced editor. Now the question parser checks if the OLX has the `<script>` tag and throws an error to redirect to the advanced editor.

Test OLX:
```
<problem>
    <script>
      some code
    </script>
  <numericalresponse answer="100">
  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
<label>Add the question text, or prompt, here. This text is required.</label>
<description>You can add an optional tip or note related to the prompt like this. </description>
<responseparam type="tolerance" default="5"/>
  <formulaequationinput/>
  <correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint>
  <additional_answer answer="200"><correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint></additional_answer>
</numericalresponse>
</problem>
```