### PR TITLE
feat: page errors indefinitely with no ancestor

### DIFF
--- a/src/editors/data/services/cms/urls.js
+++ b/src/editors/data/services/cms/urls.js
@@ -3,7 +3,7 @@ export const libraryV1 = ({ studioEndpointUrl, learningContextId }) => (
 );
 
 export const unit = ({ studioEndpointUrl, unitUrl }) => (
-  `${studioEndpointUrl}/container/${unitUrl.data.ancestors[0].id}`
+  `${studioEndpointUrl}/container/${unitUrl.data.ancestors[0]?.id}`
 );
 
 export const returnUrl = ({ studioEndpointUrl, unitUrl, learningContextId }) => {


### PR DESCRIPTION
This PR keeps the page from erroring and looping when no ancestor pages come back in the response.