### PR TITLE
feat: add xml linter to code mirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lint": "^6.2.1",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
         "@reduxjs/toolkit": "^1.8.1",
@@ -31,7 +32,8 @@
         "reselect": "^4.1.5",
         "tinymce": "^5.10.4",
         "video-react": "^0.15.0",
-        "video.js": "^7.18.1"
+        "video.js": "^7.18.1",
+        "xmlchecker": "^0.1.0"
       },
       "devDependencies": {
         "@edx/frontend-build": "^11.0.2",
@@ -2824,9 +2826,9 @@
       "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.0.tgz",
-      "integrity": "sha512-mdvDQrjRmYPvQ3WrzF6Ewaao+NWERYtpthJvoQ3tK3t/44Ynhk8ZGjTSL9jMEv8CgSMogmt75X8ceOZRDSXHtQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.1.tgz",
+      "integrity": "sha512-y1muai5U/uUPAGRyHMx9mHuHLypPcHWxzlZGknp/U5Mdb5Ol8Q5ZLp67UqyTbNFJJ3unVxZ8iX3g1fMN79S1JQ==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -34451,6 +34453,14 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/xmlchecker": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xmlchecker/-/xmlchecker-0.1.0.tgz",
+      "integrity": "sha512-ElfXP7Fse9G37go0mjD5a7zY9fnE19BHk1qbH02uXX/O6Gi5Be2TPCg3zHG7ZIzV2yoGr/Gybfw/Z2Cs62tDxw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -36532,9 +36542,9 @@
       }
     },
     "@codemirror/lint": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.0.tgz",
-      "integrity": "sha512-mdvDQrjRmYPvQ3WrzF6Ewaao+NWERYtpthJvoQ3tK3t/44Ynhk8ZGjTSL9jMEv8CgSMogmt75X8ceOZRDSXHtQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.1.tgz",
+      "integrity": "sha512-y1muai5U/uUPAGRyHMx9mHuHLypPcHWxzlZGknp/U5Mdb5Ol8Q5ZLp67UqyTbNFJJ3unVxZ8iX3g1fMN79S1JQ==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -60978,6 +60988,11 @@
           }
         }
       }
+    },
+    "xmlchecker": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xmlchecker/-/xmlchecker-0.1.0.tgz",
+      "integrity": "sha512-ElfXP7Fse9G37go0mjD5a7zY9fnE19BHk1qbH02uXX/O6Gi5Be2TPCg3zHG7ZIzV2yoGr/Gybfw/Z2Cs62tDxw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@codemirror/lang-html": "^6.0.0",
     "@codemirror/lang-xml": "^6.0.0",
+    "@codemirror/lint": "^6.2.1",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
     "@reduxjs/toolkit": "^1.8.1",
@@ -79,7 +80,8 @@
     "reselect": "^4.1.5",
     "tinymce": "^5.10.4",
     "video-react": "^0.15.0",
-    "video.js": "^7.18.1"
+    "video.js": "^7.18.1",
+    "xmlchecker": "^0.1.0"
   },
   "peerDependencies": {
     "@edx/frontend-platform": ">1.15.0",

--- a/src/editors/containers/EditorContainer/components/EditorFooter/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/EditorContainer/components/EditorFooter/__snapshots__/index.test.jsx.snap
@@ -115,7 +115,7 @@ exports[`EditorFooter render snapshot: save failed.  Show error message 1`] = `
     show={true}
   >
     <FormattedMessage
-      defaultMessage="Error: Content save failed. Try again later."
+      defaultMessage="Error: Content save failed. Please check recent changes and try again later."
       description="Error message displayed when content fails to save."
       id="authoring.editorfooter.save.error"
     />

--- a/src/editors/containers/EditorContainer/components/EditorFooter/messages.js
+++ b/src/editors/containers/EditorContainer/components/EditorFooter/messages.js
@@ -4,7 +4,7 @@ const messages = defineMessages({
 
   contentSaveFailed: {
     id: 'authoring.editorfooter.save.error',
-    defaultMessage: 'Error: Content save failed. Try again later.',
+    defaultMessage: 'Error: Content save failed. Please check recent changes and try again later.',
     description: 'Error message displayed when content fails to save.',
   },
   cancelButtonAriaLabel: {

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/__snapshots__/index.test.jsx.snap
@@ -5,6 +5,17 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with default
   fontSize="x-small"
   title="Video source"
 >
+  <ErrorAlert
+    dismissError={[Function]}
+    hideHeading={true}
+    isError={false}
+  >
+    <FormattedMessage
+      defaultMessage="The Video ID field has changed, please check the Video URL and fallback URL values and update them if necessary."
+      description="Body message for the alert that appears when the video id has been changed."
+      id="authoring.videoeditor.videoIdChangeAlert.message"
+    />
+  </ErrorAlert>
   <Form.Group>
     <div
       className="border-primary-100 border-bottom pb-4"
@@ -15,7 +26,7 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with default
         onChange={[MockFunction]}
         value=""
       />
-      <Component
+      <Form.Control.Feedback
         className="text-primary-300 mb-4"
       >
         <FormattedMessage
@@ -23,14 +34,14 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with default
           description="Feedback for video ID field"
           id="authoring.videoeditor.videoSource.videoId.feedback"
         />
-      </Component>
+      </Form.Control.Feedback>
       <Form.Control
         floatingLabel="Video URL"
         onBlur={[Function]}
         onChange={[MockFunction]}
         value=""
       />
-      <Component
+      <Form.Control.Feedback
         className="text-primary-300"
       >
         <FormattedMessage
@@ -39,7 +50,7 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with default
           description="Feedback for video URL field"
           id="authoring.videoeditor.videoSource.videoUrl.feedback"
         />
-      </Component>
+      </Form.Control.Feedback>
     </div>
     <div
       className="mt-4"
@@ -147,6 +158,17 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with videoSh
   fontSize="x-small"
   title="Video source"
 >
+  <ErrorAlert
+    dismissError={[Function]}
+    hideHeading={true}
+    isError={false}
+  >
+    <FormattedMessage
+      defaultMessage="The Video ID field has changed, please check the Video URL and fallback URL values and update them if necessary."
+      description="Body message for the alert that appears when the video id has been changed."
+      id="authoring.videoeditor.videoIdChangeAlert.message"
+    />
+  </ErrorAlert>
   <Form.Group>
     <div
       className="border-primary-100 border-bottom pb-4"
@@ -157,7 +179,7 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with videoSh
         onChange={[MockFunction]}
         value=""
       />
-      <Component
+      <Form.Control.Feedback
         className="text-primary-300 mb-4"
       >
         <FormattedMessage
@@ -165,14 +187,14 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with videoSh
           description="Feedback for video ID field"
           id="authoring.videoeditor.videoSource.videoId.feedback"
         />
-      </Component>
+      </Form.Control.Feedback>
       <Form.Control
         floatingLabel="Video URL"
         onBlur={[Function]}
         onChange={[MockFunction]}
         value=""
       />
-      <Component
+      <Form.Control.Feedback
         className="text-primary-300"
       >
         <FormattedMessage
@@ -181,7 +203,7 @@ exports[`VideoSourceWidget snapshots snapshots: renders as expected with videoSh
           description="Feedback for video URL field"
           id="authoring.videoeditor.videoSource.videoUrl.feedback"
         />
-      </Component>
+      </Form.Control.Feedback>
     </div>
     <div
       className="mt-4"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
@@ -1,8 +1,13 @@
+import React from 'react';
 import { actions } from '../../../../../../data/redux';
 import { parseYoutubeId } from '../../../../../../data/services/cms/api';
 import * as requests from '../../../../../../data/redux/thunkActions/requests';
 
-export const sourceHooks = ({ dispatch }) => ({
+export const state = {
+  showVideoIdChangeAlert: (args) => React.useState(args),
+};
+
+export const sourceHooks = ({ dispatch, previousVideoId, setAlert }) => ({
   updateVideoURL: (e, videoId) => {
     const videoUrl = e.target.value;
     dispatch(actions.video.updateField({ videoSource: videoUrl }));
@@ -22,7 +27,13 @@ export const sourceHooks = ({ dispatch }) => ({
       }));
     }
   },
-  updateVideoId: (e) => dispatch(actions.video.updateField({ videoId: e.target.value })),
+  updateVideoId: (e) => {
+    const updatedVideoId = e.target.value;
+    if (previousVideoId !== updatedVideoId && updatedVideoId) {
+      setAlert();
+    }
+    dispatch(actions.video.updateField({ videoId: updatedVideoId }));
+  },
 });
 
 export const fallbackHooks = ({ fallbackVideos, dispatch }) => ({
@@ -33,7 +44,19 @@ export const fallbackHooks = ({ fallbackVideos, dispatch }) => ({
   },
 });
 
+export const videoIdChangeAlert = () => {
+  const [showVideoIdChangeAlert, setShowVideoIdChangeAlert] = state.showVideoIdChangeAlert(false);
+  return {
+    videoIdChangeAlert: {
+      show: showVideoIdChangeAlert,
+      set: () => setShowVideoIdChangeAlert(true),
+      dismiss: () => setShowVideoIdChangeAlert(false),
+    },
+  };
+};
+
 export default {
+  videoIdChangeAlert,
   sourceHooks,
   fallbackHooks,
 };

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.jsx
@@ -10,7 +10,6 @@ import {
   Button,
   Tooltip,
   OverlayTrigger,
-  FormControlFeedback,
 } from '@edx/paragon';
 import { DeleteOutline, InfoOutline, Add } from '@edx/paragon/icons';
 import {
@@ -24,6 +23,7 @@ import * as hooks from './hooks';
 import messages from './messages';
 import { selectors } from '../../../../../../data/redux';
 
+import { ErrorAlert } from '../../../../../../sharedComponents/ErrorAlerts/ErrorAlert';
 import CollapsibleFormWidget from '../CollapsibleFormWidget';
 
 /**
@@ -52,7 +52,12 @@ export const VideoSourceWidget = ({
       [widgetHooks.selectorKeys.allowVideoSharing]: widgetHooks.genericWidget,
     },
   });
-  const { updateVideoId, updateVideoURL } = hooks.sourceHooks({ dispatch });
+  const { videoIdChangeAlert } = hooks.videoIdChangeAlert();
+  const { updateVideoId, updateVideoURL } = hooks.sourceHooks({
+    dispatch,
+    previousVideoId: videoId.formValue,
+    setAlert: videoIdChangeAlert.set,
+  });
   const {
     addFallbackVideo,
     deleteFallbackVideo,
@@ -63,6 +68,13 @@ export const VideoSourceWidget = ({
       fontSize="x-small"
       title={intl.formatMessage(messages.titleLabel)}
     >
+      <ErrorAlert
+        dismissError={videoIdChangeAlert.dismiss}
+        hideHeading
+        isError={videoIdChangeAlert.show}
+      >
+        <FormattedMessage {...messages.videoIdChangeAlert} />
+      </ErrorAlert>
       <Form.Group>
         <div className="border-primary-100 border-bottom pb-4">
           <Form.Control
@@ -71,18 +83,18 @@ export const VideoSourceWidget = ({
             onBlur={updateVideoId}
             value={videoId.local}
           />
-          <FormControlFeedback className="text-primary-300 mb-4">
+          <Form.Control.Feedback className="text-primary-300 mb-4">
             <FormattedMessage {...messages.videoIdFeedback} />
-          </FormControlFeedback>
+          </Form.Control.Feedback>
           <Form.Control
             floatingLabel={intl.formatMessage(messages.videoUrlLabel)}
             onChange={source.onChange}
             onBlur={(e) => updateVideoURL(e, videoId.local)}
             value={source.local}
           />
-          <FormControlFeedback className="text-primary-300">
+          <Form.Control.Feedback className="text-primary-300">
             <FormattedMessage {...messages.videoUrlFeedback} />
-          </FormControlFeedback>
+          </Form.Control.Feedback>
         </div>
         <div className="mt-4">
           <FormattedMessage {...messages.fallbackVideoTitle} />

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/index.test.jsx
@@ -32,6 +32,13 @@ jest.mock('../hooks', () => ({
 }));
 
 jest.mock('./hooks', () => ({
+  videoIdChangeAlert: jest.fn().mockReturnValue({
+    videoIdChangeAlert: {
+      set: (args) => ({ set: args }),
+      show: false,
+      dismiss: (args) => ({ dismiss: args }),
+    },
+  }),
   sourceHooks: jest.fn().mockReturnValue({
     updateVideoId: (args) => ({ updateVideoId: args }),
     updateVideoURL: jest.fn().mockName('updateVideoURL'),
@@ -81,20 +88,20 @@ describe('VideoSourceWidget', () => {
     let el;
     let hook;
     beforeEach(() => {
+      hook = hooks.sourceHooks({ dispatch, previousVideoId: 'someVideoId', setAlert: jest.fn() });
       el = shallow(<VideoSourceWidget {...props} />);
-      hook = hooks.sourceHooks({ dispatch });
     });
     test('updateVideoId is tied to id field onBlur', () => {
       const expected = hook.updateVideoId;
       expect(el
         // eslint-disable-next-line
-        .children().at(0).children().at(0).children().at(0)
+        .children().at(1).children().at(0).children().at(0)
         .props().onBlur).toEqual(expected);
     });
     test('updateVideoURL is tied to url field onBlur', () => {
       const { onBlur } = el
         // eslint-disable-next-line
-        .children().at(0).children().at(0).children().at(2).props();
+        .children().at(1).children().at(0).children().at(2).props();
       onBlur('onBlur event');
       expect(hook.updateVideoURL).toHaveBeenCalledWith('onBlur event', '');
     });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/messages.js
@@ -28,6 +28,11 @@ const messages = defineMessages({
     to an .mp4, .ogg, or .webm video file hosted elsewhere on the internet.`,
     description: 'Feedback for video URL field',
   },
+  videoIdChangeAlert: {
+    id: 'authoring.videoeditor.videoIdChangeAlert.message',
+    defaultMessage: 'The Video ID field has changed, please check the Video URL and fallback URL values and update them if necessary.',
+    description: 'Body message for the alert that appears when the video id has been changed.',
+  },
   fallbackVideoTitle: {
     id: 'authoring.videoeditor.videoSource.fallbackVideo.title',
     defaultMessage: 'Fallback videos',

--- a/src/editors/sharedComponents/CodeEditor/hooks.js
+++ b/src/editors/sharedComponents/CodeEditor/hooks.js
@@ -28,10 +28,9 @@ export const cleanHTML = ({ initialText }) => {
   return initialText.replace(translateRegex, translator);
 };
 
-const xmlSyntaxChecker = (view) => {
+export const xmlSyntaxChecker = (textArr) => {
   const diagnostics = [];
-  const doc = view.docView.view.viewState.state.doc.text;
-  const docString = doc.join('\n');
+  const docString = textArr.join('\n');
   const xmlDoc = `<?xml version="1.0" encoding="UTF-8"?> ${docString}`;
 
   try {
@@ -39,10 +38,10 @@ const xmlSyntaxChecker = (view) => {
   } catch (error) {
     let errorStart = 0;
     for (let i = 0; i < error.line - 1; i++) {
-      errorStart += doc[i].length;
+      errorStart += textArr[i].length;
     }
     const errorLine = error.line;
-    const errorEnd = errorStart + doc[errorLine - 1].length;
+    const errorEnd = errorStart + textArr[errorLine - 1].length;
     diagnostics.push({
       from: errorStart,
       to: errorEnd,
@@ -71,7 +70,8 @@ export const createCodeMirrorDomNode = ({
         linter((view) => {
           let diagnostics = [];
           if (lang === 'xml') {
-            diagnostics = xmlSyntaxChecker(view);
+            const textArr = view.docView.view.viewState.state.doc.text;
+            diagnostics = xmlSyntaxChecker(textArr);
           }
           return diagnostics;
         }),

--- a/src/editors/sharedComponents/CodeEditor/index.test.jsx
+++ b/src/editors/sharedComponents/CodeEditor/index.test.jsx
@@ -116,20 +116,20 @@ describe('CodeEditor', () => {
   });
   describe('xmlSyntaxChecker', () => {
     it('returns empty array', () => {
-      const textArr = ['<problem>','<p>','this is some text','</p>','</problem>'];
+      const textArr = ['<problem>', '<p>', 'this is some text', '</p>', '</problem>'];
       const diagnostics = hooks.xmlSyntaxChecker(textArr);
       expect(diagnostics).toEqual([]);
     });
     it('returns an array with error object', () => {
-      const textArr = ['<problem>','<p>','<p>','this is some text','</p>','</problem>'];
+      const textArr = ['<problem>', '<p>', '<p>', 'this is some text', '</p>', '</problem>'];
       const expectedDiagnostics = hooks.xmlSyntaxChecker(textArr);
       const diagnostics = [{
         from: 9,
         to: 12,
         severity: 'error',
-        message: `SyntaxError: Expected that start and end tag must be identical but "<" found.`
+        message: 'SyntaxError: Expected that start and end tag must be identical but "<" found.',
       }];
-      expect(expectedDiagnostics).toEqual(diagnostics)
+      expect(expectedDiagnostics).toEqual(diagnostics);
     });
   });
   describe('Component', () => {

--- a/src/editors/sharedComponents/CodeEditor/index.test.jsx
+++ b/src/editors/sharedComponents/CodeEditor/index.test.jsx
@@ -114,24 +114,35 @@ describe('CodeEditor', () => {
       });
     });
   });
+
   describe('xmlSyntaxChecker', () => {
-    it('returns empty array', () => {
-      const textArr = ['<problem>', '<p>', 'this is some text', '</p>', '</problem>'];
-      const diagnostics = hooks.xmlSyntaxChecker(textArr);
-      expect(diagnostics).toEqual([]);
+    describe('lang equals html', () => {
+      it('returns empty array', () => {
+        const textArr = ['<problem>', '<p>', 'this is some text', '</p>', '</problem>'];
+        const diagnostics = hooks.syntaxChecker({ textArr, lang: 'html' });
+        expect(diagnostics).toEqual([]);
+      });
     });
-    it('returns an array with error object', () => {
-      const textArr = ['<problem>', '<p>', '<p>', 'this is some text', '</p>', '</problem>'];
-      const expectedDiagnostics = hooks.xmlSyntaxChecker(textArr);
-      const diagnostics = [{
-        from: 9,
-        to: 12,
-        severity: 'error',
-        message: 'SyntaxError: Expected that start and end tag must be identical but "<" found.',
-      }];
-      expect(expectedDiagnostics).toEqual(diagnostics);
+    describe('lang equals xml', () => {
+      it('returns empty array', () => {
+        const textArr = ['<problem>', '<p>', 'this is some text', '</p>', '</problem>'];
+        const diagnostics = hooks.syntaxChecker({ textArr, lang: 'xml' });
+        expect(diagnostics).toEqual([]);
+      });
+      it('returns an array with error object', () => {
+        const textArr = ['<problem>', '<p>', '<p>', 'this is some text', '</p>', '</problem>'];
+        const expectedDiagnostics = hooks.syntaxChecker({ textArr, lang: 'xml' });
+        const diagnostics = [{
+          from: 9,
+          to: 12,
+          severity: 'error',
+          message: 'SyntaxError: Expected that start and end tag must be identical but "<" found.',
+        }];
+        expect(expectedDiagnostics).toEqual(diagnostics);
+      });
     });
   });
+
   describe('Component', () => {
     describe('Snapshots', () => {
       const mockHideBtn = jest.fn().mockName('mockHidebtn');

--- a/src/editors/sharedComponents/CodeEditor/index.test.jsx
+++ b/src/editors/sharedComponents/CodeEditor/index.test.jsx
@@ -114,6 +114,24 @@ describe('CodeEditor', () => {
       });
     });
   });
+  describe('xmlSyntaxChecker', () => {
+    it('returns empty array', () => {
+      const textArr = ['<problem>','<p>','this is some text','</p>','</problem>'];
+      const diagnostics = hooks.xmlSyntaxChecker(textArr);
+      expect(diagnostics).toEqual([]);
+    });
+    it('returns an array with error object', () => {
+      const textArr = ['<problem>','<p>','<p>','this is some text','</p>','</problem>'];
+      const expectedDiagnostics = hooks.xmlSyntaxChecker(textArr);
+      const diagnostics = [{
+        from: 9,
+        to: 12,
+        severity: 'error',
+        message: `SyntaxError: Expected that start and end tag must be identical but "<" found.`
+      }];
+      expect(expectedDiagnostics).toEqual(diagnostics)
+    });
+  });
   describe('Component', () => {
     describe('Snapshots', () => {
       const mockHideBtn = jest.fn().mockName('mockHidebtn');


### PR DESCRIPTION
JIRA Ticket: [TNL-10609](https://2u-internal.atlassian.net/browse/TNL-10609)

When a course author is using the advanced problem editor and they have malformed xlm, there is a toast message that appears notifying them that their changes could not be saved and to try again later. This message does not clearly communicate to the author the actual error in the xlm. The PR adds a xlm linter plugin to code mirror. When the xlm is malformed, such as unclosed tags, a red squiggle will appear at the location of the error. On hover a message describing the error will appear.