### PR TITLE
fix: feedback clearing on type change

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -228,9 +228,20 @@ export const typeRowHooks = ({
     answers.forEach(answer => {
       const title = currentAnswerTitles?.[answer.id] || answer.title;
       if (answer.correct) {
-        updateAnswer({ ...answer, title, selectedFeedback, unselectedFeedback, correct: false });
+        updateAnswer({
+          ...answer,
+          title,
+          selectedFeedback,
+          unselectedFeedback,
+          correct: false,
+        });
       } else {
-        updateAnswer({ ...answer, selectedFeedback, unselectedFeedback, title });
+        updateAnswer({
+          ...answer,
+          selectedFeedback,
+          unselectedFeedback,
+          title,
+        });
       }
     });
   };
@@ -243,7 +254,13 @@ export const typeRowHooks = ({
     }
     answers.forEach(answer => {
       const title = currentAnswerTitles ? currentAnswerTitles[answer.id] : answer.title;
-      updateAnswer({ ...answer, title, selectedFeedback, unselectedFeedback, correct: true });
+      updateAnswer({
+        ...answer,
+        title,
+        selectedFeedback,
+        unselectedFeedback,
+        correct: true,
+      });
     });
   };
 
@@ -251,7 +268,12 @@ export const typeRowHooks = ({
     const { selectedFeedback, unselectedFeedback, ...editorContent } = fetchEditorContent({ format: 'text' });
     const currentAnswerTitles = editorContent.answers;
     answers.forEach(answer => {
-      updateAnswer({ ...answer, selectedFeedback, unselectedFeedback, title: currentAnswerTitles[answer.id] });
+      updateAnswer({
+        ...answer,
+        selectedFeedback,
+        unselectedFeedback,
+        title: currentAnswerTitles[answer.id],
+      });
     });
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -221,34 +221,37 @@ export const typeRowHooks = ({
 }) => {
   const clearPreviouslySelectedAnswers = () => {
     let currentAnswerTitles;
+    const { selectedFeedback, unselectedFeedback, ...editorContent } = fetchEditorContent({ format: 'text' });
     if (RichTextProblems.includes(problemType)) {
-      currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
+      currentAnswerTitles = editorContent.answers;
     }
     answers.forEach(answer => {
       const title = currentAnswerTitles?.[answer.id] || answer.title;
       if (answer.correct) {
-        updateAnswer({ ...answer, title, correct: false });
+        updateAnswer({ ...answer, title, selectedFeedback, unselectedFeedback, correct: false });
       } else {
-        updateAnswer({ ...answer, title });
+        updateAnswer({ ...answer, selectedFeedback, unselectedFeedback, title });
       }
     });
   };
 
   const updateAnswersToCorrect = () => {
     let currentAnswerTitles;
+    const { selectedFeedback, unselectedFeedback, ...editorContent } = fetchEditorContent({ format: 'text' });
     if (RichTextProblems.includes(problemType)) {
-      currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
+      currentAnswerTitles = editorContent.answers;
     }
     answers.forEach(answer => {
       const title = currentAnswerTitles ? currentAnswerTitles[answer.id] : answer.title;
-      updateAnswer({ ...answer, title, correct: true });
+      updateAnswer({ ...answer, title, selectedFeedback, unselectedFeedback, correct: true });
     });
   };
 
   const convertToPlainText = () => {
-    const currentAnswerTitles = fetchEditorContent({ format: 'text' }).answers;
+    const { selectedFeedback, unselectedFeedback, ...editorContent } = fetchEditorContent({ format: 'text' });
+    const currentAnswerTitles = editorContent.answers;
     answers.forEach(answer => {
-      updateAnswer({ ...answer, title: currentAnswerTitles[answer.id] });
+      updateAnswer({ ...answer, selectedFeedback, unselectedFeedback, title: currentAnswerTitles[answer.id] });
     });
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.js
@@ -32,17 +32,17 @@ export const fetchEditorContent = ({ format }) => {
         const { selectedFeedback, unselectedFeedback, groupFeedback } = editorObject;
         const feedbackId = id.substring(id.indexOf('-') + 1);
         if (id.startsWith('selected')) {
-          editorObject.selectedFeedback = { ...selectedFeedback, [feedbackId]: editor.getContent({ format }) };
+          editorObject.selectedFeedback = { ...selectedFeedback, [feedbackId]: editor.getContent() };
         }
         if (id.startsWith('unselected')) {
-          editorObject.unselectedFeedback = { ...unselectedFeedback, [feedbackId]: editor.getContent({ format }) };
+          editorObject.unselectedFeedback = { ...unselectedFeedback, [feedbackId]: editor.getContent() };
         }
         if (id.startsWith('group')) {
-          editorObject.groupFeedback = { ...groupFeedback, [feedbackId]: editor.getContent({ format }) };
+          editorObject.groupFeedback = { ...groupFeedback, [feedbackId]: editor.getContent() };
         }
       } else if (id.startsWith('hint')) {
         const { hints } = editorObject;
-        hints.push(editor.getContent({ format }));
+        hints.push(editor.getContent());
       } else {
         editorObject[id] = editor.getContent();
       }


### PR DESCRIPTION
When a user changed from a single select or multi-select problem type to another, the feedback was cleared out. This is because the data wasn't stored in the redux store before the problem type was updated. Now when changing between problem types, the feedback is saved to the redux store.