### PR TITLE
fix: expandable textarea should save on blur

### DIFF
--- a/src/editors/data/services/cms/api.js
+++ b/src/editors/data/services/cms/api.js
@@ -288,7 +288,7 @@ export const processLicense = (licenseType, licenseDetails) => {
 
 export const checkMockApi = (key) => {
   if (process.env.REACT_APP_DEVGALLERY) {
-    return mockApi[key];
+    return mockApi[key] ? mockApi[key] : mockApi.emptyMock;
   }
   return module.apiMethods[key];
 };

--- a/src/editors/data/services/cms/mockApi.js
+++ b/src/editors/data/services/cms/mockApi.js
@@ -291,8 +291,4 @@ export const fetchStudioView = ({ blockId, studioEndpointUrl }) => {
   });
 };
 
-export const checkTranscriptsForImport = () => mockPromise({});
-
-export const uploadTranscript = () => mockPromise({});
-
-export const fetchAdvancedSettings = () => mockPromise({});
+export const emptyMock = () => mockPromise({});

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -152,6 +152,8 @@ export const setupCustomBehavior = ({
         updateContent,
       });
     });
+    // TODO: consider using tinyMCE onblur for all react state updates
+    editor.on('blur', () => updateContent(editor.getContent()));
   }
   editor.on('ExecCommand', (e) => {
     if (editorType === 'text' && e.command === 'mceFocus') {

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
@@ -49,7 +49,7 @@ describe('TinyMceEditor hooks', () => {
         const openSourceCodeModal = jest.fn();
         const setImage = jest.fn();
         const updateContent = jest.fn();
-        const editorType = 'SOmeEDitor';
+        const editorType = 'expandable';
         const lmsEndpointUrl = 'sOmEvaLue.cOm';
         const editor = {
           ui: { registry: { addButton, addToggleButton, addIcon } },
@@ -88,6 +88,7 @@ describe('TinyMceEditor hooks', () => {
           }],
         ]);
         expect(openImgModal).not.toHaveBeenCalled();
+        expect(editor.on).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
The expandable textareas employing tinyMCE in problem editor answer fields were only saving to react state when the problem was saved or the problem type was changed. This causes an issue when deleting answer fields that have not been saved to react state. This PR ensures that we save these tinyMCE fields on blur.

https://2u-internal.atlassian.net/browse/TNL-10644