### PR TITLE
fix: advanced editor not saving

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
@@ -126,7 +126,7 @@ export const getContent = ({
   lmsEndpointUrl,
 }) => {
   const problem = problemState;
-  const hasNoAnswers = checkForNoAnswers({
+  const hasNoAnswers = isAdvancedProblemType ? false : checkForNoAnswers({
     problem,
     openNoAnswerModal,
   });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
@@ -190,17 +190,16 @@ describe('EditProblemView hooks parseState', () => {
     });
   });
   describe('getContent', () => {
-    const problemState = { problemType: ProblemTypeKeys.NUMERIC, answers: [{ id: 'A', title: 'problem', correct: true }] };
-    const isAdvancedProblem = false;
     const assets = {};
     const lmsEndpointUrl = 'someUrl';
     const editorRef = refMock;
     const openNoAnswerModal = jest.fn();
 
-    test('default save and returns parseState data', () => {
+    test('default visual save and returns parseState data', () => {
+      const problemState = { problemType: ProblemTypeKeys.NUMERIC, answers: [{ id: 'A', title: 'problem', correct: true }] };
       const content = hooks.getContent({
+        isAdvancedProblemType: false,
         problemState,
-        isAdvancedProblem,
         editorRef,
         assets,
         lmsEndpointUrl,
@@ -211,11 +210,26 @@ describe('EditProblemView hooks parseState', () => {
         settings: undefined,
       });
     });
-    test('returns null', () => {
-      const problem = { ...problemState, answers: [{ id: 'A', title: '', correct: true }] };
+    test('default advanced save and returns parseState data', () => {
+      const problemState = { problemType: ProblemTypeKeys.ADVANCED };
       const content = hooks.getContent({
-        problemState: problem,
-        isAdvancedProblem,
+        isAdvancedProblemType: true,
+        problemState,
+        editorRef,
+        assets,
+        lmsEndpointUrl,
+        openNoAnswerModal,
+      });
+      expect(content).toEqual({
+        olx: 'rawOLX',
+        settings: undefined,
+      });
+    });
+    test('returns null', () => {
+      const problemState = { problemType: ProblemTypeKeys.NUMERIC, answers: [{ id: 'A', title: '', correct: true }] };
+      const content = hooks.getContent({
+        isAdvancedProblemType: false,
+        problemState,
         editorRef,
         assets,
         lmsEndpointUrl,


### PR DESCRIPTION
JIRA Ticket: [TNL-10647](https://2u-internal.atlassian.net/browse/TNL-10647)

The addition of the no answer alert in the visual editor created a bug in the advanced editor that prevented the editor from being saved. The editor was trying to find answers that did not exist. This PR adds a check if the problem editor is in the advanced view. If it is in the advanced editor, it will skip over the no answer check.