### PR TITLE
feat: add raw olx settings parser

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -33,9 +33,7 @@ exports[`EditorProblemView component renders raw editor 1`] = `
     title="OLX settings discrepancy"
   >
     <FormattedMessage
-      defaultMessage="A discrepancy was found between the settings defined in the <problem> tag
-      and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved
-      and corresponding values in the sidebar will be discarded."
+      defaultMessage="A discrepancy was found between the settings defined in the <problem> tag and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved and corresponding values in the sidebar will be discarded."
       description="Explanation in body of mismatched settings modal"
       id="authoring.problemEditor.editProblemView.saveWarningModal.olxSettingDiscrepancy.body.explanation"
     />

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -33,7 +33,9 @@ exports[`EditorProblemView component renders raw editor 1`] = `
     title="OLX settings discrepancy"
   >
     <FormattedMessage
-      defaultMessage="A discrepancy was found between the settings defined in the <problem> tag and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved and corresponding values in the sidebar will be discarded."
+      defaultMessage="A discrepancy was found between the settings defined in the OLX's problem tag and the
+      settings selected in the sidebar. The settings defined in the OLX's problem tag will be saved and
+      corresponding values in the sidebar will be discarded."
       description="Explanation in body of mismatched settings modal"
       id="authoring.problemEditor.editProblemView.saveWarningModal.olxSettingDiscrepancy.body.explanation"
     />

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -13,8 +13,8 @@ exports[`EditorProblemView component renders raw editor 1`] = `
         >
           <FormattedMessage
             defaultMessage="Cancel"
-            description="Label for cancel button in the no answer modal"
-            id="authoring.problemEditor.editProblemView.noAnswerModal.cancelButton.label"
+            description="Label for cancel button in the save warning modal"
+            id="authoring.problemEditor.editProblemView.saveWarningModal.cancelButton.label"
           />
         </Button>
         <Button
@@ -22,30 +22,23 @@ exports[`EditorProblemView component renders raw editor 1`] = `
         >
           <FormattedMessage
             defaultMessage="Ok"
-            description="Label for save button in the no answer modal"
-            id="authoring.problemEditor.editProblemView.noAnswerModal.saveButton.label"
+            description="Label for save button in the save warning modal"
+            id="authoring.problemEditor.editProblemView.saveWarningModal.saveButton.label"
           />
         </Button>
       </ActionRow>
     }
     isOpen={false}
     onClose={[Function]}
-    title="No answer specified"
+    title="OLX settings discrepancy"
   >
-    <div>
-      <FormattedMessage
-        defaultMessage="Are you sure you want to exit the editor?"
-        description="Question in body of no answer modal"
-        id="authoring.problemEditor.editProblemView.noAnswerModal.body.question"
-      />
-    </div>
-    <div>
-      <FormattedMessage
-        defaultMessage="No correct answer has been specified."
-        description="Explanation in body of no answer modal"
-        id="authoring.problemEditor.editProblemView.noAnswerModal.body.explanation"
-      />
-    </div>
+    <FormattedMessage
+      defaultMessage="A discrepancy was found between the settings defined in the <problem> tag
+      and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved
+      and corresponding values in the sidebar will be discarded."
+      description="Explanation in body of mismatched settings modal"
+      id="authoring.problemEditor.editProblemView.saveWarningModal.olxSettingDiscrepancy.body.explanation"
+    />
   </Component>
   <div
     className="editProblemView d-flex flex-row flex-nowrap justify-content-end"
@@ -88,8 +81,8 @@ exports[`EditorProblemView component renders simple view 1`] = `
         >
           <FormattedMessage
             defaultMessage="Cancel"
-            description="Label for cancel button in the no answer modal"
-            id="authoring.problemEditor.editProblemView.noAnswerModal.cancelButton.label"
+            description="Label for cancel button in the save warning modal"
+            id="authoring.problemEditor.editProblemView.saveWarningModal.cancelButton.label"
           />
         </Button>
         <Button
@@ -97,8 +90,8 @@ exports[`EditorProblemView component renders simple view 1`] = `
         >
           <FormattedMessage
             defaultMessage="Ok"
-            description="Label for save button in the no answer modal"
-            id="authoring.problemEditor.editProblemView.noAnswerModal.saveButton.label"
+            description="Label for save button in the save warning modal"
+            id="authoring.problemEditor.editProblemView.saveWarningModal.saveButton.label"
           />
         </Button>
       </ActionRow>
@@ -110,15 +103,15 @@ exports[`EditorProblemView component renders simple view 1`] = `
     <div>
       <FormattedMessage
         defaultMessage="Are you sure you want to exit the editor?"
-        description="Question in body of no answer modal"
-        id="authoring.problemEditor.editProblemView.noAnswerModal.body.question"
+        description="Question in body of save warning modal"
+        id="authoring.problemEditor.editProblemView.saveWarningModal.body.question"
       />
     </div>
     <div>
       <FormattedMessage
         defaultMessage="No correct answer has been specified."
         description="Explanation in body of no answer modal"
-        id="authoring.problemEditor.editProblemView.noAnswerModal.body.explanation"
+        id="authoring.problemEditor.editProblemView.saveWarningModal.noAnswer.body.explanation"
       />
     </div>
   </Component>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
@@ -7,15 +7,15 @@ import { setAssetToStaticUrl } from '../../../../sharedComponents/TinyMceWidget/
 import { ProblemTypeKeys } from '../../../../data/constants/problem';
 
 export const state = StrictDict({
-  isNoAnswerModalOpen: (val) => useState(val),
+  isSaveWarningModalOpen: (val) => useState(val),
 });
 
-export const noAnswerModalToggle = () => {
-  const [isNoAnswerModalOpen, setIsOpen] = state.isNoAnswerModalOpen(false);
+export const saveWarningModalToggle = () => {
+  const [isSaveWarningModalOpen, setIsOpen] = state.isSaveWarningModalOpen(false);
   return {
-    isNoAnswerModalOpen,
-    openNoAnswerModal: () => setIsOpen(true),
-    closeNoAnswerModal: () => setIsOpen(false),
+    isSaveWarningModalOpen,
+    openSaveWarningModal: () => setIsOpen(true),
+    closeSaveWarningModal: () => setIsOpen(false),
   };
 };
 
@@ -58,18 +58,18 @@ export const parseState = ({
   assets,
   lmsEndpointUrl,
 }) => () => {
-  const editorObject = fetchEditorContent({ format: '' });
-  const reactSettingsParser = new ReactStateSettingsParser(problem);
-  const reactOLXParser = new ReactStateOLXParser({ problem, editorObject });
-  const reactBuiltOlx = setAssetToStaticUrl({ editorValue: reactOLXParser.buildOLX(), assets, lmsEndpointUrl });
   const rawOLX = ref?.current?.state.doc.toString();
+  const editorObject = fetchEditorContent({ format: '' });
+  const reactOLXParser = new ReactStateOLXParser({ problem, editorObject });
+  const reactSettingsParser = new ReactStateSettingsParser({ problem, rawOLX });
+  const reactBuiltOlx = setAssetToStaticUrl({ editorValue: reactOLXParser.buildOLX(), assets, lmsEndpointUrl });
   return {
-    settings: reactSettingsParser.getSettings(),
+    settings: isAdvanced ? reactSettingsParser.parseRawOlxSettings() : reactSettingsParser.getSettings(),
     olx: isAdvanced ? rawOLX : reactBuiltOlx,
   };
 };
 
-export const checkForNoAnswers = ({ openNoAnswerModal, problem }) => {
+export const checkForNoAnswers = ({ openSaveWarningModal, problem }) => {
   const simpleTextAreaProblems = [ProblemTypeKeys.DROPDOWN, ProblemTypeKeys.NUMERIC, ProblemTypeKeys.TEXTINPUT];
   const editorObject = fetchEditorContent({ format: '' });
   const { problemType } = problem;
@@ -107,11 +107,31 @@ export const checkForNoAnswers = ({ openNoAnswerModal, problem }) => {
   };
 
   if (problemType === ProblemTypeKeys.NUMERIC && !hasTitle()) {
-    openNoAnswerModal();
+    openSaveWarningModal();
     return true;
   }
   if (!hasNoCorrectAnswer()) {
-    openNoAnswerModal();
+    openSaveWarningModal();
+    return true;
+  }
+  return false;
+};
+
+export const checkForSettingDiscrepancy = ({ problem, ref, openSaveWarningModal }) => {
+  const rawOLX = ref?.current?.state.doc.toString();
+  const reactSettingsParser = new ReactStateSettingsParser({ problem, rawOLX });
+  const problemSettings = reactSettingsParser.getSettings();
+  const rawOlxSettings = reactSettingsParser.parseRawOlxSettings();
+  let isMismatched = false;
+  // console.log(rawOlxSettings);
+  Object.entries(rawOlxSettings).forEach(([key, value]) => {
+    if (value !== problemSettings[key]) {
+      isMismatched = true;
+    }
+  });
+
+  if (isMismatched) {
+    openSaveWarningModal();
     return true;
   }
   return false;
@@ -119,7 +139,7 @@ export const checkForNoAnswers = ({ openNoAnswerModal, problem }) => {
 
 export const getContent = ({
   problemState,
-  openNoAnswerModal,
+  openSaveWarningModal,
   isAdvancedProblemType,
   editorRef,
   assets,
@@ -128,9 +148,14 @@ export const getContent = ({
   const problem = problemState;
   const hasNoAnswers = isAdvancedProblemType ? false : checkForNoAnswers({
     problem,
-    openNoAnswerModal,
+    openSaveWarningModal,
   });
-  if (!hasNoAnswers) {
+  const hasMismatchedSettings = isAdvancedProblemType ? checkForSettingDiscrepancy({
+    ref: editorRef,
+    problem,
+    openSaveWarningModal,
+  }) : false;
+  if (!hasNoAnswers && !hasMismatchedSettings) {
     const data = parseState({
       isAdvanced: isAdvancedProblemType,
       ref: editorRef,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
@@ -90,7 +90,7 @@ export const checkForNoAnswers = ({ openSaveWarningModal, problem }) => {
     return false;
   };
 
-  const hasNoCorrectAnswer = () => {
+  const hasCorrectAnswer = () => {
     let correctAnswer;
     answers.forEach(answer => {
       if (answer.correct) {
@@ -110,7 +110,7 @@ export const checkForNoAnswers = ({ openSaveWarningModal, problem }) => {
     openSaveWarningModal();
     return true;
   }
-  if (!hasNoCorrectAnswer()) {
+  if (!hasCorrectAnswer()) {
     openSaveWarningModal();
     return true;
   }

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
@@ -2,8 +2,49 @@ import { ProblemTypeKeys } from '../../../../data/constants/problem';
 import * as hooks from './hooks';
 import { MockUseState } from '../../../../../testUtils';
 
-const mockRawOLX = 'rawOLX';
+const mockRawOLX = '<problem>rawOLX</problem>';
 const mockBuiltOLX = 'builtOLX';
+const mockGetSettings = {
+  max_attempts: 1,
+  weight: 2,
+  showanswer: 'finished',
+  show_reset_button: false,
+  rerandomize: 'never',
+};
+const mockParseRawOlxSettingsDiscrepancy = {
+  max_attempts: 1,
+  weight: 2,
+  showanswer: 'finished',
+  show_reset_button: true,
+  rerandomize: 'never',
+};
+const mockParseRawOlxSettings = {
+  max_attempts: 1,
+  weight: 2,
+  showanswer: 'finished',
+  show_reset_button: false,
+  rerandomize: 'never',
+};
+const problemState = {
+  problemType: ProblemTypeKeys.ADVANCED,
+  settings: {
+    randomization: null,
+    scoring: {
+      weight: 1,
+      attempts: {
+        unlimited: true,
+        number: '',
+      },
+    },
+    timeBetween: 0,
+    showAnswer: {
+      on: 'finished',
+      afterAttempts: 0,
+    },
+    showResetButton: false,
+    solutionExplanation: '',
+  },
+};
 
 const toStringMock = () => mockRawOLX;
 const refMock = { current: { state: { doc: { toString: toStringMock } } } };
@@ -13,12 +54,11 @@ jest.mock('../../data/ReactStateOLXParser', () => (
     buildOLX: () => mockBuiltOLX,
   }))
 ));
-jest.mock('../../data/ReactStateSettingsParser');
 
 const hookState = new MockUseState(hooks);
 
-describe('noAnswerModalToggle', () => {
-  const hookKey = hookState.keys.isNoAnswerModalOpen;
+describe('saveWarningModalToggle', () => {
+  const hookKey = hookState.keys.isSaveWarningModalOpen;
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -33,20 +73,20 @@ describe('noAnswerModalToggle', () => {
       hookState.restore();
     });
 
-    describe('noAnswerModalToggle', () => {
+    describe('saveWarningModalToggle', () => {
       let hook;
       beforeEach(() => {
-        hook = hooks.noAnswerModalToggle();
+        hook = hooks.saveWarningModalToggle();
       });
-      test('isNoAnswerModalOpen: state value', () => {
-        expect(hook.isNoAnswerModalOpen).toEqual(hookState.stateVals[hookKey]);
+      test('isSaveWarningModalOpen: state value', () => {
+        expect(hook.isSaveWarningModalOpen).toEqual(hookState.stateVals[hookKey]);
       });
-      test('openCancelConfirmModal: calls setter with true', () => {
-        hook.openNoAnswerModal();
+      test('openSaveWarningModal: calls setter with true', () => {
+        hook.openSaveWarningModal();
         expect(hookState.setState[hookKey]).toHaveBeenCalledWith(true);
       });
-      test('closeCancelConfirmModal: calls setter with false', () => {
-        hook.closeNoAnswerModal();
+      test('closeSaveWarningModal: calls setter with false', () => {
+        hook.closeSaveWarningModal();
         expect(hookState.setState[hookKey]).toHaveBeenCalledWith(false);
       });
     });
@@ -93,18 +133,24 @@ describe('EditProblemView hooks parseState', () => {
     });
   });
   describe('parseState', () => {
-    test('default problem', () => {
+    jest.mock('../../data/ReactStateSettingsParser', () => (
+      jest.fn().mockImplementationOnce(() => ({
+        getSettings: () => mockGetSettings,
+        parseRawOlxSettings: () => mockParseRawOlxSettings,
+      }))
+    ));
+    it('default problem', () => {
       const res = hooks.parseState({
-        problem: 'problem',
+        problem: problemState,
         isAdvanced: false,
         ref: refMock,
         assets: {},
       })();
       expect(res.olx).toBe(mockBuiltOLX);
     });
-    test('advanced problem', () => {
+    it('advanced problem', () => {
       const res = hooks.parseState({
-        problem: 'problem',
+        problem: problemState,
         isAdvanced: true,
         ref: refMock,
         assets: {},
@@ -113,7 +159,7 @@ describe('EditProblemView hooks parseState', () => {
     });
   });
   describe('checkNoAnswers', () => {
-    const openNoAnswerModal = jest.fn();
+    const openSaveWarningModal = jest.fn();
     describe('hasNoTitle', () => {
       const problem = {
         problemType: ProblemTypeKeys.NUMERIC,
@@ -123,24 +169,24 @@ describe('EditProblemView hooks parseState', () => {
       });
       it('returns true for numerical problem with empty title', () => {
         const expected = hooks.checkForNoAnswers({
-          openNoAnswerModal,
+          openSaveWarningModal,
           problem: {
             ...problem,
             answers: [{ id: 'A', title: '', correct: true }],
           },
         });
-        expect(openNoAnswerModal).toHaveBeenCalled();
+        expect(openSaveWarningModal).toHaveBeenCalled();
         expect(expected).toEqual(true);
       });
       it('returns false for numerical problem with title', () => {
         const expected = hooks.checkForNoAnswers({
-          openNoAnswerModal,
+          openSaveWarningModal,
           problem: {
             ...problem,
             answers: [{ id: 'A', title: 'sOmevALUe', correct: true }],
           },
         });
-        expect(openNoAnswerModal).not.toHaveBeenCalled();
+        expect(openSaveWarningModal).not.toHaveBeenCalled();
         expect(expected).toEqual(false);
       });
     });
@@ -154,88 +200,134 @@ describe('EditProblemView hooks parseState', () => {
       it('returns true for single select problem with empty title', () => {
         window.tinymce.editors = { 'answer-A': { getContent: () => '' }, 'answer-B': { getContent: () => 'sOmevALUe' } };
         const expected = hooks.checkForNoAnswers({
-          openNoAnswerModal,
+          openSaveWarningModal,
           problem: {
             ...problem,
             answers: [{ id: 'A', title: '', correct: true }, { id: 'B', title: 'sOmevALUe', correct: false }],
           },
         });
-        expect(openNoAnswerModal).toHaveBeenCalled();
+        expect(openSaveWarningModal).toHaveBeenCalled();
         expect(expected).toEqual(true);
       });
       it('returns true for single select with title but no correct answer', () => {
         window.tinymce.editors = { 'answer-A': { getContent: () => 'sOmevALUe' } };
         const expected = hooks.checkForNoAnswers({
-          openNoAnswerModal,
+          openSaveWarningModal,
           problem: {
             ...problem,
             answers: [{ id: 'A', title: 'sOmevALUe', correct: false }, { id: 'B', title: '', correct: false }],
           },
         });
-        expect(openNoAnswerModal).toHaveBeenCalled();
+        expect(openSaveWarningModal).toHaveBeenCalled();
         expect(expected).toEqual(true);
       });
       it('returns true for single select with title and correct answer', () => {
         window.tinymce.editors = { 'answer-A': { getContent: () => 'sOmevALUe' } };
         const expected = hooks.checkForNoAnswers({
-          openNoAnswerModal,
+          openSaveWarningModal,
           problem: {
             ...problem,
             answers: [{ id: 'A', title: 'sOmevALUe', correct: true }],
           },
         });
-        expect(openNoAnswerModal).not.toHaveBeenCalled();
+        expect(openSaveWarningModal).not.toHaveBeenCalled();
         expect(expected).toEqual(false);
       });
+    });
+  });
+  describe('checkForSettingDiscrepancy', () => {
+    const openSaveWarningModal = jest.fn();
+    const problem = problemState;
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('returns true for setting discrepancies', () => {
+      jest.mock('../../data/ReactStateSettingsParser', () => (
+        jest.fn().mockImplementationOnce(() => ({
+          getSettings: () => mockGetSettings,
+          parseRawOlxSettings: () => mockParseRawOlxSettingsDiscrepancy,
+        }))
+      ));
+      const mockRawOLXWithSettings = '<problem show_reset_button="true">rawOLX</problem>';
+      const refMockWithSettings = { current: { state: { doc: { toString: () => mockRawOLXWithSettings } } } };
+      const expected = hooks.checkForSettingDiscrepancy({
+        openSaveWarningModal,
+        problem,
+        ref: refMockWithSettings,
+      });
+      expect(openSaveWarningModal).toHaveBeenCalled();
+      expect(expected).toEqual(true);
+    });
+    it('returns false for setting discrepancies', () => {
+      jest.mock('../../data/ReactStateSettingsParser', () => (
+        jest.fn().mockImplementationOnce(() => ({
+          getSettings: () => mockGetSettings,
+          parseRawOlxSettings: () => mockParseRawOlxSettings,
+        }))
+      ));
+      const expected = hooks.checkForSettingDiscrepancy({
+        openSaveWarningModal,
+        problem,
+        ref: refMock,
+      });
+      expect(openSaveWarningModal).not.toHaveBeenCalled();
+      expect(expected).toEqual(false);
     });
   });
   describe('getContent', () => {
     const assets = {};
     const lmsEndpointUrl = 'someUrl';
     const editorRef = refMock;
-    const openNoAnswerModal = jest.fn();
+    const expectedSettings = {
+      max_attempts: '',
+      weight: 1,
+      showanswer: 'finished',
+      show_reset_button: false,
+      submission_wait_seconds: 0,
+      attempts_before_showanswer_button: 0,
+    };
+    const openSaveWarningModal = jest.fn();
 
-    test('default visual save and returns parseState data', () => {
-      const problemState = { problemType: ProblemTypeKeys.NUMERIC, answers: [{ id: 'A', title: 'problem', correct: true }] };
+    it('default visual save and returns parseState data', () => {
+      const problem = { ...problemState, problemType: ProblemTypeKeys.NUMERIC, answers: [{ id: 'A', title: 'problem', correct: true }] };
       const content = hooks.getContent({
         isAdvancedProblemType: false,
-        problemState,
+        problemState: problem,
         editorRef,
         assets,
         lmsEndpointUrl,
-        openNoAnswerModal,
+        openSaveWarningModal,
       });
       expect(content).toEqual({
         olx: 'builtOLX',
-        settings: undefined,
+        settings: expectedSettings,
       });
     });
-    test('default advanced save and returns parseState data', () => {
-      const problemState = { problemType: ProblemTypeKeys.ADVANCED };
+    it('default advanced save and returns parseState data', () => {
       const content = hooks.getContent({
         isAdvancedProblemType: true,
         problemState,
         editorRef,
         assets,
         lmsEndpointUrl,
-        openNoAnswerModal,
+        openSaveWarningModal,
       });
       expect(content).toEqual({
-        olx: 'rawOLX',
-        settings: undefined,
+        olx: '<problem>rawOLX</problem>',
+        settings: expectedSettings,
       });
     });
-    test('returns null', () => {
-      const problemState = { problemType: ProblemTypeKeys.NUMERIC, answers: [{ id: 'A', title: '', correct: true }] };
+    it('should return null', () => {
+      const problem = { ...problemState, problemType: ProblemTypeKeys.NUMERIC, answers: [{ id: 'A', title: '', correct: true }] };
       const content = hooks.getContent({
         isAdvancedProblemType: false,
-        problemState,
+        problemState: problem,
         editorRef,
         assets,
         lmsEndpointUrl,
-        openNoAnswerModal,
+        openSaveWarningModal,
       });
-      expect(openNoAnswerModal).toHaveBeenCalled();
+      expect(openSaveWarningModal).toHaveBeenCalled();
       expect(content).toEqual(null);
     });
   });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
@@ -160,14 +160,14 @@ describe('EditProblemView hooks parseState', () => {
   });
   describe('checkNoAnswers', () => {
     const openSaveWarningModal = jest.fn();
-    describe('hasNoTitle', () => {
+    describe('hasTitle', () => {
       const problem = {
         problemType: ProblemTypeKeys.NUMERIC,
       };
       beforeEach(() => {
         jest.clearAllMocks();
       });
-      it('returns true for numerical problem with empty title', () => {
+      it('should call openSaveWarningModal for numerical problem with empty title', () => {
         const expected = hooks.checkForNoAnswers({
           openSaveWarningModal,
           problem: {
@@ -190,14 +190,14 @@ describe('EditProblemView hooks parseState', () => {
         expect(expected).toEqual(false);
       });
     });
-    describe('hasNoCorrectAnswer', () => {
+    describe('hasCorrectAnswer', () => {
       const problem = {
         problemType: ProblemTypeKeys.SINGLESELECT,
       };
       beforeEach(() => {
         jest.clearAllMocks();
       });
-      it('returns true for single select problem with empty title', () => {
+      it('should call openSaveWarningModal for single select problem with empty title', () => {
         window.tinymce.editors = { 'answer-A': { getContent: () => '' }, 'answer-B': { getContent: () => 'sOmevALUe' } };
         const expected = hooks.checkForNoAnswers({
           openSaveWarningModal,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
@@ -258,7 +258,7 @@ describe('EditProblemView hooks parseState', () => {
       expect(openSaveWarningModal).toHaveBeenCalled();
       expect(expected).toEqual(true);
     });
-    it('returns false for setting discrepancies', () => {
+    it('returns false when there are no setting discrepancies', () => {
       jest.mock('../../data/ReactStateSettingsParser', () => (
         jest.fn().mockImplementationOnce(() => ({
           getSettings: () => mockGetSettings,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -17,7 +17,7 @@ import { selectors } from '../../../../data/redux';
 import RawEditor from '../../../../sharedComponents/RawEditor';
 import { ProblemTypeKeys } from '../../../../data/constants/problem';
 
-import { parseState, noAnswerModalToggle, getContent } from './hooks';
+import { parseState, saveWarningModalToggle, getContent } from './hooks';
 import './index.scss';
 import messages from './messages';
 
@@ -35,16 +35,16 @@ export const EditProblemView = ({
   // injected
   intl,
 }) => {
+  const dispatch = useDispatch();
   const editorRef = useRef(null);
   const isAdvancedProblemType = problemType === ProblemTypeKeys.ADVANCED;
-  const { isNoAnswerModalOpen, openNoAnswerModal, closeNoAnswerModal } = noAnswerModalToggle();
-  const dispatch = useDispatch();
+  const { isSaveWarningModalOpen, openSaveWarningModal, closeSaveWarningModal } = saveWarningModalToggle();
 
   return (
     <EditorContainer
       getContent={() => getContent({
         problemState,
-        openNoAnswerModal,
+        openSaveWarningModal,
         isAdvancedProblemType,
         editorRef,
         assets,
@@ -52,13 +52,15 @@ export const EditProblemView = ({
       })}
     >
       <AlertModal
-        title={intl.formatMessage(messages.noAnswerModalTitle)}
-        isOpen={isNoAnswerModalOpen}
-        onClose={closeNoAnswerModal}
+        title={isAdvancedProblemType ? (
+          intl.formatMessage(messages.olxSettingDiscrepancyTitle)
+        ) : intl.formatMessage(messages.noAnswerTitle)}
+        isOpen={isSaveWarningModalOpen}
+        onClose={closeSaveWarningModal}
         footerNode={(
           <ActionRow>
-            <Button variant="tertiary" onClick={closeNoAnswerModal}>
-              <FormattedMessage {...messages.noAnswerCancelButtonLabel} />
+            <Button variant="tertiary" onClick={closeSaveWarningModal}>
+              <FormattedMessage {...messages.saveWarningModalCancelButtonLabel} />
             </Button>
             <Button
               onClick={() => saveBlock({
@@ -74,17 +76,23 @@ export const EditProblemView = ({
                 analytics,
               })}
             >
-              <FormattedMessage {...messages.noAnswerSaveButtonLabel} />
+              <FormattedMessage {...messages.saveWarningModalSaveButtonLabel} />
             </Button>
           </ActionRow>
         )}
       >
-        <div>
-          <FormattedMessage {...messages.noAnswerModalBodyQuestion} />
-        </div>
-        <div>
-          <FormattedMessage {...messages.noAnswerModalBodyExplanation} />
-        </div>
+        {isAdvancedProblemType ? (
+          <FormattedMessage {...messages.olxSettingDiscrepancyBodyExplanation} />
+        ) : (
+          <>
+            <div>
+              <FormattedMessage {...messages.saveWarningModalBodyQuestion} />
+            </div>
+            <div>
+              <FormattedMessage {...messages.noAnswerBodyExplanation} />
+            </div>
+          </>
+        )}
       </AlertModal>
       <div className="editProblemView d-flex flex-row flex-nowrap justify-content-end">
         {isAdvancedProblemType ? (

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/messages.js
@@ -33,9 +33,7 @@ const messages = defineMessages({
   },
   olxSettingDiscrepancyBodyExplanation: {
     id: 'authoring.problemEditor.editProblemView.saveWarningModal.olxSettingDiscrepancy.body.explanation',
-    defaultMessage: `A discrepancy was found between the settings defined in the <problem> tag
-      and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved
-      and corresponding values in the sidebar will be discarded.`,
+    defaultMessage: 'A discrepancy was found between the settings defined in the <problem> tag and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved and corresponding values in the sidebar will be discarded.',
     description: 'Explanation in body of mismatched settings modal',
   },
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/messages.js
@@ -33,7 +33,9 @@ const messages = defineMessages({
   },
   olxSettingDiscrepancyBodyExplanation: {
     id: 'authoring.problemEditor.editProblemView.saveWarningModal.olxSettingDiscrepancy.body.explanation',
-    defaultMessage: 'A discrepancy was found between the settings defined in the <problem> tag and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved and corresponding values in the sidebar will be discarded.',
+    defaultMessage: `A discrepancy was found between the settings defined in the OLX's problem tag and the
+      settings selected in the sidebar. The settings defined in the OLX's problem tag will be saved and
+      corresponding values in the sidebar will be discarded.`,
     description: 'Explanation in body of mismatched settings modal',
   },
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/messages.js
@@ -1,30 +1,42 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
-  noAnswerCancelButtonLabel: {
-    id: 'authoring.problemEditor.editProblemView.noAnswerModal.cancelButton.label',
+  saveWarningModalCancelButtonLabel: {
+    id: 'authoring.problemEditor.editProblemView.saveWarningModal.cancelButton.label',
     defaultMessage: 'Cancel',
-    description: 'Label for cancel button in the no answer modal',
+    description: 'Label for cancel button in the save warning modal',
   },
-  noAnswerSaveButtonLabel: {
-    id: 'authoring.problemEditor.editProblemView.noAnswerModal.saveButton.label',
+  saveWarningModalSaveButtonLabel: {
+    id: 'authoring.problemEditor.editProblemView.saveWarningModal.saveButton.label',
     defaultMessage: 'Ok',
-    description: 'Label for save button in the no answer modal',
+    description: 'Label for save button in the save warning modal',
   },
-  noAnswerModalTitle: {
-    id: 'authoring.problemEditor.editProblemView.noAnswerModal.title',
+  saveWarningModalBodyQuestion: {
+    id: 'authoring.problemEditor.editProblemView.saveWarningModal.body.question',
+    defaultMessage: 'Are you sure you want to exit the editor?',
+    description: 'Question in body of save warning modal',
+  },
+  noAnswerTitle: {
+    id: 'authoring.problemEditor.editProblemView.saveWarningModal.noAnswer.title',
     defaultMessage: 'No answer specified',
     description: 'Title for no answer modal',
   },
-  noAnswerModalBodyQuestion: {
-    id: 'authoring.problemEditor.editProblemView.noAnswerModal.body.question',
-    defaultMessage: 'Are you sure you want to exit the editor?',
-    description: 'Question in body of no answer modal',
-  },
-  noAnswerModalBodyExplanation: {
-    id: 'authoring.problemEditor.editProblemView.noAnswerModal.body.explanation',
+  noAnswerBodyExplanation: {
+    id: 'authoring.problemEditor.editProblemView.saveWarningModal.noAnswer.body.explanation',
     defaultMessage: 'No correct answer has been specified.',
     description: 'Explanation in body of no answer modal',
+  },
+  olxSettingDiscrepancyTitle: {
+    id: 'authoring.problemEditor.editProblemView.saveWarningModal.olxSettingDiscrepancy.title',
+    defaultMessage: 'OLX settings discrepancy',
+    description: 'Title for mismatched settings modal',
+  },
+  olxSettingDiscrepancyBodyExplanation: {
+    id: 'authoring.problemEditor.editProblemView.saveWarningModal.olxSettingDiscrepancy.body.explanation',
+    defaultMessage: `A discrepancy was found between the settings defined in the <problem> tag
+      and the settings selected in the sidebar. The settings defined in the <problem> tag will be saved
+      and corresponding values in the sidebar will be discarded.`,
+    description: 'Explanation in body of mismatched settings modal',
   },
 });
 

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
@@ -1,13 +1,23 @@
+import { XMLParser } from 'fast-xml-parser';
 import { popuplateItem } from './SettingsParser';
+
+const SETTING_KEYS = [
+  'max_attempts',
+  'weight',
+  'showanswer',
+  'show_reset_button',
+  'rerandomize',
+];
 
 class ReactStateSettingsParser {
   constructor(problemState) {
-    this.problemState = problemState;
+    this.problem = problemState.problem;
+    this.rawOLX = problemState.rawOLX;
   }
 
   getSettings() {
     let settings = {};
-    const stateSettings = this.problemState.settings;
+    const stateSettings = this.problem.settings;
 
     settings = popuplateItem(settings, 'number', 'max_attempts', stateSettings.scoring.attempts);
     settings = popuplateItem(settings, 'weight', 'weight', stateSettings.scoring);
@@ -18,6 +28,34 @@ class ReactStateSettingsParser {
     settings = popuplateItem(settings, 'randomization', 'rerandomize', stateSettings);
 
     return settings;
+  }
+
+  parseRawOlxSettings() {
+    const rawOlxSettings = this.getSettings();
+    // console.log(rawOlxSettings);
+    // console.log(this.rawOLX);
+    const parserOptions = {
+      ignoreAttributes: false,
+      alwaysCreateTextNode: true,
+      numberParseOptions: {
+        leadingZeros: false,
+        hex: false,
+      },
+    };
+    const parser = new XMLParser(parserOptions);
+    const olx = parser.parse(this.rawOLX);
+    const settingAttributes = Object.keys(olx.problem).filter(tag => tag.startsWith('@_'));
+    settingAttributes.forEach(attribute => {
+      const attributeKey = attribute.substring(2);
+      if (SETTING_KEYS.includes(attributeKey)) {
+        if (attributeKey === 'max_attempts' || attributeKey === 'weight') {
+          rawOlxSettings[attributeKey] = parseInt(olx.problem[attribute]);
+        } else {
+          rawOlxSettings[attributeKey] = olx.problem[attribute];
+        }
+      }
+    });
+    return rawOlxSettings;
   }
 }
 

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.test.js
@@ -12,7 +12,7 @@ describe('Test State to Settings Parser', () => {
   test('Test settings parsed from raw olx', () => {
     const settings = new ReactStateSettingsParser({
       problem: checklistWithFeebackHints.state,
-      rawOLX: '<problem showanswer="always">text</problem>'
+      rawOLX: '<problem showanswer="always">text</problem>',
     }).parseRawOlxSettings();
     const { markdown, ...settingsPayload } = checklistWithFeebackHints.metadata;
     expect(settings).toStrictEqual({ ...settingsPayload, showanswer: 'always' });

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.test.js
@@ -5,8 +5,16 @@ import {
 
 describe('Test State to Settings Parser', () => {
   test('Test settings parsed from react state', () => {
-    const settings = new ReactStateSettingsParser(checklistWithFeebackHints.state).getSettings();
+    const settings = new ReactStateSettingsParser({ problem: checklistWithFeebackHints.state }).getSettings();
     const { markdown, ...settingsPayload } = checklistWithFeebackHints.metadata;
     expect(settings).toStrictEqual(settingsPayload);
+  });
+  test('Test settings parsed from raw olx', () => {
+    const settings = new ReactStateSettingsParser({
+      problem: checklistWithFeebackHints.state,
+      rawOLX: '<problem showanswer="always">text</problem>'
+    }).parseRawOlxSettings();
+    const { markdown, ...settingsPayload } = checklistWithFeebackHints.metadata;
+    expect(settings).toStrictEqual({ ...settingsPayload, showanswer: 'always' });
   });
 });

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -19,7 +19,7 @@ export const switchToAdvancedEditor = () => (dispatch, getState) => {
 };
 
 export const isBlankProblem = ({ rawOLX }) => {
-  if (rawOLX === blankProblemOLX.rawOLX) {
+  if (rawOLX.replace(/\s/g, '') === blankProblemOLX.rawOLX) {
     return true;
   }
   return false;
@@ -43,7 +43,7 @@ export const getDataFromOlx = ({ rawOLX, rawSettings }) => {
   if (!_.isEmpty(rawOLX) && !_.isEmpty(data)) {
     return { ...data, rawOLX, settings: parsedSettings };
   }
-  return {};
+  return { settings: parsedSettings };
 };
 
 export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispatch) => {


### PR DESCRIPTION
JIRA Ticket: [TNL-10619](https://2u-internal.atlassian.net/browse/TNL-10619)

A problem's metadata can be defined in the `<problem>` tags like the following:
```
<problem showanswer="always">raw olx</problem>
```
The presence of this attribute navigates to the advanced editor. However, the value of the attribute is not saved to the problem's metadata. This means that the intended value is not displayed in Studio or the LMS. This PR adds a function that parses the raw olx and updates the metadata according to the values in the olx. When the raw olx settings do not match the metadata settings, the user is notified of the difference. On confirmation the raw olx settings overwrite the corresponding metadata.