### PR TITLE
feat: further number parse changes

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -18,7 +18,8 @@ import {
   shuffleProblemOLX,
   scriptProblemOlX,
   labelDescriptionQuestionOLX,
-  encodingTestOLX,
+  htmlEntityTestOLX,
+  numberParseTestOLX,
 } from './mockData/olxTestData';
 import { ProblemTypeKeys } from '../../../data/constants/problem';
 
@@ -235,14 +236,14 @@ describe('OLXParser for problem with solution tag', () => {
 
 describe('Check OLXParser for proper encoding', () => {
   it('should not encode html entities', () => {
-    const olxparser = new OLXParser(encodingTestOLX.rawOLX);
+    const olxparser = new OLXParser(htmlEntityTestOLX.rawOLX);
     const problemType = olxparser.getProblemType();
     const question = olxparser.parseQuestions(problemType);
-    expect(question).toBe(encodingTestOLX.question);
+    expect(question).toBe(htmlEntityTestOLX.question);
   });
   it('should not parse hex numbers and leading zeros', () => {
-    const olxparser = new OLXParser(encodingTestOLX.rawOLX);
+    const olxparser = new OLXParser(numberParseTestOLX.rawOLX);
     const answer = olxparser.parseMultipleChoiceAnswers('multiplechoiceresponse', 'choicegroup', 'choice');
-    expect(answer).toEqual(encodingTestOLX.data);
+    expect(answer).toEqual(numberParseTestOLX.data);
   });
 });

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -8,10 +8,18 @@ class ReactStateOLXParser {
     const parserOptions = {
       ignoreAttributes: false,
       alwaysCreateTextNode: true,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
     };
     const questionParserOptions = {
       ignoreAttributes: false,
       alwaysCreateTextNode: true,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
       preserveOrder: true,
     };
     const questionBuilderOptions = {
@@ -19,6 +27,10 @@ class ReactStateOLXParser {
       attributeNamePrefix: '@_',
       suppressBooleanAttributes: false,
       format: true,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
       preserveOrder: true,
     };
     const builderOptions = {
@@ -26,6 +38,10 @@ class ReactStateOLXParser {
       attributeNamePrefix: '@_',
       suppressBooleanAttributes: false,
       format: true,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
     };
     this.questionParser = new XMLParser(questionParserOptions);
     this.parser = new XMLParser(parserOptions);

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
@@ -7,6 +7,7 @@ import {
   textInputWithFeedbackAndHintsOLX,
   multipleChoiceWithFeedbackAndHintsOLX,
   textInputWithFeedbackAndHintsOLXWithMultipleAnswers,
+  numberParseTestOLX,
 } from './mockData/olxTestData';
 import {
   checkboxesWithFeedbackAndHints,
@@ -16,10 +17,11 @@ import {
   numericInputWithFeedbackAndHints,
   numericInputWithAnswerRange,
   textInputWithFeedbackAndHintsWithMultipleAnswers,
+  numberParseTest,
 } from './mockData/editorTestData';
 import ReactStateOLXParser from './ReactStateOLXParser';
 
-describe('Check React Sate OLXParser problem', () => {
+describe('Check React State OLXParser problem', () => {
   test('Test checkbox with feedback and hints problem type', () => {
     const olxparser = new OLXParser(checkboxesOLXWithFeedbackAndHintsOLX.rawOLX);
     const problem = olxparser.getParsedOLXData();
@@ -90,5 +92,17 @@ describe('Check React Sate OLXParser problem', () => {
     });
     const buildOLX = stateParser.buildOLX();
     expect(buildOLX.replace(/\s/g, '')).toEqual(textInputWithFeedbackAndHintsOLXWithMultipleAnswers.buildOLX.replace(/\s/g, ''));
+  });
+  describe('encode/decode', () => {
+    test('does not change hex values to dec and does not remove leading 0s', () => {
+      const olxparser = new OLXParser(numberParseTestOLX.rawOLX);
+      const problem = olxparser.getParsedOLXData();
+      const stateParser = new ReactStateOLXParser({
+        problem,
+        editorObject: numberParseTest,
+      });
+      const buildOLX = stateParser.buildOLX();
+      expect(buildOLX.replace(/\s/g, '')).toEqual(numberParseTestOLX.buildOLX.replace(/\s/g, ''));
+    });
   });
 });

--- a/src/editors/containers/ProblemEditor/data/mockData/editorTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/editorTestData.js
@@ -116,3 +116,15 @@ export const textInputWithFeedbackAndHintsWithMultipleAnswers = {
   ],
   question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for text input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
 };
+
+export const numberParseTest = {
+  solution: '',
+  answers: {
+    A: `<span style="font-family: 'courier new', courier;"><strong>0x10</strong></span>`, // eslint-disable-line
+    B: `<span style="font-family: 'courier new', courier;"><strong>0x0f</strong></span>`, // eslint-disable-line
+    C: `<span style="font-family: 'courier new', courier;"><strong>0x07</strong></span>`, // eslint-disable-line
+    D: `<span style="font-family: 'courier new', courier;"><strong>0009</strong></span>`, // eslint-disable-line
+  },
+  hints: [],
+  question: '<p>What is the content of the register x2 after executing the following three lines of instructions?</p>',
+};

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -695,17 +695,15 @@ export const labelDescriptionQuestionOLX = {
   question: '<p style="text-align: center;"><img height="274" width="" src="/static/boiling_eggs_water_system.png" alt="boiling eggs: water system"></img></p><label>Taking the system as just the<b>water</b>, as indicated by the red dashed line, what would be the correct expression for the first law of thermodynamics applied to this system?</label><em>Watch out, boiling water is hot</em>',
 };
 
-export const encodingTestOLX = {
+export const htmlEntityTestOLX = {
   rawOLX:
   `<problem>
   <multiplechoiceresponse>
   <p>What is the content of the register x2 after executing the following three lines of instructions?</p>
   <p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions <br />0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br />0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br />0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>
   <choicegroup type="MultipleChoice">
-      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0x10</strong></span></choice>
-      <choice correct="true"><span style="font-family: 'courier new', courier;"><strong>0x0f</strong></span></choice>
-      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0x07</strong></span></choice>
-      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0009</strong></span></choice>
+      <choice correct="false">answerA</choice>
+      <choice correct="true">answerB</choice>
     </choicegroup>
   <solution>
   <div class="detailed-solution">
@@ -719,27 +717,13 @@ export const encodingTestOLX = {
     answers: [
       {
         id: 'A',
-        // eslint-disable-next-line
-        title: `<span style="font-family: 'courier new', courier;"><strong>0x10</strong></span>`,
+        title: 'answerA',
         correct: false,
       },
       {
         id: 'B',
-        // eslint-disable-next-line
-        title: `<span style="font-family: 'courier new', courier;"><strong>0x0f</strong></span>`,
+        title: 'answerB',
         correct: true,
-      },
-      {
-        id: 'C',
-        // eslint-disable-next-line
-        title: `<span style="font-family: 'courier new', courier;"><strong>0x07</strong></span>`,
-        correct: false,
-      },
-      {
-        id: 'D',
-        // eslint-disable-next-line
-        title: `<span style="font-family: 'courier new', courier;"><strong>0009</strong></span>`,
-        correct: false,
       },
     ],
   },
@@ -747,4 +731,54 @@ export const encodingTestOLX = {
   question: `<p>What is the content of the register x2 after executing the following three lines of instructions?</p><p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions<br></br>0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br></br>0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br></br>0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>`,
   // eslint-disable-next-line
   solutionExplanation: `<p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions&#160;&#160;&#160;&#160;comment<br></br>0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = 0x1<br></br>0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x2 = x1 &lt;&lt; 4 = 0x10<br></br>0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = x2 - x1 = 0x10 - 0x01 = 0xf</strong></span></p>`,
+};
+
+export const numberParseTestOLX = {
+  rawOLX: `<problem>
+  <multiplechoiceresponse>
+  <p>What is the content of the register x2 after executing the following three lines of instructions?</p>
+  <choicegroup type="MultipleChoice">
+      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0x10</strong></span></choice>
+      <choice correct="true"><span style="font-family: 'courier new', courier;"><strong>0x0f</strong></span></choice>
+      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0x07</strong></span></choice>
+      <choice correct="false"><span style="font-family: 'courier new', courier;"><strong>0009</strong></span></choice>
+    </choicegroup>
+  </multiplechoiceresponse>
+  </problem>`,
+  data: {
+    answers: [
+      {
+        id: 'A',
+        title: `<span style="font-family: 'courier new', courier;"><strong>0x10</strong></span>`, // eslint-disable-line
+        correct: false,
+      },
+      {
+        id: 'B',
+        title: `<span style="font-family: 'courier new', courier;"><strong>0x0f</strong></span>`, // eslint-disable-line
+        correct: true,
+      },
+      {
+        id: 'C',
+        title: `<span style="font-family: 'courier new', courier;"><strong>0x07</strong></span>`, // eslint-disable-line
+        correct: false,
+      },
+      {
+        id: 'D',
+        title: `<span style="font-family: 'courier new', courier;"><strong>0009</strong></span>`, // eslint-disable-line
+        correct: false,
+      },
+    ],
+  },
+  question: '<p>What is the content of the register x2 after executing the following three lines of instructions?</p>',
+  buildOLX: `<problem>
+  <multiplechoiceresponse>
+  <p>What is the content of the register x2 after executing the following three lines of instructions?</p>
+  <choicegroup>
+      <choice correct="false"><span style="font-family: &apos;courier new&apos;, courier;"><strong>0x10</strong></span></choice>
+      <choice correct="true"><span style="font-family: &apos;courier new&apos;, courier;"><strong>0x0f</strong></span></choice>
+      <choice correct="false"><span style="font-family: &apos;courier new&apos;, courier;"><strong>0x07</strong></span></choice>
+      <choice correct="false"><span style="font-family: &apos;courier new&apos;, courier;"><strong>0009</strong></span></choice>
+    </choicegroup>
+  </multiplechoiceresponse>
+  </problem>`,
 };


### PR DESCRIPTION
This PR ensures we do not parse numbers the following ways on save:
- hex -> dec
- remove leading 0's