### PR TITLE
feat: remove layered button

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -110,12 +110,10 @@ export const AnswerOption = ({
         </Collapsible.Body>
       </div>
       <div className="d-flex flex-row flex-nowrap">
-        <Collapsible.Trigger>
-          <IconButton
+        <Collapsible.Trigger aria-label="Toggle feedback" className="btn-icon btn-icon-primary btn-icon-md align-items-center">
+          <Icon
             src={FeedbackOutline}
-            iconAs={Icon}
             alt={intl.formatMessage(messages.feedbackToggleIconAltText)}
-            variant="primary"
           />
         </Collapsible.Trigger>
         <IconButton

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/__snapshots__/AnswerOption.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/__snapshots__/AnswerOption.test.jsx.snap
@@ -58,11 +58,12 @@ exports[`AnswerOption render snapshot: renders correct option with feedback 1`] 
   <div
     className="d-flex flex-row flex-nowrap"
   >
-    <Trigger>
-      <IconButton
+    <Trigger
+      aria-label="Toggle feedback"
+      className="btn-icon btn-icon-primary btn-icon-md align-items-center"
+    >
+      <Icon
         alt="Toggle feedback"
-        iconAs="Icon"
-        variant="primary"
       />
     </Trigger>
     <IconButton
@@ -134,11 +135,12 @@ exports[`AnswerOption render snapshot: renders correct option with numeric input
   <div
     className="d-flex flex-row flex-nowrap"
   >
-    <Trigger>
-      <IconButton
+    <Trigger
+      aria-label="Toggle feedback"
+      className="btn-icon btn-icon-primary btn-icon-md align-items-center"
+    >
+      <Icon
         alt="Toggle feedback"
-        iconAs="Icon"
-        variant="primary"
       />
     </Trigger>
     <IconButton
@@ -225,11 +227,12 @@ exports[`AnswerOption render snapshot: renders correct option with numeric input
   <div
     className="d-flex flex-row flex-nowrap"
   >
-    <Trigger>
-      <IconButton
+    <Trigger
+      aria-label="Toggle feedback"
+      className="btn-icon btn-icon-primary btn-icon-md align-items-center"
+    >
+      <Icon
         alt="Toggle feedback"
-        iconAs="Icon"
-        variant="primary"
       />
     </Trigger>
     <IconButton
@@ -302,11 +305,12 @@ exports[`AnswerOption render snapshot: renders correct option with selected unse
   <div
     className="d-flex flex-row flex-nowrap"
   >
-    <Trigger>
-      <IconButton
+    <Trigger
+      aria-label="Toggle feedback"
+      className="btn-icon btn-icon-primary btn-icon-md align-items-center"
+    >
+      <Icon
         alt="Toggle feedback"
-        iconAs="Icon"
-        variant="primary"
       />
     </Trigger>
     <IconButton


### PR DESCRIPTION
Having a button inside a button makes the button content focusable, not just the button, allowing users to click the wrong thing. This removes that but keeps the styling.

![Screenshot 2023-04-21 at 9 56 44 AM](https://user-images.githubusercontent.com/49422820/233654701-4e774a12-072b-46f7-acfe-b783fbf4ab27.png)
