### PR TITLE
fix: show setting note for course set social share

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/__snapshots__/index.test.jsx.snap
@@ -31,13 +31,6 @@ exports[`SocialShareWidget rendered with videoSharingEnabled true and allowVideo
       This video is shareable to social media
     </div>
   </Form.Checkbox>
-  <div>
-    <FormattedMessage
-      defaultMessage="Note: This setting is overridden by the course outline page."
-      description="Message that the setting can be overriden in the course outline"
-      id="authoring.videoeditor.socialShare.overrideNote"
-    />
-  </div>
   <div
     className="mt-3"
   >
@@ -77,13 +70,6 @@ exports[`SocialShareWidget rendered with videoSharingEnabled true and allowVideo
       This video is shareable to social media
     </div>
   </Form.Checkbox>
-  <div>
-    <FormattedMessage
-      defaultMessage="Note: This setting is overridden by the course outline page."
-      description="Message that the setting can be overriden in the course outline"
-      id="authoring.videoeditor.socialShare.overrideNote"
-    />
-  </div>
   <div
     className="mt-3"
   >

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
@@ -63,15 +63,15 @@ export const SocialShareWidget = ({
           {intl.formatMessage(messages.socialSharingCheckboxLabel)}
         </div>
       </Form.Checkbox>
-      {!isLibrary && (
-        <div>
-          <FormattedMessage {...messages.overrideSocialSharingNote} />
-        </div>
-      )}
       {isSetByCourse && (
-        <div>
-          <FormattedMessage {...messages.disclaimerSettingLocation} />
-        </div>
+        <>
+          <div className="mt-2">
+            <FormattedMessage {...messages.overrideSocialSharingNote} />
+          </div>
+          <div>
+            <FormattedMessage {...messages.disclaimerSettingLocation} />
+          </div>
+        </>
       )}
       <div className="mt-3">
         <Hyperlink className="text-primary-500" destination={learnMoreLink} target="_blank">

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.test.jsx
@@ -101,9 +101,13 @@ describe('SocialShareWidget', () => {
         />);
         it('should not have setting location message', () => {
           const formattedMessages = wrapper.find('FormattedMessage');
-          expect(formattedMessages.length).toEqual(2);
+          expect(formattedMessages.length).toEqual(1);
           expect(formattedMessages.at(0)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
-          expect(formattedMessages.at(1)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
+        });
+        it('should not have override note', () => {
+          const formattedMessages = wrapper.find('FormattedMessage');
+          expect(formattedMessages.length).toEqual(1);
+          expect(formattedMessages.at(0)).not.toEqual(messages.overrideSocialSharingNote.defaultMessage);
         });
         it('should have checkbox disabled prop equal false', () => {
           const disabledCheckbox = wrapper.children().at(1).prop('disabled');
@@ -179,9 +183,13 @@ describe('SocialShareWidget', () => {
         />);
         it('should not have setting location message', () => {
           const formattedMessages = wrapper.find('FormattedMessage');
-          expect(formattedMessages.length).toEqual(2);
+          expect(formattedMessages.length).toEqual(1);
           expect(formattedMessages.at(0)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
-          expect(formattedMessages.at(1)).not.toEqual(messages.disclaimerSettingLocation.defaultMessage);
+        });
+        it('should not have override note', () => {
+          const formattedMessages = wrapper.find('FormattedMessage');
+          expect(formattedMessages.length).toEqual(1);
+          expect(formattedMessages.at(0)).not.toEqual(messages.overrideSocialSharingNote.defaultMessage);
         });
         it('should have checkbox disabled prop equal false', () => {
           const disabledCheckbox = wrapper.children().at(1).prop('disabled');


### PR DESCRIPTION
When a course has 'all-on' or 'all-off' for the social sharing in the course outline, there should be two messages under the checkbox notifying the user that the setting overridden by the course settings and that they can be changed on the course outline page. When a course has 'per-video' for the social sharing in the course outline, there will be no messages bewlow the checkbox.