### PR TITLE
fix: delete answers without changing expandable

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -24,10 +24,16 @@ export const AnswerOption = ({
   // injected
   intl,
   // redux
+  answers,
   problemType,
 }) => {
   const dispatch = useDispatch();
-  const removeAnswer = hooks.removeAnswer({ answer, dispatch });
+  const removeAnswer = hooks.removeAnswer({
+    answers,
+    answer,
+    problemType,
+    dispatch,
+  });
   const setAnswer = hooks.setAnswer({ answer, hasSingleAnswer, dispatch });
   const setAnswerTitle = hooks.setAnswerTitle({
     answer,
@@ -134,10 +140,18 @@ AnswerOption.propTypes = {
   // injected
   intl: intlShape.isRequired,
   // redux
+  answers: PropTypes.arrayOf(PropTypes.shape({
+    correct: PropTypes.bool,
+    id: PropTypes.string,
+    selectedFeedback: PropTypes.string,
+    title: PropTypes.string,
+    unselectedFeedback: PropTypes.string,
+  })).isRequired,
   problemType: PropTypes.string.isRequired,
 };
 
 export const mapStateToProps = (state) => ({
+  answers: selectors.problem.answers(state),
   problemType: selectors.problem.problemType(state),
 });
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.jsx
@@ -24,16 +24,10 @@ export const AnswerOption = ({
   // injected
   intl,
   // redux
-  answers,
   problemType,
 }) => {
   const dispatch = useDispatch();
-  const removeAnswer = hooks.removeAnswer({
-    answers,
-    answer,
-    problemType,
-    dispatch,
-  });
+  const removeAnswer = hooks.removeAnswer({ answer, dispatch });
   const setAnswer = hooks.setAnswer({ answer, hasSingleAnswer, dispatch });
   const setAnswerTitle = hooks.setAnswerTitle({
     answer,
@@ -140,18 +134,10 @@ AnswerOption.propTypes = {
   // injected
   intl: intlShape.isRequired,
   // redux
-  answers: PropTypes.arrayOf(PropTypes.shape({
-    correct: PropTypes.bool,
-    id: PropTypes.string,
-    selectedFeedback: PropTypes.string,
-    title: PropTypes.string,
-    unselectedFeedback: PropTypes.string,
-  })).isRequired,
   problemType: PropTypes.string.isRequired,
 };
 
 export const mapStateToProps = (state) => ({
-  answers: selectors.problem.answers(state),
   problemType: selectors.problem.problemType(state),
 });
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.test.jsx
@@ -64,11 +64,6 @@ describe('AnswerOption', () => {
 
   describe('mapStateToProps', () => {
     const testState = { A: 'pple', B: 'anana', C: 'ucumber' };
-    test('answers from problem.answers', () => {
-      expect(
-        mapStateToProps(testState).answers,
-      ).toEqual(selectors.problem.answers(testState));
-    });
     test('problemType from problem.problemType', () => {
       expect(
         mapStateToProps(testState).problemType,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/AnswerOption.test.jsx
@@ -7,6 +7,7 @@ import { AnswerOption, mapStateToProps } from './AnswerOption';
 jest.mock('../../../../../data/redux', () => ({
   selectors: {
     problem: {
+      answers: jest.fn(state => ({ answers: state })),
       problemType: jest.fn(state => ({ problemType: state })),
     },
   },
@@ -63,6 +64,11 @@ describe('AnswerOption', () => {
 
   describe('mapStateToProps', () => {
     const testState = { A: 'pple', B: 'anana', C: 'ucumber' };
+    test('answers from problem.answers', () => {
+      expect(
+        mapStateToProps(testState).answers,
+      ).toEqual(selectors.problem.answers(testState));
+    });
     test('problemType from problem.problemType', () => {
       expect(
         mapStateToProps(testState).problemType,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -16,13 +16,30 @@ export const removeAnswer = ({
   dispatch,
 }) => () => {
   if (RichTextProblems.includes(problemType)) {
+    let newAnswers = [];
     const currentAnswerTitles = fetchEditorContent({ format: '' }).answers;
     answers.forEach(ans => {
-      dispatch(actions.problem.updateAnswer({
-        ...ans,
-        title: currentAnswerTitles?.[ans.id] || ans.title,
-        correct: ans.correct,
-      }));
+      if (ans !== answer) {
+        newAnswers = [
+          ...newAnswers,
+          currentAnswerTitles?.[ans.id] || '',
+        ];
+      }
+    });
+    const editorObject = { hints: [] };
+    const EditorsArray = window.tinymce.editors;
+    let iter = 0;
+    Object.entries(EditorsArray).forEach(([id, editor]) => {
+      if (Number.isNaN(parseInt(id))) {
+        if (id.startsWith('answer')) {
+          const { editorAnswers } = editorObject;
+          const answerId = id.substring(id.indexOf('-') + 1);
+          if (iter < newAnswers.length) {
+            editorObject.editorAnswers = { ...editorAnswers, [answerId]: editor.setContent(newAnswers[iter]) };
+            iter++;
+          }
+        }
+      }
     });
   }
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -16,7 +16,7 @@ export const removeAnswer = ({
   dispatch,
 }) => () => {
   if (RichTextProblems.includes(problemType)) {
-    const currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
+    const currentAnswerTitles = fetchEditorContent({ format: '' }).answers;
     answers.forEach(ans => {
       dispatch(actions.problem.updateAnswer({
         ...ans,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -25,6 +25,11 @@ export const removeAnswer = ({
           currentAnswerTitles?.[ans.id] || '',
         ];
       }
+      dispatch(actions.problem.updateAnswer({
+        ...ans,
+        title: currentAnswerTitles?.[ans.id] || ans.title,
+        correct: ans.correct,
+      }));
     });
     const editorObject = { hints: [] };
     const EditorsArray = window.tinymce.editors;
@@ -85,7 +90,7 @@ export const useFeedback = (answer) => {
     // Show feedback fields if feedback is present
     const isVisible = !!answer.selectedFeedback || !!answer.unselectedFeedback;
     setIsFeedbackVisible(isVisible);
-  }, []);
+  }, [answer]);
 
   const toggleFeedback = (open) => {
     // Do not allow to hide if feedback is added

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -9,7 +9,25 @@ export const state = StrictDict({
   isFeedbackVisible: (val) => useState(val),
 });
 
-export const removeAnswer = ({ answer, dispatch }) => () => {
+export const removeAnswer = ({
+  answers,
+  answer,
+  problemType,
+  dispatch,
+}) => () => {
+  const richTextProblems = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT];
+
+  if (richTextProblems.includes(problemType)) {
+    const currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
+    answers.forEach(ans => {
+      dispatch(actions.problem.updateAnswer({
+        ...ans,
+        title: currentAnswerTitles?.[ans.id] || ans.title,
+        correct: ans.correct,
+      }));
+    });
+  }
+
   dispatch(actions.problem.deleteAnswer({ id: answer.id, correct: answer.correct }));
 };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { StrictDict } from '../../../../../utils';
 import * as module from './hooks';
 import { actions } from '../../../../../data/redux';
-import { ProblemTypeKeys } from '../../../../../data/constants/problem';
+import { ProblemTypeKeys, RichTextProblems } from '../../../../../data/constants/problem';
 import { fetchEditorContent } from '../hooks';
 
 export const state = StrictDict({
@@ -15,9 +15,7 @@ export const removeAnswer = ({
   problemType,
   dispatch,
 }) => () => {
-  const richTextProblems = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT];
-
-  if (richTextProblems.includes(problemType)) {
+  if (RichTextProblems.includes(problemType)) {
     const currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
     answers.forEach(ans => {
       dispatch(actions.problem.updateAnswer({

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -2,45 +2,22 @@ import { useState, useEffect } from 'react';
 import { StrictDict } from '../../../../../utils';
 import * as module from './hooks';
 import { actions } from '../../../../../data/redux';
-import { ProblemTypeKeys, RichTextProblems } from '../../../../../data/constants/problem';
+import { ProblemTypeKeys } from '../../../../../data/constants/problem';
 import { fetchEditorContent } from '../hooks';
-import { indexToLetterMap } from '../../../data/OLXParser';
 
 export const state = StrictDict({
   isFeedbackVisible: (val) => useState(val),
 });
 
 export const removeAnswer = ({
-  answers,
   answer,
-  problemType,
   dispatch,
 }) => () => {
-  if (RichTextProblems.includes(problemType)) {
-    let newAnswers = [];
-    const currentAnswerTitles = fetchEditorContent({ format: '' }).answers;
-    answers.forEach(ans => {
-      if (ans !== answer) {
-        newAnswers = [
-          ...newAnswers,
-          currentAnswerTitles?.[ans.id] || '',
-        ];
-      }
-      dispatch(actions.problem.updateAnswer({
-        ...ans,
-        title: currentAnswerTitles?.[ans.id] || ans.title,
-        correct: ans.correct,
-      }));
-    });
-    const EditorsArray = window.tinymce.editors;
-    newAnswers.forEach((value, index) => {
-      const newId = indexToLetterMap[index];
-      const editor = EditorsArray[`answer-${newId}`];
-      editor.setContent(value);
-    });
-  }
-
-  dispatch(actions.problem.deleteAnswer({ id: answer.id, correct: answer.correct }));
+  dispatch(actions.problem.deleteAnswer({
+    id: answer.id,
+    correct: answer.correct,
+    editorState: fetchEditorContent({ format: '' }),
+  }));
 };
 
 export const setAnswer = ({ answer, hasSingleAnswer, dispatch }) => (payload) => {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.js
@@ -4,6 +4,7 @@ import * as module from './hooks';
 import { actions } from '../../../../../data/redux';
 import { ProblemTypeKeys, RichTextProblems } from '../../../../../data/constants/problem';
 import { fetchEditorContent } from '../hooks';
+import { indexToLetterMap } from '../../../data/OLXParser';
 
 export const state = StrictDict({
   isFeedbackVisible: (val) => useState(val),
@@ -31,20 +32,11 @@ export const removeAnswer = ({
         correct: ans.correct,
       }));
     });
-    const editorObject = { hints: [] };
     const EditorsArray = window.tinymce.editors;
-    let iter = 0;
-    Object.entries(EditorsArray).forEach(([id, editor]) => {
-      if (Number.isNaN(parseInt(id))) {
-        if (id.startsWith('answer')) {
-          const { editorAnswers } = editorObject;
-          const answerId = id.substring(id.indexOf('-') + 1);
-          if (iter < newAnswers.length) {
-            editorObject.editorAnswers = { ...editorAnswers, [answerId]: editor.setContent(newAnswers[iter]) };
-            iter++;
-          }
-        }
-      }
+    newAnswers.forEach((value, index) => {
+      const newId = indexToLetterMap[index];
+      const editor = EditorsArray[`answer-${newId}`];
+      editor.setContent(value);
     });
   }
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
@@ -51,19 +51,6 @@ describe('Answer Options Hooks', () => {
     const answer = { id: 'A', correct: false };
     const problemType = 'multiplechoiceresponse';
     const dispatch = useDispatch();
-    it('dispatches actions.problem.updateAnswer if problemType is SINGLESELECT', () => {
-      module.removeAnswer({
-        answers,
-        answer,
-        problemType,
-        dispatch,
-      })();
-      expect(dispatch).toHaveBeenCalledWith(actions.problem.updateAnswer({
-        id: 'A',
-        title: 'atitle',
-        correct: false,
-      }));
-    });
     it('dispatches actions.problem.deleteAnswer', () => {
       module.removeAnswer({
         answers,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
@@ -48,9 +48,25 @@ describe('Answer Options Hooks', () => {
       { id: 'B', title: 'btitle', correct: false },
       { id: 'C', title: 'ctitle', correct: false },
     ];
-    const answer = { id: 'A', correct: false };
+    const answer = answers[0];
     const problemType = 'multiplechoiceresponse';
     const dispatch = useDispatch();
+    const getContent = () => '<p></p>';
+    const setContent = jest.fn();
+    window.tinymce.editors = {
+      'answer-A': { getContent, setContent },
+      'answer-B': { getContent, setContent },
+      'answer-C': { getContent, setContent },
+    };
+    it('calls setContent if problemType is a RichTextProblem', () => {
+      module.removeAnswer({
+        answers,
+        answer,
+        problemType,
+        dispatch,
+      })();
+      expect(setContent).toHaveBeenCalledTimes(answers.length - 1);
+    });
     it('dispatches actions.problem.deleteAnswer', () => {
       module.removeAnswer({
         answers,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
@@ -13,11 +13,9 @@ jest.mock('react', () => {
     useState: jest.fn(val => ([{ state: val }, (newVal) => updateState({ val, newVal })])),
   };
 });
-
 jest.mock('@edx/frontend-platform/i18n', () => ({
   defineMessages: m => m,
 }));
-
 jest.mock('../../../../../data/redux', () => ({
   actions: {
     problem: {
@@ -36,47 +34,37 @@ const answerWithOnlyFeedback = {
   correct: true,
   selectedFeedback: 'some feedback',
 };
+let windowSpy;
 
 describe('Answer Options Hooks', () => {
-  beforeEach(() => { jest.clearAllMocks(); });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   describe('state hooks', () => {
     state.testGetter(state.keys.isFeedbackVisible);
   });
   describe('removeAnswer', () => {
-    const answers = [
-      { id: 'A', title: 'atitle', correct: false },
-      { id: 'B', title: 'btitle', correct: false },
-      { id: 'C', title: 'ctitle', correct: false },
-    ];
-    const answer = answers[0];
-    const problemType = 'multiplechoiceresponse';
-    const dispatch = useDispatch();
-    const getContent = () => '<p></p>';
-    const setContent = jest.fn();
-    window.tinymce.editors = {
-      'answer-A': { getContent, setContent },
-      'answer-B': { getContent, setContent },
-      'answer-C': { getContent, setContent },
-    };
-    it('calls setContent if problemType is a RichTextProblem', () => {
-      module.removeAnswer({
-        answers,
-        answer,
-        problemType,
-        dispatch,
-      })();
-      expect(setContent).toHaveBeenCalledTimes(answers.length - 1);
+    beforeEach(() => {
+      windowSpy = jest.spyOn(window, 'window', 'get');
     });
+    afterEach(() => {
+      windowSpy.mockRestore();
+    });
+    const answer = { id: 'A', correct: false };
+    const dispatch = useDispatch();
     it('dispatches actions.problem.deleteAnswer', () => {
+      windowSpy.mockImplementation(() => ({ tinymce: { editors: { 'answer-A': { getContent: () => 'string' } } } }));
       module.removeAnswer({
-        answers,
         answer,
-        problemType,
         dispatch,
       })();
       expect(dispatch).toHaveBeenCalledWith(actions.problem.deleteAnswer({
         id: answer.id,
         correct: answer.correct,
+        editorState: {
+          answers: { A: 'string' },
+          hints: [],
+        },
       }));
     });
   });
@@ -161,9 +149,15 @@ describe('Answer Options Hooks', () => {
     });
   });
   describe('useFeedback hook', () => {
-    beforeEach(() => { state.mock(); });
-    afterEach(() => { state.restore(); });
-    test('test default state is false', () => {
+    beforeEach(() => {
+      state.mock();
+      windowSpy = jest.spyOn(window, 'window', 'get');
+    });
+    afterEach(() => {
+      state.restore();
+      windowSpy.mockRestore();
+    });
+    test('default state is false', () => {
       output = module.useFeedback(answerWithOnlyFeedback);
       expect(output.isFeedbackVisible).toBeFalsy();
     });
@@ -175,24 +169,24 @@ describe('Answer Options Hooks', () => {
       cb();
       expect(state.setState[key]).toHaveBeenCalledWith(true);
     });
-    test('test toggleFeedback with selected feedback', () => {
+    test('toggleFeedback with selected feedback', () => {
       const key = state.keys.isFeedbackVisible;
       output = module.useFeedback(answerWithOnlyFeedback);
-      window.tinymce.editors = { 'selectedFeedback-A': { getContent: () => 'string' } };
+      windowSpy.mockImplementation(() => ({ tinymce: { editors: { 'selectedFeedback-A': { getContent: () => 'string' } } } }));
       output.toggleFeedback(false);
       expect(state.setState[key]).toHaveBeenCalledWith(true);
     });
-    test('test toggleFeedback with unselected feedback', () => {
+    test('toggleFeedback with unselected feedback', () => {
       const key = state.keys.isFeedbackVisible;
       output = module.useFeedback(answerWithOnlyFeedback);
-      window.tinymce.editors = { 'unselectedFeedback-A': { getContent: () => 'string' } };
+      windowSpy.mockImplementation(() => ({ tinymce: { editors: { 'unselectedFeedback-A': { getContent: () => 'string' } } } }));
       output.toggleFeedback(false);
       expect(state.setState[key]).toHaveBeenCalledWith(true);
     });
-    test('test toggleFeedback with unselected feedback', () => {
+    test('toggleFeedback with unselected feedback', () => {
       const key = state.keys.isFeedbackVisible;
       output = module.useFeedback(answerWithOnlyFeedback);
-      window.tinymce.editors = { 'answer-A': { getContent: () => 'string' } };
+      windowSpy.mockImplementation(() => ({ tinymce: { editors: { 'answer-A': { getContent: () => 'string' } } } }));
       output.toggleFeedback(false);
       expect(state.setState[key]).toHaveBeenCalledWith(false);
     });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/AnswerWidget/hooks.test.js
@@ -43,10 +43,34 @@ describe('Answer Options Hooks', () => {
     state.testGetter(state.keys.isFeedbackVisible);
   });
   describe('removeAnswer', () => {
-    test('it dispatches actions.problem.deleteAnswer', () => {
-      const answer = { id: 'A', correct: false };
-      const dispatch = useDispatch();
-      module.removeAnswer({ answer, dispatch })();
+    const answers = [
+      { id: 'A', title: 'atitle', correct: false },
+      { id: 'B', title: 'btitle', correct: false },
+      { id: 'C', title: 'ctitle', correct: false },
+    ];
+    const answer = { id: 'A', correct: false };
+    const problemType = 'multiplechoiceresponse';
+    const dispatch = useDispatch();
+    it('dispatches actions.problem.updateAnswer if problemType is SINGLESELECT', () => {
+      module.removeAnswer({
+        answers,
+        answer,
+        problemType,
+        dispatch,
+      })();
+      expect(dispatch).toHaveBeenCalledWith(actions.problem.updateAnswer({
+        id: 'A',
+        title: 'atitle',
+        correct: false,
+      }));
+    });
+    it('dispatches actions.problem.deleteAnswer', () => {
+      module.removeAnswer({
+        answers,
+        answer,
+        problemType,
+        dispatch,
+      })();
       expect(dispatch).toHaveBeenCalledWith(actions.problem.deleteAnswer({
         id: answer.id,
         correct: answer.correct,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -3,7 +3,12 @@ import { useState, useEffect } from 'react';
 import _ from 'lodash-es';
 import * as module from './hooks';
 import messages from './messages';
-import { ProblemTypeKeys, ProblemTypes, RichTextProblems, ShowAnswerTypesKeys } from '../../../../../data/constants/problem';
+import {
+  ProblemTypeKeys,
+  ProblemTypes,
+  RichTextProblems,
+  ShowAnswerTypesKeys,
+} from '../../../../../data/constants/problem';
 import { fetchEditorContent } from '../hooks';
 
 export const state = {
@@ -234,7 +239,7 @@ export const typeRowHooks = ({
   typeKey,
   updateField,
   updateAnswer,
-}) => {  
+}) => {
   const clearPreviouslySelectedAnswers = () => {
     let currentAnswerTitles;
     if (RichTextProblems.includes(problemType)) {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import _ from 'lodash-es';
 import * as module from './hooks';
 import messages from './messages';
-import { ProblemTypeKeys, ProblemTypes, ShowAnswerTypesKeys } from '../../../../../data/constants/problem';
+import { ProblemTypeKeys, ProblemTypes, RichTextProblems, ShowAnswerTypesKeys } from '../../../../../data/constants/problem';
 import { fetchEditorContent } from '../hooks';
 
 export const state = {
@@ -234,12 +234,10 @@ export const typeRowHooks = ({
   typeKey,
   updateField,
   updateAnswer,
-}) => {
-  const richTextProblems = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT];
-
+}) => {  
   const clearPreviouslySelectedAnswers = () => {
     let currentAnswerTitles;
-    if (richTextProblems.includes(problemType)) {
+    if (RichTextProblems.includes(problemType)) {
       currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
     }
     answers.forEach(answer => {
@@ -254,7 +252,7 @@ export const typeRowHooks = ({
 
   const updateAnswersToCorrect = () => {
     let currentAnswerTitles;
-    if (richTextProblems.includes(problemType)) {
+    if (RichTextProblems.includes(problemType)) {
       currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
     }
     answers.forEach(answer => {
@@ -273,7 +271,7 @@ export const typeRowHooks = ({
   const onClick = () => {
     // Numeric, text, and dropdowns cannot render HTML as answer values, so if switching from a single select
     // or multi-select problem the rich text needs to covert to plain text
-    if (typeKey === ProblemTypeKeys.TEXTINPUT && richTextProblems.includes(problemType)) {
+    if (typeKey === ProblemTypeKeys.TEXTINPUT && RichTextProblems.includes(problemType)) {
       convertToPlainText();
     }
     // Dropdown problems can only have one correct answer. When there is more than one correct answer
@@ -281,7 +279,7 @@ export const typeRowHooks = ({
     if (typeKey === ProblemTypeKeys.DROPDOWN) {
       if (correctAnswerCount > 1) {
         clearPreviouslySelectedAnswers();
-      } else if (richTextProblems.includes(problemType)) {
+      } else if (RichTextProblems.includes(problemType)) {
         convertToPlainText();
       }
     }

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -541,6 +541,8 @@ export class OLXParser {
       } else {
         settings.tolerance = { value: parseInt(toleranceValue), type: 'Number' };
       }
+    } else {
+      settings.tolerance = { value: null, type: 'None' };
     }
     if (solutionExplanation) { settings.solutionExplanation = solutionExplanation; }
 

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -196,14 +196,13 @@ export const RandomizationTypesKeys = StrictDict({
   ONRESET: 'on_reset',
   PERSTUDENT: 'per_student',
 });
+
 export const RandomizationTypes = StrictDict({
-  [RandomizationTypesKeys.ALWAYS]:
-        {
-          id: 'authoring.problemeditor.settings.RandomizationTypes.always',
-          defaultMessage: 'Always',
-        },
-  [RandomizationTypesKeys.NEVER]:
-    {
+  [RandomizationTypesKeys.ALWAYS]: {
+      id: 'authoring.problemeditor.settings.RandomizationTypes.always',
+      defaultMessage: 'Always',
+    },
+  [RandomizationTypesKeys.NEVER]: {
       id: 'authoring.problemeditor.settings.RandomizationTypes.never',
       defaultMessage: 'Never',
     },
@@ -216,3 +215,5 @@ export const RandomizationTypes = StrictDict({
     defaultMessage: 'Per Student',
   },
 });
+
+export const RichTextProblems = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT];

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -199,13 +199,13 @@ export const RandomizationTypesKeys = StrictDict({
 
 export const RandomizationTypes = StrictDict({
   [RandomizationTypesKeys.ALWAYS]: {
-      id: 'authoring.problemeditor.settings.RandomizationTypes.always',
-      defaultMessage: 'Always',
-    },
+    id: 'authoring.problemeditor.settings.RandomizationTypes.always',
+    defaultMessage: 'Always',
+  },
   [RandomizationTypesKeys.NEVER]: {
-      id: 'authoring.problemeditor.settings.RandomizationTypes.never',
-      defaultMessage: 'Never',
-    },
+    id: 'authoring.problemeditor.settings.RandomizationTypes.never',
+    defaultMessage: 'Never',
+  },
   [RandomizationTypesKeys.ONRESET]: {
     id: 'authoring.problemeditor.settings.RandomizationTypes.onreset',
     defaultMessage: 'On Reset',

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -2,7 +2,7 @@ import _ from 'lodash-es';
 import { createSlice } from '@reduxjs/toolkit';
 import { indexToLetterMap } from '../../../containers/ProblemEditor/data/OLXParser';
 import { StrictDict } from '../../../utils';
-import { ProblemTypeKeys, ShowAnswerTypesKeys } from '../../constants/problem';
+import { ProblemTypeKeys, RichTextProblems, ShowAnswerTypesKeys } from '../../constants/problem';
 import { ToleranceTypes } from '../../../containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/constants';
 
 const nextAlphaId = (lastId) => String.fromCharCode(lastId.charCodeAt(0) + 1);
@@ -83,36 +83,51 @@ const problem = createSlice({
       };
     },
     deleteAnswer: (state, { payload }) => {
-      const { id, correct } = payload;
-      if (state.answers.length <= 1) {
-        if (state.answers.length > 0 && state.answers[0].isAnswerRange) {
-          return {
-            ...state,
-            correctAnswerCount: 1,
-            answers: [{
-              id: 'A',
-              title: '',
-              selectedFeedback: '',
-              unselectedFeedback: '',
-              correct: state.problemType === ProblemTypeKeys.NUMERIC,
-              isAnswerRange: false,
-            },
-            ],
-          };
-        }
-        return state;
-      }
-
-      let { correctAnswerCount } = state;
-      if (correct) {
-        correctAnswerCount -= 1;
+      const { id, correct, editorState } = payload;
+      const EditorsArray = window.tinymce.editors;
+      if (state.answers.length === 1) {
+        return {
+          ...state,
+          correctAnswerCount: state.problemType === ProblemTypeKeys.NUMERIC ? 1 : 0,
+          answers: [{
+            id: 'A',
+            title: '',
+            selectedFeedback: '',
+            unselectedFeedback: '',
+            correct: state.problemType === ProblemTypeKeys.NUMERIC,
+            isAnswerRange: false,
+          }],
+        };
       }
       const answers = state.answers.filter(obj => obj.id !== id).map((answer, index) => {
         const newId = indexToLetterMap[index];
         if (answer.id === newId) {
           return answer;
         }
-        return { ...answer, id: newId };
+        let newAnswer = {
+          ...answer,
+          id: newId,
+          selectedFeedback: editorState.selectedFeedback ? editorState.selectedFeedback[answer.id] : '',
+          unselectedFeedback: editorState.unselectedFeedback ? editorState.unselectedFeedback[answer.id] : '',
+        };
+        if (RichTextProblems.includes(state.problemType)) {
+          newAnswer = {
+            ...newAnswer,
+            title: editorState.answers[answer.id],
+          };
+          if (EditorsArray[`answer-${newId}`]) {
+            EditorsArray[`answer-${newId}`].setContent(newAnswer.title ?? '');
+          }
+        }
+        // Note: The following assumes selectedFeedback and unselectedFeedback is using ExpandedTextArea
+        //   Content only needs to be set here when the 'next' feedback fields are shown.
+        if (EditorsArray[`selectedFeedback-${newId}`]) {
+          EditorsArray[`selectedFeedback-${newId}`].setContent(newAnswer.selectedFeedback ?? '');
+        }
+        if (EditorsArray[`unselectedFeedback-${newId}`]) {
+          EditorsArray[`unselectedFeedback-${newId}`].setContent(newAnswer.unselectedFeedback ?? '');
+        }
+        return newAnswer;
       });
       const groupFeedbackList = state.groupFeedbackList.map(feedback => {
         const newAnswers = feedback.answers.filter(obj => obj !== id).map(letter => {
@@ -125,9 +140,9 @@ const problem = createSlice({
       });
       return {
         ...state,
-        correctAnswerCount,
-        groupFeedbackList,
         answers,
+        correctAnswerCount: correct ? state.correctAnswerCount - 1 : state.correctAnswerCount,
+        groupFeedbackList,
       };
     },
     addAnswer: (state) => {

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -114,9 +114,19 @@ const problem = createSlice({
         }
         return { ...answer, id: newId };
       });
+      const groupFeedbackList = state.groupFeedbackList.map(feedback => {
+        const newAnswers = feedback.answers.filter(obj => obj !== id).map(letter => {
+          if (letter.charCodeAt(0) > id.charCodeAt(0)) {
+            return String.fromCharCode(letter.charCodeAt(0) - 1);
+          }
+          return letter;
+        });
+        return { ...feedback, answers: newAnswers };
+      });
       return {
         ...state,
         correctAnswerCount,
+        groupFeedbackList,
         answers,
       };
     },

--- a/src/editors/data/redux/problem/reducers.test.js
+++ b/src/editors/data/redux/problem/reducers.test.js
@@ -118,7 +118,6 @@ describe('problem reducer', () => {
         });
       });
     });
-
     describe('addAnswerRange', () => {
       const answerRange = {
         id: 'A',
@@ -137,7 +136,6 @@ describe('problem reducer', () => {
         });
       });
     });
-
     describe('updateAnswer', () => {
       it('sets answers, as well as setting the correctAnswerCount ', () => {
         const answer = { id: 'A', correct: true };
@@ -158,66 +156,241 @@ describe('problem reducer', () => {
       });
     });
     describe('deleteAnswer', () => {
-      it('sets answers, as well as setting the correctAnswerCount ', () => {
-        const answer = { id: 'A', correct: false };
+      let windowSpy;
+      beforeEach(() => {
+        windowSpy = jest.spyOn(window, 'window', 'get');
+      });
+      afterEach(() => {
+        windowSpy.mockRestore();
+      });
+      it('sets a default when deleting the last answer', () => {
+        windowSpy.mockImplementation(() => ({
+          tinymce: {
+            editors: 'mock-editors',
+          },
+        }));
+        const payload = {
+          id: 'A',
+          correct: false,
+          editorState: 'empty',
+        };
+        expect(reducer(
+          {
+            ...testingState,
+            correctAnswerCount: 0,
+            answers: [{ id: 'A', correct: false }],
+          },
+          actions.deleteAnswer(payload),
+        )).toEqual({
+          ...testingState,
+          correctAnswerCount: 0,
+          answers: [{
+            id: 'A',
+            title: '',
+            selectedFeedback: '',
+            unselectedFeedback: '',
+            correct: false,
+            isAnswerRange: false,
+          }],
+        });
+      });
+      it('sets answers and correctAnswerCount', () => {
+        windowSpy.mockImplementation(() => ({
+          tinymce: {
+            editors: 'mock-editors',
+          },
+        }));
+        const payload = {
+          id: 'A',
+          correct: false,
+          editorState: {
+            answers: { A: 'mockA' },
+          },
+        };
         expect(reducer(
           {
             ...testingState,
             correctAnswerCount: 1,
-            answers: [{
-              id: 'A',
-              correct: false,
-            },
-            {
-              id: 'B',
-              correct: true,
-            }],
+            answers: [
+              { id: 'A', correct: false },
+              { id: 'B', correct: true },
+            ],
           },
-          actions.deleteAnswer(answer),
+          actions.deleteAnswer(payload),
         )).toEqual({
           ...testingState,
           correctAnswerCount: 1,
           answers: [{
             id: 'A',
             correct: true,
+            selectedFeedback: '',
+            unselectedFeedback: '',
           }],
         });
       });
-      it('sets groupFeedbackList by removing the checked list of ', () => {
-        const answer = { id: 'A', correct: false };
+      it('sets answers and correctAnswerCount with editorState for RichTextProblems', () => {
+        const setContent = jest.fn();
+        windowSpy.mockImplementation(() => ({
+          tinymce: {
+            editors: {
+              'answer-A': { setContent },
+              'answer-B': { setContent },
+            },
+          },
+        }));
+        const payload = {
+          id: 'A',
+          correct: false,
+          editorState: {
+            answers: { A: 'editorAnsA', B: 'editorAnsB' },
+          },
+        };
+        expect(reducer(
+          {
+            ...testingState,
+            problemType: ProblemTypeKeys.SINGLESELECT,
+            correctAnswerCount: 1,
+            answers: [
+              { id: 'A', correct: false },
+              { id: 'B', correct: true },
+            ],
+          },
+          actions.deleteAnswer(payload),
+        )).toEqual({
+          ...testingState,
+          problemType: ProblemTypeKeys.SINGLESELECT,
+          correctAnswerCount: 1,
+          answers: [{
+            id: 'A',
+            correct: true,
+            title: 'editorAnsB',
+            selectedFeedback: '',
+            unselectedFeedback: '',
+          }],
+        });
+      });
+      it('sets selectedFeedback and unselectedFeedback with editorState', () => {
+        windowSpy.mockImplementation(() => ({
+          tinymce: {
+            editors: {
+              'answer-A': 'mockEditor',
+              'answer-B': 'mockEditor',
+            },
+          },
+        }));
+        const payload = {
+          id: 'A',
+          correct: false,
+          editorState: {
+            answers: { A: 'editorAnsA', B: 'editorAnsB' },
+            selectedFeedback: { A: 'editSelFA', B: 'editSelFB' },
+            unselectedFeedback: { A: 'editUnselFA', B: 'editUnselFB' },
+          },
+        };
         expect(reducer(
           {
             ...testingState,
             correctAnswerCount: 1,
-            answers: [{
-              id: 'A',
-              correct: false,
+            answers: [
+              { id: 'A', correct: false },
+              { id: 'B', correct: true },
+            ],
+          },
+          actions.deleteAnswer(payload),
+        )).toEqual({
+          ...testingState,
+          correctAnswerCount: 1,
+          answers: [{
+            id: 'A',
+            correct: true,
+            selectedFeedback: 'editSelFB',
+            unselectedFeedback: 'editUnselFB',
+          }],
+        });
+      });
+      it('calls editor setContent to set answer and feedback fields', () => {
+        const setContent = jest.fn();
+        windowSpy.mockImplementation(() => ({
+          tinymce: {
+            editors: {
+              'answer-A': { setContent },
+              'answer-B': { setContent },
+              'selectedFeedback-A': { setContent },
+              'selectedFeedback-B': { setContent },
+              'unselectedFeedback-A': { setContent },
+              'unselectedFeedback-B': { setContent },
             },
-            {
-              id: 'B',
-              correct: true,
-            },
-            {
-              id: 'C',
-              correct: false,
-            }],
+          },
+        }));
+        const payload = {
+          id: 'A',
+          correct: false,
+          editorState: {
+            answers: { A: 'editorAnsA', B: 'editorAnsB' },
+            selectedFeedback: { A: 'editSelFA', B: 'editSelFB' },
+            unselectedFeedback: { A: 'editUnselFA', B: 'editUnselFB' },
+          },
+        };
+        reducer(
+          {
+            ...testingState,
+            problemType: ProblemTypeKeys.SINGLESELECT,
+            correctAnswerCount: 1,
+            answers: [
+              { id: 'A', correct: false },
+              { id: 'B', correct: true },
+            ],
+          },
+          actions.deleteAnswer(payload),
+        );
+        expect(window.tinymce.editors['answer-A'].setContent).toHaveBeenCalled();
+        expect(window.tinymce.editors['answer-A'].setContent).toHaveBeenCalledWith('editorAnsB');
+        expect(window.tinymce.editors['selectedFeedback-A'].setContent).toHaveBeenCalledWith('editSelFB');
+        expect(window.tinymce.editors['unselectedFeedback-A'].setContent).toHaveBeenCalledWith('editUnselFB');
+      });
+      it('sets groupFeedbackList by removing the checked item in the groupFeedback', () => {
+        windowSpy.mockImplementation(() => ({
+          tinymce: {
+            editors: 'mock-editors',
+          },
+        }));
+        const payload = {
+          id: 'A',
+          correct: false,
+          editorState: {
+            answer: { A: 'aNSwERA', B: 'anSWeRB' },
+          },
+        };
+        expect(reducer(
+          {
+            ...testingState,
+            correctAnswerCount: 1,
+            answers: [
+              { id: 'A', correct: false },
+              { id: 'B', correct: true },
+              { id: 'C', correct: false },
+            ],
             groupFeedbackList: [{
               id: 0,
               answers: ['A', 'C'],
               feedback: 'fake feedback',
             }],
           },
-          actions.deleteAnswer(answer),
+          actions.deleteAnswer(payload),
         )).toEqual({
           ...testingState,
           correctAnswerCount: 1,
           answers: [{
             id: 'A',
             correct: true,
+            selectedFeedback: '',
+            unselectedFeedback: '',
           },
           {
             id: 'B',
             correct: false,
+            selectedFeedback: '',
+            unselectedFeedback: '',
           }],
           groupFeedbackList: [{
             id: 0,
@@ -227,36 +400,43 @@ describe('problem reducer', () => {
         });
       });
       it('if you delete an answer range, it will be replaced with a blank answer', () => {
-        const answer = {
+        windowSpy.mockImplementation(() => ({
+          tinymce: {
+            editors: 'mock-editors',
+          },
+        }));
+        const payload = {
           id: 'A',
           correct: true,
-          selectedFeedback: '',
-          title: '',
-          isAnswerRange: false,
-          unselectedFeedback: '',
+          editorState: 'mockEditoRStAte',
         };
-        const answerRange = {
-          id: 'A',
-          correct: false,
-          selectedFeedback: '',
-          title: '',
-          isAnswerRange: true,
-          unselectedFeedback: '',
-        };
-
         expect(reducer(
           {
             ...testingState,
             problemType: ProblemTypeKeys.NUMERIC,
             correctAnswerCount: 1,
-            answers: [{ ...answerRange }],
+            answers: [{
+              id: 'A',
+              correct: false,
+              selectedFeedback: '',
+              title: '',
+              isAnswerRange: true,
+              unselectedFeedback: '',
+            }],
           },
-          actions.deleteAnswer(answer),
+          actions.deleteAnswer(payload),
         )).toEqual({
           ...testingState,
           problemType: ProblemTypeKeys.NUMERIC,
           correctAnswerCount: 1,
-          answers: [{ ...answer }],
+          answers: [{
+            id: 'A',
+            title: '',
+            selectedFeedback: '',
+            unselectedFeedback: '',
+            correct: true,
+            isAnswerRange: false,
+          }],
         });
       });
     });

--- a/src/editors/data/redux/problem/reducers.test.js
+++ b/src/editors/data/redux/problem/reducers.test.js
@@ -177,11 +177,53 @@ describe('problem reducer', () => {
         )).toEqual({
           ...testingState,
           correctAnswerCount: 1,
-          answers: [
-            {
+          answers: [{
+            id: 'A',
+            correct: true,
+          }],
+        });
+      });
+      it('sets groupFeedbackList by removing the checked list of ', () => {
+        const answer = { id: 'A', correct: false };
+        expect(reducer(
+          {
+            ...testingState,
+            correctAnswerCount: 1,
+            answers: [{
               id: 'A',
+              correct: false,
+            },
+            {
+              id: 'B',
               correct: true,
+            },
+            {
+              id: 'C',
+              correct: false,
             }],
+            groupFeedbackList: [{
+              id: 0,
+              answers: ['A', 'C'],
+              feedback: 'fake feedback',
+            }],
+          },
+          actions.deleteAnswer(answer),
+        )).toEqual({
+          ...testingState,
+          correctAnswerCount: 1,
+          answers: [{
+            id: 'A',
+            correct: true,
+          },
+          {
+            id: 'B',
+            correct: false,
+          }],
+          groupFeedbackList: [{
+            id: 0,
+            answers: ['B'],
+            feedback: 'fake feedback',
+          }],
         });
       });
       it('if you delete an answer range, it will be replaced with a blank answer', () => {

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -152,8 +152,6 @@ export const setupCustomBehavior = ({
         updateContent,
       });
     });
-    // TODO: consider using tinyMCE onblur for all react state updates
-    editor.on('blur', () => updateContent(editor.getContent()));
   }
   editor.on('ExecCommand', (e) => {
     if (editorType === 'text' && e.command === 'mceFocus') {


### PR DESCRIPTION
[A previous PR](https://github.com/openedx/frontend-lib-content-components/pull/325) introduces an issue with expandable textarea where images can not be inserted anywhere except at the beginning of the textarea.

This PR fixes this by approaching the solution from a different way. The answer fields are saved to the state before deletion, allowing for the correct answer to be deleted.

This PR also allows the last answer to be deleted by wiping the values of the answer, selectedFeedback and unselectedFeedback text fields for this last answer when delete is clicked.

https://2u-internal.atlassian.net/browse/TNL-10644