### PR TITLE
fix: settings helper text font size

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/CardSection.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/CardSection.jsx
@@ -11,7 +11,7 @@ const CardSection = ({
   if (!show) { return null; }
 
   return (
-    <Card.Section>
+    <Card.Section className="pt-0">
       <Collapsible.Advanced
         open={!isCardCollapsibleOpen}
       >

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/CardSection.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/CardSection.test.jsx.snap
@@ -3,7 +3,9 @@
 exports[`CardSection closed 1`] = `""`;
 
 exports[`CardSection open 1`] = `
-<Card.Section>
+<Card.Section
+  className="pt-0"
+>
   <Advanced
     open={false}
   >

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.scss
@@ -12,6 +12,9 @@
 
 .settingsWidget {
     margin-top: 40px;
+    .pgn__form-text {
+        font-size: small;
+    }
 }
 
 .resetCard {


### PR DESCRIPTION
JIRA Ticket: [TNL-10451](https://2u-internal.atlassian.net/browse/TNL-10451)

This PR is an extension of [PR 308](https://github.com/openedx/frontend-lib-content-components/pull/308). The helper text font size and padding on the setting widgets did not populate in stage. Something causes the behaviors for `Collapsible` components font inheritance and padding to differ between the openedx and edx themes.