### PR TITLE
feat: default scoring to 1, not zero.

### DIFF
--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -19,7 +19,7 @@ const initialState = {
   settings: {
     randomization: null,
     scoring: {
-      weight: 0,
+      weight: 1,
       attempts: {
         unlimited: true,
         number: '',


### PR DESCRIPTION
Since every course has graded problems, every course author will be editing or creating problems, and every learner will need to receive points for any problem in a graded assignment in order to earn a passing grade. So if what I encountered and am reporting here is reproducible, this should probably be addressed before the problem editor feature is released.