### PR TITLE
feat: allow social share widget in libraries

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/__snapshots__/index.test.jsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SocialShareWidget rendered with videoSharingEnabled false should return null 1`] = `""`;
-
 exports[`SocialShareWidget rendered with videoSharingEnabled false with default props should return null 1`] = `""`;
 
 exports[`SocialShareWidget rendered with videoSharingEnabled false with videoSharingEnabledForAll false and isLibrary true should return null 1`] = `""`;
@@ -99,5 +97,3 @@ exports[`SocialShareWidget rendered with videoSharingEnabled true and allowVideo
   </div>
 </injectIntl(ShimmedIntlComponent)>
 `;
-
-exports[`SocialShareWidget rendered with with videoSharingEnabled false should return null 1`] = `""`;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SocialShareWidget rendered with videoSharingEnabled false should return null 1`] = `""`;
+
+exports[`SocialShareWidget rendered with videoSharingEnabled false with default props should return null 1`] = `""`;
+
+exports[`SocialShareWidget rendered with videoSharingEnabled false with videoSharingEnabledForAll false and isLibrary true should return null 1`] = `""`;
+
+exports[`SocialShareWidget rendered with videoSharingEnabled false with videoSharingEnabledForCourse and isLibrary false and videoSharingEnabledForAll true should return null 1`] = `""`;
+
 exports[`SocialShareWidget rendered with videoSharingEnabled true and allowVideoSharing value equals false should have subtitle with text that reads Enabled 1`] = `
 <injectIntl(ShimmedIntlComponent)
   fontSize="x-small"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
@@ -23,11 +23,15 @@ export const SocialShareWidget = ({
   intl,
   // redux
   allowVideoSharing,
+  isLibrary,
+  videoSharingEnabledForAll,
   videoSharingEnabledForCourse,
   videoSharingLearnMoreLink,
   updateField,
 }) => {
   const isSetByCourse = allowVideoSharing.level === 'course';
+  const videoSharingEnabled = isLibrary ? videoSharingEnabledForAll : videoSharingEnabledForCourse;
+  const learnMoreLink = videoSharingLearnMoreLink || 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/developing_course/social_sharing.html';
   const getSubtitle = () => {
     if (allowVideoSharing.value) {
       return intl.formatMessage(messages.enabledSubtitle);
@@ -35,7 +39,7 @@ export const SocialShareWidget = ({
     return intl.formatMessage(messages.disabledSubtitle);
   };
 
-  return (videoSharingEnabledForCourse ? (
+  return (videoSharingEnabled ? (
     <CollapsibleFormWidget
       fontSize="x-small"
       title={intl.formatMessage(messages.title)}
@@ -59,16 +63,18 @@ export const SocialShareWidget = ({
           {intl.formatMessage(messages.socialSharingCheckboxLabel)}
         </div>
       </Form.Checkbox>
-      <div>
-        <FormattedMessage {...messages.overrideSocialSharingNote} />
-      </div>
+      {!isLibrary && (
+        <div>
+          <FormattedMessage {...messages.overrideSocialSharingNote} />
+        </div>
+      )}
       {isSetByCourse && (
         <div>
           <FormattedMessage {...messages.disclaimerSettingLocation} />
         </div>
       )}
       <div className="mt-3">
-        <Hyperlink className="text-primary-500" destination={videoSharingLearnMoreLink} target="_blank">
+        <Hyperlink className="text-primary-500" destination={learnMoreLink} target="_blank">
           {intl.formatMessage(messages.learnMoreLinkLabel)}
         </Hyperlink>
       </div>
@@ -82,6 +88,7 @@ SocialShareWidget.defaultProps = {
     value: false,
   },
   videoSharingEnabledForCourse: false,
+  videoSharingEnabledForAll: false,
 };
 
 SocialShareWidget.propTypes = {
@@ -92,6 +99,8 @@ SocialShareWidget.propTypes = {
     level: PropTypes.string.isRequired,
     value: PropTypes.bool.isRequired,
   }),
+  isLibrary: PropTypes.bool.isRequired,
+  videoSharingEnabledForAll: PropTypes.bool,
   videoSharingEnabledForCourse: PropTypes.bool,
   videoSharingLearnMoreLink: PropTypes.string.isRequired,
   updateField: PropTypes.func.isRequired,
@@ -99,7 +108,9 @@ SocialShareWidget.propTypes = {
 
 export const mapStateToProps = (state) => ({
   allowVideoSharing: selectors.video.allowVideoSharing(state),
+  isLibrary: selectors.app.isLibrary(state),
   videoSharingLearnMoreLink: selectors.video.videoSharingLearnMoreLink(state),
+  videoSharingEnabledForAll: selectors.video.videoSharingEnabledForAll(state),
   videoSharingEnabledForCourse: selectors.video.videoSharingEnabledForCourse(state),
 });
 

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.test.jsx
@@ -22,8 +22,12 @@ jest.mock('../../../../../../data/redux', () => ({
     },
   },
   selectors: {
+    app: {
+      isLibrary: jest.fn(state => ({ isLibrary: state })),
+    },
     video: {
       allowVideoSharing: jest.fn(state => ({ allowVideoSharing: state })),
+      videoSharingEnabledForAll: jest.fn(state => ({ videoSharingEnabledForAll: state })),
       videoSharingEnabledForCourse: jest.fn(state => ({ videoSharingEnabledForCourse: state })),
       videoSharingLearnMoreLink: jest.fn(state => ({ videoSharingLearnMoreLink: state })),
     },
@@ -35,6 +39,8 @@ describe('SocialShareWidget', () => {
     title: 'tiTLE',
     intl: { formatMessage },
     videoSharingEnabledForCourse: false,
+    videoSharingEnabledForAll: false,
+    isLibrary: false,
     allowVideoSharing: {
       level: 'block',
       value: false,
@@ -43,10 +49,24 @@ describe('SocialShareWidget', () => {
     updateField: jest.fn().mockName('args.updateField'),
   };
 
-  describe('rendered with with videoSharingEnabled false', () => {
-    it('should return null', () => {
-      const wrapper = shallow(<SocialShareWidget {...props} />);
-      expect(wrapper).toMatchSnapshot();
+  describe('rendered with videoSharingEnabled false', () => {
+    describe('with default props', () => {
+      it('should return null', () => {
+        const wrapper = shallow(<SocialShareWidget {...props} />);
+        expect(wrapper).toMatchSnapshot();
+      });
+    });
+    describe('with videoSharingEnabledForAll false and isLibrary true', () => {
+      it('should return null', () => {
+        const wrapper = shallow(<SocialShareWidget {...props} isLibrary />);
+        expect(wrapper).toMatchSnapshot();
+      });
+    });
+    describe('with videoSharingEnabledForCourse and isLibrary false and videoSharingEnabledForAll true', () => {
+      it('should return null', () => {
+        const wrapper = shallow(<SocialShareWidget {...props} videoSharingEnabledForAll />);
+        expect(wrapper).toMatchSnapshot();
+      });
     });
   });
 
@@ -84,6 +104,31 @@ describe('SocialShareWidget', () => {
           expect(formattedMessages.length).toEqual(2);
           expect(formattedMessages.at(0)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
           expect(formattedMessages.at(1)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
+        });
+        it('should have checkbox disabled prop equal false', () => {
+          const disabledCheckbox = wrapper.children().at(1).prop('disabled');
+          expect(disabledCheckbox).toEqual(false);
+        });
+      });
+      describe('isLibrary equals true', () => {
+        const wrapper = shallow(<SocialShareWidget
+          {...props}
+          videoSharingEnabledForAll
+          isLibrary
+          allowVideoSharing={{
+            level: 'block',
+            value: true,
+          }}
+        />);
+        it('should not have setting location message', () => {
+          const formattedMessages = wrapper.find('FormattedMessage');
+          expect(formattedMessages.length).toEqual(1);
+          expect(formattedMessages.at(0)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
+        });
+        it('should not have override note', () => {
+          const formattedMessages = wrapper.find('FormattedMessage');
+          expect(formattedMessages.length).toEqual(1);
+          expect(formattedMessages.at(0)).not.toEqual(messages.overrideSocialSharingNote.defaultMessage);
         });
         it('should have checkbox disabled prop equal false', () => {
           const disabledCheckbox = wrapper.children().at(1).prop('disabled');
@@ -143,6 +188,31 @@ describe('SocialShareWidget', () => {
           expect(disabledCheckbox).toEqual(false);
         });
       });
+      describe('isLibrary equals true', () => {
+        const wrapper = shallow(<SocialShareWidget
+          {...props}
+          videoSharingEnabledForAll
+          isLibrary
+          allowVideoSharing={{
+            level: 'block',
+            value: false,
+          }}
+        />);
+        it('should not have setting location message', () => {
+          const formattedMessages = wrapper.find('FormattedMessage');
+          expect(formattedMessages.length).toEqual(1);
+          expect(formattedMessages.at(0)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
+        });
+        it('should not have override note', () => {
+          const formattedMessages = wrapper.find('FormattedMessage');
+          expect(formattedMessages.length).toEqual(1);
+          expect(formattedMessages.at(0)).not.toEqual(messages.overrideSocialSharingNote.defaultMessage);
+        });
+        it('should have checkbox disabled prop equal false', () => {
+          const disabledCheckbox = wrapper.children().at(1).prop('disabled');
+          expect(disabledCheckbox).toEqual(false);
+        });
+      });
       it('should have subtitle with text that reads Enabled', () => {
         const wrapper = shallow(<SocialShareWidget
           {...props}
@@ -160,6 +230,11 @@ describe('SocialShareWidget', () => {
   });
   describe('mapStateToProps', () => {
     const testState = { A: 'pple', B: 'anana', C: 'ucumber' };
+    test('isLibrary from app.isLibrary', () => {
+      expect(
+        mapStateToProps(testState).isLibrary,
+      ).toEqual(selectors.app.isLibrary(testState));
+    });
     test('allowVideoSharing from video.allowVideoSharing', () => {
       expect(
         mapStateToProps(testState).allowVideoSharing,
@@ -169,6 +244,11 @@ describe('SocialShareWidget', () => {
       expect(
         mapStateToProps(testState).videoSharingEnabledForCourse,
       ).toEqual(selectors.video.videoSharingEnabledForCourse(testState));
+    });
+    test('videoSharingEnabledForAll from video.videoSharingEnabledForAll', () => {
+      expect(
+        mapStateToProps(testState).videoSharingEnabledForAll,
+      ).toEqual(selectors.video.videoSharingEnabledForAll(testState));
     });
     test('videoSharingLearnMoreLink from video.videoSharingLearnMoreLink', () => {
       expect(

--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -67,6 +67,7 @@ export const loadVideoData = () => (dispatch, getState) => {
   dispatch(requests.fetchVideoFeatures({
     onSuccess: (response) => dispatch(actions.video.updateField({
       allowThumbnailUpload: response.data.allowThumbnailUpload,
+      videoSharingEnabledForAll: response.data.videoSharingEnabled,
     })),
   }));
   const youTubeId = parseYoutubeId(videoUrl);

--- a/src/editors/data/redux/thunkActions/video.test.js
+++ b/src/editors/data/redux/thunkActions/video.test.js
@@ -53,6 +53,7 @@ const mockAllowTranscriptImport = { data: { command: 'import' } };
 const mockVideoFeatures = {
   data: {
     allowThumbnailUpload: 'soMEbOolEAn',
+    videoSharingEnabled: 'soMEbOolEAn',
   },
 };
 
@@ -190,6 +191,7 @@ describe('video thunkActions', () => {
       dispatchedAction1.fetchVideoFeatures.onSuccess(mockVideoFeatures);
       expect(dispatch).toHaveBeenCalledWith(actions.video.updateField({
         allowThumbnailUpload: mockVideoFeatures.data.allowThumbnailUpload,
+        videoSharingEnabledForAll: mockVideoFeatures.data.videoSharingEnabled,
       }));
       dispatch.mockClear();
       dispatchedAction2.checkTranscriptsForImport.onSuccess(mockAllowTranscriptImport);

--- a/src/editors/data/redux/video/reducer.js
+++ b/src/editors/data/redux/video/reducer.js
@@ -14,6 +14,7 @@ const initialState = {
     level: 'block',
     value: false,
   },
+  videoSharingEnabledForAll: false,
   videoSharingEnabledForCourse: false,
   videoSharingLearnMoreLink: '',
   thumbnail: null,

--- a/src/editors/data/redux/video/selectors.js
+++ b/src/editors/data/redux/video/selectors.js
@@ -19,6 +19,7 @@ export const simpleSelectors = [
   stateKeys.allowVideoDownloads,
   stateKeys.videoSharingEnabledForCourse,
   stateKeys.videoSharingLearnMoreLink,
+  stateKeys.videoSharingEnabledForAll,
   stateKeys.allowVideoSharing,
   stateKeys.thumbnail,
   stateKeys.transcripts,


### PR DESCRIPTION
Follow-up to [PR 323](https://github.com/openedx/frontend-lib-content-components/pull/323). This PR is dependent on [edx-plaform PR](). This change makes the social share widget available in libraries. The social share widget is on a per-video basis.