### PR TITLE
feat: hint trash button should not be squished

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintRow.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/HintRow.jsx
@@ -28,12 +28,15 @@ export const HintRow = ({
         id={`hint-${id}`}
       />
     </Container>
-    <IconButton
-      src={DeleteOutline}
-      iconAs={Icon}
-      alt={intl.formatMessage(messages.settingsDeleteIconAltText)}
-      onClick={handleDelete}
-    />
+    <div className="d-flex flex-row flex-nowrap">
+      <IconButton
+        src={DeleteOutline}
+        iconAs={Icon}
+        alt={intl.formatMessage(messages.settingsDeleteIconAltText)}
+        onClick={handleDelete}
+        variant="primary"
+      />
+    </div>
   </ActionRow>
 );
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/HintRow.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/HintRow.test.jsx.snap
@@ -17,10 +17,15 @@ exports[`HintRow snapshot snapshot: renders hints row 1`] = `
       value="hint_1"
     />
   </Container>
-  <IconButton
-    alt="Delete answer"
-    iconAs="Icon"
-    onClick={[MockFunction]}
-  />
+  <div
+    className="d-flex flex-row flex-nowrap"
+  >
+    <IconButton
+      alt="Delete answer"
+      iconAs="Icon"
+      onClick={[MockFunction]}
+      variant="primary"
+    />
+  </div>
 </ActionRow>
 `;


### PR DESCRIPTION
In problem editor settings:

<img width="237" alt="image" src="https://user-images.githubusercontent.com/56318341/233472858-83eacaa3-45b4-46de-ab44-71d197f28b8c.png">

|
|
v

<img width="271" alt="image" src="https://user-images.githubusercontent.com/56318341/233473003-087db60f-f8c1-4af3-95bf-e4bf251b47ec.png">
