### PR TITLE
feat: remove custom css with paragon upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@edx/frontend-build": "^11.0.2",
         "@edx/frontend-platform": "2.4.0",
-        "@edx/paragon": "^20.28.0",
+        "@edx/paragon": "^20.32.0",
         "@edx/reactifex": "^2.1.1",
         "@testing-library/dom": "^8.13.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -4283,9 +4283,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.28.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.28.0.tgz",
-      "integrity": "sha512-ydM3DK2aqdYRXyNEC0+P9tFpckH9kx/b/HtgSGrNMreRGAJ90QNkI/zAdlwj8U9mmoaE9jfIpjsO4g84qnrk1A==",
+      "version": "20.32.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.32.0.tgz",
+      "integrity": "sha512-d2rlYoWyRLvzPMo7MfCojqU/Qvk0cXnBpXW7aOOOQYhTvC3m3Y3yNWjQ8DJhbnWyL1tFEjZG2mjlgXHDHBqtLQ==",
       "dev": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
@@ -4301,6 +4301,7 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -28558,6 +28559,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "dev": true,
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -38061,9 +38072,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "20.28.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.28.0.tgz",
-      "integrity": "sha512-ydM3DK2aqdYRXyNEC0+P9tFpckH9kx/b/HtgSGrNMreRGAJ90QNkI/zAdlwj8U9mmoaE9jfIpjsO4g84qnrk1A==",
+      "version": "20.32.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.32.0.tgz",
+      "integrity": "sha512-d2rlYoWyRLvzPMo7MfCojqU/Qvk0cXnBpXW7aOOOQYhTvC3m3Y3yNWjQ8DJhbnWyL1tFEjZG2mjlgXHDHBqtLQ==",
       "dev": true,
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
@@ -38079,6 +38090,7 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -56812,6 +56824,13 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "dev": true,
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@edx/frontend-build": "^11.0.2",
     "@edx/frontend-platform": "2.4.0",
-    "@edx/paragon": "^20.28.0",
+    "@edx/paragon": "^20.32.0",
     "@edx/reactifex": "^2.1.1",
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
@@ -37,18 +37,3 @@
     }
   }
 }
-
-// overrides paragon in order to make checked radio and checkboxes green
-$checked-color: '%230D7D4D';
-
-.pgn__form-radio.pgn__form-control-valid input {
-  &:checked {
-    background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='#{$checked-color}'/></svg>")
-  }
-}
-
-.pgn__form-checkbox.pgn__form-control-valid input {
-  &:checked {
-    background-image: url("data:image/svg+xml,<svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M21 3H3V21H21V3ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z' fill='#{$checked-color}'/></svg>");
-  }
-}

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -14,7 +14,7 @@
         "@edx/frontend-build": "^11.0.0",
         "@edx/frontend-lib-content-components": "file:..",
         "@edx/frontend-platform": "2.5.1",
-        "@edx/paragon": "^20.28.0",
+        "@edx/paragon": "^20.32.0",
         "core-js": "^3.21.1",
         "dotenv": "^16.0.0",
         "prop-types": "^15.5.10",
@@ -32,6 +32,7 @@
       "dependencies": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lint": "^6.2.1",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
         "@reduxjs/toolkit": "^1.8.1",
@@ -41,6 +42,8 @@
         "codemirror": "^6.0.0",
         "fast-xml-parser": "^4.0.10",
         "lodash-es": "^4.17.21",
+        "moment": "^2.29.4",
+        "moment-shortformat": "^2.1.0",
         "react-redux": "^7.2.8",
         "react-responsive": "8.2.0",
         "react-transition-group": "4.4.2",
@@ -52,13 +55,16 @@
         "reselect": "^4.1.5",
         "tinymce": "^5.10.4",
         "video-react": "^0.15.0",
-        "video.js": "^7.18.1"
+        "video.js": "^7.18.1",
+        "xmlchecker": "^0.1.0"
       },
       "devDependencies": {
         "@edx/frontend-build": "^11.0.2",
         "@edx/frontend-platform": "2.4.0",
-        "@edx/paragon": "^20.28.0",
+        "@edx/paragon": "^20.32.0",
+        "@edx/reactifex": "^2.1.1",
         "@testing-library/dom": "^8.13.0",
+        "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.1",
         "@testing-library/user-event": "^13.5.0",
         "codecov": "3.8.3",
@@ -73,7 +79,6 @@
         "react-dom": "16.14.0",
         "react-router-dom": "5.3.0",
         "react-test-renderer": "16.14.0",
-        "reactifex": "1.1.1",
         "redux-saga": "1.1.3",
         "webpack-cli": "4.10.0"
       },
@@ -1988,9 +1993,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.28.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.28.0.tgz",
-      "integrity": "sha512-ydM3DK2aqdYRXyNEC0+P9tFpckH9kx/b/HtgSGrNMreRGAJ90QNkI/zAdlwj8U9mmoaE9jfIpjsO4g84qnrk1A==",
+      "version": "20.32.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.32.0.tgz",
+      "integrity": "sha512-d2rlYoWyRLvzPMo7MfCojqU/Qvk0cXnBpXW7aOOOQYhTvC3m3Y3yNWjQ8DJhbnWyL1tFEjZG2mjlgXHDHBqtLQ==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -2005,6 +2010,7 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -16279,6 +16285,15 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -22129,13 +22144,16 @@
       "requires": {
         "@codemirror/lang-html": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lint": "^6.2.1",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
         "@edx/frontend-build": "^11.0.2",
         "@edx/frontend-platform": "2.4.0",
-        "@edx/paragon": "^20.28.0",
+        "@edx/paragon": "^20.32.0",
+        "@edx/reactifex": "^2.1.1",
         "@reduxjs/toolkit": "^1.8.1",
         "@testing-library/dom": "^8.13.0",
+        "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.1",
         "@testing-library/user-event": "^13.5.0",
         "@tinymce/tinymce-react": "^3.14.0",
@@ -22151,6 +22169,8 @@
         "fast-xml-parser": "^4.0.10",
         "husky": "7.0.4",
         "lodash-es": "^4.17.21",
+        "moment": "^2.29.4",
+        "moment-shortformat": "^2.1.0",
         "prop-types": "15.7.2",
         "react": "16.14.0",
         "react-dom": "16.14.0",
@@ -22159,7 +22179,6 @@
         "react-router-dom": "5.3.0",
         "react-test-renderer": "16.14.0",
         "react-transition-group": "4.4.2",
-        "reactifex": "1.1.1",
         "redux": "4.1.2",
         "redux-devtools-extension": "^2.13.9",
         "redux-logger": "^3.0.6",
@@ -22170,7 +22189,8 @@
         "tinymce": "^5.10.4",
         "video-react": "^0.15.0",
         "video.js": "^7.18.1",
-        "webpack-cli": "4.10.0"
+        "webpack-cli": "4.10.0",
+        "xmlchecker": "^0.1.0"
       }
     },
     "@edx/frontend-platform": {
@@ -22231,9 +22251,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "20.28.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.28.0.tgz",
-      "integrity": "sha512-ydM3DK2aqdYRXyNEC0+P9tFpckH9kx/b/HtgSGrNMreRGAJ90QNkI/zAdlwj8U9mmoaE9jfIpjsO4g84qnrk1A==",
+      "version": "20.32.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.32.0.tgz",
+      "integrity": "sha512-d2rlYoWyRLvzPMo7MfCojqU/Qvk0cXnBpXW7aOOOQYhTvC3m3Y3yNWjQ8DJhbnWyL1tFEjZG2mjlgXHDHBqtLQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -22248,6 +22268,7 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -32851,6 +32872,12 @@
       "requires": {
         "@babel/runtime": "^7.12.13"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.0",

--- a/www/package.json
+++ b/www/package.json
@@ -15,7 +15,7 @@
     "@edx/frontend-build": "^11.0.0",
     "@edx/frontend-lib-content-components": "file:..",
     "@edx/frontend-platform": "2.5.1",
-    "@edx/paragon": "^20.28.0",
+    "@edx/paragon": "^20.32.0",
     "core-js": "^3.21.1",
     "dotenv": "^16.0.0",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
JIRA Ticket: [TNL-10618](https://2u-internal.atlassian.net/browse/TNL-10618)

Removes custom css for green checkboxes/radios when selected. This functionality is now supported by Paragon.