### PR TITLE
feat: default randomization to never

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
@@ -24,16 +24,16 @@ exports[`RandomizationCard snapshot snapshot: renders randonmization setting car
       value="sOmE_vAlUE"
     >
       <option
-        key="always"
-        value="always"
-      >
-        Always
-      </option>
-      <option
         key="never"
         value="never"
       >
         Never
+      </option>
+      <option
+        key="always"
+        value="always"
+      >
+        Always
       </option>
       <option
         key="on_reset"
@@ -76,10 +76,28 @@ exports[`RandomizationCard snapshot snapshot: renders randonmization setting car
       value={null}
     >
       <option
-        key="notApplicable"
-        value={null}
+        key="never"
+        value="never"
       >
-        Not Applicable
+        Never
+      </option>
+      <option
+        key="always"
+        value="always"
+      >
+        Always
+      </option>
+      <option
+        key="on_reset"
+        value="on_reset"
+      >
+        On Reset
+      </option>
+      <option
+        key="per_student"
+        value="per_student"
+      >
+        Per Student
       </option>
     </Form.Control>
   </Form.Group>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
-import messages from './messages';
-import { RandomizationTypes } from '../../../../../../../data/constants/problem';
+import { RandomizationTypes, RandomizationTypesKeys } from '../../../../../../../data/constants/problem';
 import * as module from './hooks';
 
 export const state = {
@@ -8,10 +7,13 @@ export const state = {
 };
 
 export const useRandomizationSettingStatus = ({ randomization, updateSettings }) => {
-  const [summary, setSummary] = module.state.summary({ message: messages.noRandomizationSummary, values: {} });
+  const [summary, setSummary] = module.state.summary({
+    message: RandomizationTypes[RandomizationTypesKeys.NEVER],
+    values: {},
+  });
   useEffect(() => {
     setSummary({
-      message: randomization ? RandomizationTypes[randomization] : messages.noRandomizationSummary,
+      message: randomization ? RandomizationTypes[randomization] : RandomizationTypes[RandomizationTypesKeys.NEVER],
     });
   }, [randomization]);
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/hooks.test.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { MockUseState } from '../../../../../../../../testUtils';
-import messages from './messages';
 import * as hooks from './hooks';
+import { RandomizationTypes, RandomizationTypesKeys } from '../../../../../../../data/constants/problem';
 
 jest.mock('react', () => {
   const updateState = jest.fn();
@@ -36,7 +36,7 @@ describe('Problem settings hooks', () => {
       output = hooks.useRandomizationSettingStatus({ randomization, updateSettings });
     });
     test('test default state is false', () => {
-      expect(output.summary).toEqual({ message: messages.noRandomizationSummary, values: {} });
+      expect(output.summary).toEqual({ message: RandomizationTypes[RandomizationTypesKeys.NEVER], values: {} });
     });
     test('test showAdvancedCards sets state to true', () => {
       const mockEvent = { target: { value: 'sOmE_otheR_ValUe' } };

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.jsx
@@ -30,7 +30,7 @@ export const RandomizationCard = ({
           value={randomization}
           onChange={handleChange}
         >
-          {randomization ? (
+          {
             Object.values(RandomizationTypesKeys).map((randomizationType) => (
               <option
                 key={randomizationType}
@@ -39,14 +39,7 @@ export const RandomizationCard = ({
                 {intl.formatMessage(RandomizationTypes[randomizationType])}
               </option>
             ))
-          ) : (
-            <option
-              key="notApplicable"
-              value={randomization}
-            >
-              {intl.formatMessage(messages.noRandomizationSummary)}
-            </option>
-          )}
+          }
         </Form.Control>
       </Form.Group>
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/messages.js
@@ -15,11 +15,6 @@ const messages = defineMessages({
     }`,
     description: 'Description of Possibilities for value in Randomization widget',
   },
-  noRandomizationSummary: {
-    id: 'authoring.problemeditor.settings.randomization.noRandomizationSummary',
-    defaultMessage: 'Not Applicable',
-    description: 'text shown when no randomization option is given',
-  },
 });
 
 export default messages;

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -191,8 +191,8 @@ export const ShowAnswerTypes = StrictDict({
 });
 
 export const RandomizationTypesKeys = StrictDict({
-  ALWAYS: 'always',
   NEVER: 'never',
+  ALWAYS: 'always',
   ONRESET: 'on_reset',
   PERSTUDENT: 'per_student',
 });


### PR DESCRIPTION
In the problem editor, the randomization setting is typically used for randomization with a python script. However, the setting is also needed for the shuffle answer functionality. This PR ensures that the randomization setting can be configured for all problems and defaults the setting to 'never'.

Jira: https://2u-internal.atlassian.net/browse/TNL-10652