### PR TITLE
feat: tinyMCE formatting and parsing

### DIFF
--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -188,6 +188,22 @@ class ReactStateOLXParser {
   addQuestion() {
     const { question } = this.editorObject;
     const questionObject = this.questionParser.parse(question);
+    /* Removes block tags like <p> or <h1> that surround the <label> format.
+      Block tags are required by tinyMCE but have adverse effect on css in studio.
+      */
+    questionObject.forEach((tag, ind) => {
+      const tagName = Object.keys(tag)[0];
+      let label = null;
+      tag[tagName].forEach(subTag => {
+        const subTagName = Object.keys(subTag)[0];
+        if (subTagName === 'label') {
+          label = subTag;
+        }
+      });
+      if (label) {
+        questionObject[ind] = label;
+      }
+    });
     return questionObject;
   }
 

--- a/src/editors/containers/ProblemEditor/data/mockData/editorTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/editorTestData.js
@@ -52,7 +52,9 @@ export const dropdownWithFeedbackAndHints = {
 
 export const multipleChoiceWithFeedbackAndHints = {
   solution: '<p>You can add a solution</p>',
-  question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for multiple choice with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
+  question: `<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for multiple choice with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+    <p><label>Add the question text, or prompt, here. This text is required.</label></p>
+    <em>You can add an optional tip or note related to the prompt like this.</em>`,
   answers: {
     A: '<p>an incorrect answer</p>',
     B: '<p>the correct answer</p>',

--- a/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
+++ b/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
@@ -14,7 +14,7 @@ const pluginConfig = ({ isLibrary, placeholder, editorType }) => {
   const quickToolbar = editorType === 'expandable' ? plugins.quickbars : '';
   const inline = editorType === 'expandable';
   const toolbar = editorType !== 'expandable';
-  const defaultFormat = editorType === 'text' ? 'p' : 'div';
+  const defaultFormat = (editorType === 'question' || editorType === 'expandable') ? 'div' : 'p';
 
   return (
     StrictDict({
@@ -94,7 +94,7 @@ const pluginConfig = ({ isLibrary, placeholder, editorType }) => {
         convert_urls: false,
         placeholder,
         inline,
-        block_formats: 'Div=div;Paragraph=p;Header 1=h1;Header 2=h2;Header 3=h3;Header 4=h4;Header 5=h5;Header 6=h6;Preformatted=pre',
+        block_formats: 'Header 1=h1;Header 2=h2;Header 3=h3;Header 4=h4;Header 5=h5;Header 6=h6;Div=div;Paragraph=p;Preformatted=pre',
         forced_root_block: defaultFormat,
       },
     })

--- a/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
+++ b/src/editors/sharedComponents/TinyMceWidget/pluginConfig.js
@@ -14,6 +14,7 @@ const pluginConfig = ({ isLibrary, placeholder, editorType }) => {
   const quickToolbar = editorType === 'expandable' ? plugins.quickbars : '';
   const inline = editorType === 'expandable';
   const toolbar = editorType !== 'expandable';
+  const defaultFormat = editorType === 'text' ? 'p' : 'div';
 
   return (
     StrictDict({
@@ -93,6 +94,8 @@ const pluginConfig = ({ isLibrary, placeholder, editorType }) => {
         convert_urls: false,
         placeholder,
         inline,
+        block_formats: 'Div=div;Paragraph=p;Header 1=h1;Header 2=h2;Header 3=h3;Header 4=h4;Header 5=h5;Header 6=h6;Preformatted=pre',
+        forced_root_block: defaultFormat,
       },
     })
   );


### PR DESCRIPTION
Blocks that look like this:
<img width="845" alt="image" src="https://user-images.githubusercontent.com/56318341/233252841-2bd48692-8cce-412d-85d5-074b559264ed.png">

are turning into this when just opening and saving the block without changes:
<img width="845" alt="image" src="https://user-images.githubusercontent.com/56318341/233252812-c9fbacc5-2462-459a-93cf-c2bbc3ad650b.png">

The weird spacing and formatting is due to how studio displays text wrapped in a `<p>` block tag. Before the visual problem editor update, this text was not wrapped in `<p>`. However, tinyMCE requires text to be wrapped in block tags.

This PR fixes this by doing the following:
1. Have tinyMCE default to a `<div>` block tag instead of a `<p>` block tag. Allow selection of div block tag.
2. Strip the block tag around `<label>` tags.

Internal ticket: https://2u-internal.atlassian.net/browse/TNL-10632