### PR TITLE
fix: textArr join error in syntaxChecker

### DIFF
--- a/src/editors/sharedComponents/CodeEditor/hooks.js
+++ b/src/editors/sharedComponents/CodeEditor/hooks.js
@@ -30,7 +30,7 @@ export const cleanHTML = ({ initialText }) => {
 
 export const syntaxChecker = ({ textArr, lang }) => {
   const diagnostics = [];
-  if (lang === 'xml') {
+  if (lang === 'xml' && textArr) {
     const docString = textArr.join('\n');
     const xmlDoc = `<?xml version="1.0" encoding="UTF-8"?> ${docString}`;
 
@@ -70,7 +70,7 @@ export const createCodeMirrorDomNode = ({
         languageExtension,
         EditorView.lineWrapping,
         linter((view) => {
-          const textArr = view.docView.view.viewState.state.doc.text;
+          const textArr = view.state.doc.text;
           return syntaxChecker({ textArr, lang });
         }),
       ],

--- a/src/editors/sharedComponents/CodeEditor/index.test.jsx
+++ b/src/editors/sharedComponents/CodeEditor/index.test.jsx
@@ -123,6 +123,13 @@ describe('CodeEditor', () => {
         expect(diagnostics).toEqual([]);
       });
     });
+    describe('textArr is undefined', () => {
+      it('returns empty array', () => {
+        let textArr;
+        const diagnostics = hooks.syntaxChecker({ textArr, lang: 'html' });
+        expect(diagnostics).toEqual([]);
+      });
+    });
     describe('lang equals xml', () => {
       it('returns empty array', () => {
         const textArr = ['<problem>', '<p>', 'this is some text', '</p>', '</problem>'];


### PR DESCRIPTION
Currently is `textArr` is undefined, the `syntaxChecker` returns an error because `.join` can only run on arrays. This PR has the checker return an empty array if `textArr` is undefined.