### PR TITLE
fix: settings font size and spacing

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/CardSection.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/CardSection.jsx
@@ -11,7 +11,7 @@ const CardSection = ({
   if (!show) { return null; }
 
   return (
-    <Card.Section className="px-4 pb-4 pt-3">
+    <Card.Section>
       <Collapsible.Advanced
         open={!isCardCollapsibleOpen}
       >
@@ -22,7 +22,7 @@ const CardSection = ({
       <Collapsible.Advanced
         open={isCardCollapsibleOpen}
       >
-        <Collapsible.Body className="collapsible-body">
+        <Collapsible.Body className="collapsible-body text-primary-500 x-small">
           {children}
         </Collapsible.Body>
       </Collapsible.Advanced>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/CardSection.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/CardSection.test.jsx.snap
@@ -3,9 +3,7 @@
 exports[`CardSection closed 1`] = `""`;
 
 exports[`CardSection open 1`] = `
-<Card.Section
-  className="px-4 pb-4 pt-3"
->
+<Card.Section>
   <Advanced
     open={false}
   >
@@ -23,7 +21,7 @@ exports[`CardSection open 1`] = `
     open={true}
   >
     <Body
-      className="collapsible-body"
+      className="collapsible-body text-primary-500 x-small"
     >
       <h1>
         Section Text

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/GroupFeedbackRow.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/GroupFeedbackRow.jsx
@@ -44,7 +44,10 @@ export const GroupFeedbackRow = ({
             value={letter.id}
             checked={value.answers.indexOf(letter.id)}
             isValid={value.answers.indexOf(letter.id) >= 0}
-          >{letter.id}
+          >
+            <div className="x-small">
+              {letter.id}
+            </div>
           </Form.Checkbox>
         ))}
       </Row>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/__snapshots__/GroupFeedbackRow.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/__snapshots__/GroupFeedbackRow.test.jsx.snap
@@ -38,22 +38,38 @@ exports[`GroupFeedbackRow snapshot snapshot: renders hints row 1`] = `
         checked={-1}
         className="mr-4 mt-1"
         isValid={false}
-      />
+      >
+        <div
+          className="x-small"
+        />
+      </Form.Checkbox>
       <Form.Checkbox
         checked={-1}
         className="mr-4 mt-1"
         isValid={false}
-      />
+      >
+        <div
+          className="x-small"
+        />
+      </Form.Checkbox>
       <Form.Checkbox
         checked={-1}
         className="mr-4 mt-1"
         isValid={false}
-      />
+      >
+        <div
+          className="x-small"
+        />
+      </Form.Checkbox>
       <Form.Checkbox
         checked={-1}
         className="mr-4 mt-1"
         isValid={false}
-      />
+      >
+        <div
+          className="x-small"
+        />
+      </Form.Checkbox>
     </Row>
   </Component>
 </div>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/__snapshots__/index.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`HintsCard snapshot snapshot: renders groupFeedbacks setting card multip
   title="Group Feedback"
 >
   <div
-    className="py-3"
+    className="pb-3"
   >
     <FormattedMessage
       defaultMessage="Group feedback will appear when a student selects a specific set of answers."
@@ -89,7 +89,7 @@ exports[`HintsCard snapshot snapshot: renders groupFeedbacks setting card no gro
   title="Group Feedback"
 >
   <div
-    className="py-3"
+    className="pb-3"
   >
     <FormattedMessage
       defaultMessage="Group feedback will appear when a student selects a specific set of answers."
@@ -123,7 +123,7 @@ exports[`HintsCard snapshot snapshot: renders groupFeedbacks setting card one gr
   title="Group Feedback"
 >
   <div
-    className="py-3"
+    className="pb-3"
   >
     <FormattedMessage
       defaultMessage="Group feedback will appear when a student selects a specific set of answers."

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/GroupFeedback/index.jsx
@@ -22,7 +22,7 @@ export const GroupFeedbackCard = ({
       none={!groupFeedbacks.length}
       hasExpandableTextArea
     >
-      <div className="py-3">
+      <div className="pb-3">
         <FormattedMessage {...messages.groupFeedbackInputLabel} />
       </div>
       {groupFeedbacks.map((groupFeedback) => (

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RandomizationCard snapshot snapshot: renders reset true setting card 1`] = `
+exports[`RandomizationCard snapshot snapshot: renders randonmization setting card with randomization defined 1`] = `
 <SettingsOption
   className=""
   extraSections={Array []}
@@ -46,6 +46,40 @@ exports[`RandomizationCard snapshot snapshot: renders reset true setting card 1`
         value="per_student"
       >
         Per Student
+      </option>
+    </Form.Control>
+  </Form.Group>
+</SettingsOption>
+`;
+
+exports[`RandomizationCard snapshot snapshot: renders randonmization setting card with randomization null 1`] = `
+<SettingsOption
+  className=""
+  extraSections={Array []}
+  hasExpandableTextArea={false}
+  none={true}
+  summary="sUmmary"
+  title="Randomization"
+>
+  <div
+    className="mb-3"
+  >
+    {randomization, select,
+      null {No Python based randomization is present in this problem.}
+      other {Defines when to randomize the variables specified in the associated Python script. For problems that do not randomize values, specify "Never".}
+    }
+  </div>
+  <Form.Group>
+    <Form.Control
+      as="select"
+      onChange={[MockFunction randomizationCardHooks.handleChange]}
+      value={null}
+    >
+      <option
+        key="notApplicable"
+        value={null}
+      >
+        Not Applicable
       </option>
     </Form.Control>
   </Form.Group>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
@@ -10,15 +10,12 @@ exports[`RandomizationCard snapshot snapshot: renders reset true setting card 1`
   title="Randomization"
 >
   <div
-    className="halfSpacedMessage"
+    className="mb-3"
   >
-    <span>
-      <FormattedMessage
-        defaultMessage="Defines when to randomize the variables specified in the associated Python script. For problems that do not randomize values, specify \\"Never\\"."
-        description="Description of Possibilities for value in Randomization widget"
-        id="authoring.problemeditor.settings.randomization.SettingText"
-      />
-    </span>
+    {randomization, select,
+      null {No Python based randomization is present in this problem.}
+      other {Defines when to randomize the variables specified in the associated Python script. For problems that do not randomize values, specify "Never".}
+    }
   </div>
   <Form.Group>
     <Form.Control

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Form } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import SettingsOption from '../../SettingsOption';
@@ -20,10 +20,8 @@ export const RandomizationCard = ({
       summary={intl.formatMessage(summary.message)}
       none={!randomization}
     >
-      <div className="halfSpacedMessage">
-        <span>
-          <FormattedMessage {...messages.randomizationSettingText} />
-        </span>
+      <div className="mb-3">
+        {intl.formatMessage(messages.randomizationSettingText, { randomization })}
       </div>
 
       <Form.Group>
@@ -32,14 +30,23 @@ export const RandomizationCard = ({
           value={randomization}
           onChange={handleChange}
         >
-          {Object.values(RandomizationTypesKeys).map((randomizationType) => (
+          {randomization ? (
+            Object.values(RandomizationTypesKeys).map((randomizationType) => (
+              <option
+                key={randomizationType}
+                value={randomizationType}
+              >
+                {intl.formatMessage(RandomizationTypes[randomizationType])}
+              </option>
+            ))
+          ) : (
             <option
-              key={randomizationType}
-              value={randomizationType}
+              key="notApplicable"
+              value={randomization}
             >
-              {intl.formatMessage(RandomizationTypes[randomizationType])}
+              {intl.formatMessage(messages.noRandomizationSummary)}
             </option>
-          ))}
+          )}
         </Form.Control>
       </Form.Group>
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.test.jsx
@@ -32,8 +32,11 @@ describe('RandomizationCard', () => {
   });
 
   describe('snapshot', () => {
-    test('snapshot: renders reset true setting card', () => {
+    test('snapshot: renders randonmization setting card with randomization defined', () => {
       expect(shallow(<RandomizationCard {...props} />)).toMatchSnapshot();
+    });
+    test('snapshot: renders randonmization setting card with randomization null', () => {
+      expect(shallow(<RandomizationCard {...props} randomization={null} />)).toMatchSnapshot();
     });
   });
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/messages.js
@@ -9,12 +9,15 @@ const messages = defineMessages({
   },
   randomizationSettingText: {
     id: 'authoring.problemeditor.settings.randomization.SettingText',
-    defaultMessage: 'Defines when to randomize the variables specified in the associated Python script. For problems that do not randomize values, specify "Never".',
+    defaultMessage: `{randomization, select,
+      null {No Python based randomization is present in this problem.}
+      other {Defines when to randomize the variables specified in the associated Python script. For problems that do not randomize values, specify "Never".}
+    }`,
     description: 'Description of Possibilities for value in Randomization widget',
   },
   noRandomizationSummary: {
     id: 'authoring.problemeditor.settings.randomization.noRandomizationSummary',
-    defaultMessage: 'No Python based randomization is present in this problem.',
+    defaultMessage: 'Not Applicable',
     description: 'text shown when no randomization option is given',
   },
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -41,9 +41,9 @@ export const ScoringCard = ({
       summary={getScoringSummary(scoring.weight, scoring.attempts.number, scoring.attempts.unlimited)}
       className="scoringCard"
     >
-      <Form.Label className="mb-4">
+      <div className="mb-4">
         <FormattedMessage {...messages.scoringSettingsLabel} />
-      </Form.Label>
+      </div>
       <Form.Group>
         <Form.Control
           type="number"
@@ -71,7 +71,7 @@ export const ScoringCard = ({
           checked={scoring.attempts.unlimited}
           onChange={handleUnlimitedChange}
         >
-          <div className="small">
+          <div className="x-small">
             <FormattedMessage {...messages.unlimitedAttemptsCheckboxLabel} />
           </div>
         </Form.Checkbox>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/index.jsx
@@ -66,7 +66,7 @@ export const ToleranceCard = ({
          <FormattedMessage {...messages.toleranceAnswerRangeWarning} />
        </Alert>
        )}
-      <div className="halfSpacedMessage">
+      <div className="mb-3">
         <span>
           <FormattedMessage {...messages.toleranceSettingText} />
         </span>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
   summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
   title="Scoring"
 >
-  <Form.Label
+  <div
     className="mb-4"
   >
     <FormattedMessage
@@ -16,7 +16,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
-  </Form.Label>
+  </div>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -51,7 +51,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
       className="mt-3 decoration-control-label"
     >
       <div
-        className="small"
+        className="x-small"
       >
         <FormattedMessage
           defaultMessage="Unlimited attempts"
@@ -82,7 +82,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
   summary="{weight, plural, =0 {Ungraded} other {# points}} · Unlimited attempts"
   title="Scoring"
 >
-  <Form.Label
+  <div
     className="mb-4"
   >
     <FormattedMessage
@@ -90,7 +90,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
-  </Form.Label>
+  </div>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -125,7 +125,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
       className="mt-3 decoration-control-label"
     >
       <div
-        className="small"
+        className="x-small"
       >
         <FormattedMessage
           defaultMessage="Unlimited attempts"
@@ -156,7 +156,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
   summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
   title="Scoring"
 >
-  <Form.Label
+  <div
     className="mb-4"
   >
     <FormattedMessage
@@ -164,7 +164,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
-  </Form.Label>
+  </div>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -199,7 +199,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
       className="mt-3 decoration-control-label"
     >
       <div
-        className="small"
+        className="x-small"
       >
         <FormattedMessage
           defaultMessage="Unlimited attempts"


### PR DESCRIPTION
JIRA Ticket: [TNL-10451](https://2u-internal.atlassian.net/browse/TNL-10451)

This PR changes the font sizes in the opened view of the setting widgets from small to extra small and adjusts the spacing between text. Additionally, this PR fixes the text for the Randomization widget to match the expect experience when there is no randomization (null).

<img width="311" alt="Screenshot 2023-04-18 at 10 45 38 AM" src="https://user-images.githubusercontent.com/42981026/232814235-82430657-4c12-4ec2-82a6-2a5233e2b3ef.png">
<img width="311" alt="Screenshot 2023-04-18 at 10 45 13 AM" src="https://user-images.githubusercontent.com/42981026/232814257-4052b7ee-d21f-4000-805b-5edf5af3dcf3.png">

<img width="311" alt="Screenshot 2023-04-18 at 10 46 09 AM" src="https://user-images.githubusercontent.com/42981026/232814223-72709c93-d2ec-417d-bde6-6b3a1cdada56.png">
<img width="311" alt="Screenshot 2023-04-18 at 10 46 16 AM" src="https://user-images.githubusercontent.com/42981026/232814210-a4e9c180-dcf2-43e4-83d2-d5ffa3ed562e.png">