### PR TITLE
feat: XMLBuilder and XMLParser performing unwanted processing in encoding / parsing 

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -481,7 +481,6 @@ export class OLXParser {
   }
 
   getParsedOLXData() {
-    console.log('test', this.parsedOLX)
     if (_.isEmpty(this.problem)) {
       return {};
     }

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -67,14 +67,28 @@ export class OLXParser {
     const questionOptions = {
       ignoreAttributes: false,
       alwaysCreateTextNode: true,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
       preserveOrder: true,
+      processEntities: false,
     };
     const parserOptions = {
       ignoreAttributes: false,
       alwaysCreateTextNode: true,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
+      processEntities: false,
     };
     const builderOptions = {
       ignoreAttributes: false,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
       processEntities: false,
     };
     // There are two versions of the parsed XLM because the question requires the order of the
@@ -332,6 +346,10 @@ export class OLXParser {
   parseQuestions(problemType) {
     const options = {
       ignoreAttributes: false,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
       preserveOrder: true,
       processEntities: false,
     };
@@ -463,6 +481,7 @@ export class OLXParser {
   }
 
   getParsedOLXData() {
+    console.log('test', this.parsedOLX)
     if (_.isEmpty(this.problem)) {
       return {};
     }

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -75,6 +75,7 @@ export class OLXParser {
     };
     const builderOptions = {
       ignoreAttributes: false,
+      processEntities: false,
     };
     // There are two versions of the parsed XLM because the question requires the order of the
     // parsed data to be preserved. However, all the other widgets need the data grouped by
@@ -332,6 +333,7 @@ export class OLXParser {
     const options = {
       ignoreAttributes: false,
       preserveOrder: true,
+      processEntities: false,
     };
     const builder = new XMLBuilder(options);
     const problemArray = _.get(this.questionData[0], problemType) || this.questionData;

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -18,6 +18,7 @@ import {
   shuffleProblemOLX,
   scriptProblemOlX,
   labelDescriptionQuestionOLX,
+  encodingTestOLX,
 } from './mockData/olxTestData';
 import { ProblemTypeKeys } from '../../../data/constants/problem';
 
@@ -229,5 +230,19 @@ describe('OLXParser for problem with solution tag', () => {
       const expected = getCheckboxesOLXWithFeedbackAndHintsOLX().solutionExplanation;
       expect(explanation.replace(/\s/g, '')).toBe(expected.replace(/\s/g, ''));
     });
+  });
+});
+
+describe('Check OLXParser for proper encoding', () => {
+  it('should not encode html entities', () => {
+    const olxparser = new OLXParser(encodingTestOLX.rawOLX);
+    const problemType = olxparser.getProblemType();
+    const question = olxparser.parseQuestions(problemType);
+    expect(question).toBe(encodingTestOLX.question);
+  });
+  it('should not parse hex numbers and leading zeros', () => {
+    const olxparser = new OLXParser(encodingTestOLX.rawOLX);
+    const answer = olxparser.parseMultipleChoiceAnswers('multiplechoiceresponse', 'choicegroup', 'choice');
+    expect(answer).toEqual(encodingTestOLX.data);
   });
 });

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -694,3 +694,57 @@ export const labelDescriptionQuestionOLX = {
 
   question: '<p style="text-align: center;"><img height="274" width="" src="/static/boiling_eggs_water_system.png" alt="boiling eggs: water system"></img></p><label>Taking the system as just the<b>water</b>, as indicated by the red dashed line, what would be the correct expression for the first law of thermodynamics applied to this system?</label><em>Watch out, boiling water is hot</em>',
 };
+
+export const encodingTestOLX = {
+  rawOLX:
+  `<problem>
+  <multiplechoiceresponse>
+  <p>What is the content of the register x2 after executing the following three lines of instructions?</p>
+  <p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions <br />0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br />0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br />0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>
+  <choicegroup type="MultipleChoice">
+      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0x10</strong></span></choice>
+      <choice correct="true"><span style="font-family: 'courier new', courier;"><strong>0x0f</strong></span></choice>
+      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0x07</strong></span></choice>
+      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0009</strong></span></choice>
+    </choicegroup>
+  <solution>
+  <div class="detailed-solution">
+   <p>Explanation</p>
+    <p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions&#160;&#160;&#160;&#160;comment<br />0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = 0x1<br />0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x2 = x1 &lt;&lt; 4 = 0x10<br />0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = x2 - x1 = 0x10 - 0x01 = 0xf</strong></span></p>
+    </div>
+    </solution>
+  </multiplechoiceresponse>
+  </problem>`,
+  data: {
+    answers: [
+      {
+        id: 'A',
+        // eslint-disable-next-line
+        title: `<span style="font-family: 'courier new', courier;"><strong>0x10</strong></span>`,
+        correct: false,
+      },
+      {
+        id: 'B',
+        // eslint-disable-next-line
+        title: `<span style="font-family: 'courier new', courier;"><strong>0x0f</strong></span>`,
+        correct: true,
+      },
+      {
+        id: 'C',
+        // eslint-disable-next-line
+        title: `<span style="font-family: 'courier new', courier;"><strong>0x07</strong></span>`,
+        correct: false,
+      },
+      {
+        id: 'D',
+        // eslint-disable-next-line
+        title: `<span style="font-family: 'courier new', courier;"><strong>0009</strong></span>`,
+        correct: false,
+      },
+    ],
+  },
+  // eslint-disable-next-line
+  question: `<p>What is the content of the register x2 after executing the following three lines of instructions?</p><p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions<br></br>0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br></br>0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br></br>0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>`,
+  // eslint-disable-next-line
+  solutionExplanation: `<p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions&#160;&#160;&#160;&#160;comment<br></br>0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = 0x1<br></br>0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x2 = x1 &lt;&lt; 4 = 0x10<br></br>0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = x2 - x1 = 0x10 - 0x01 = 0xf</strong></span></p>`,
+};


### PR DESCRIPTION
When the simple problem editor loads OLX, the XMLBuilder encodes the OLX before tinyMCE decodes it again. This means that if the block contains any encoded HTML entities, they will not appear decoded on the editor.
LMS simply decodes the OLX. The simple editor should match that behavior.

An example of what is happening currently:
LMS: ` `
Block OLX: `&#160;`
After XMLBuilder processing: `&amp;#160;`
After tinyMCE processing: `&#160;`  (this is what is seen in the simple problem editor)

This PR keeps XMLBuilder from encoding the OLX.

https://2u-internal.atlassian.net/browse/TNL-10627

=========================

Somewhat related, the XMLParser automatically parses numbers like 0x12 as hexes. This PR will turn this parsing off as well.

https://2u-internal.atlassian.net/browse/TNL-10629