### PR TITLE
fix: olx parsers with formatted text

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -127,6 +127,7 @@ export class OLXParser {
    * @return {array} array containing answer objects and possibly an array of grouped feedback
    */
   getPreservedAnswersAndFeedback(problemType, widgetName, option) {
+    console.log('calling preserved');
     const preservedProblem = this.richTextProblem;
     const isChoiceProblem = problemType !== ProblemTypeKeys.NUMERIC ? problemType !== ProblemTypeKeys.TEXTINPUT : false;
     const preservedAnswers = [];
@@ -159,6 +160,7 @@ export class OLXParser {
         });
       }
     });
+    console.log(preservedAnswers);
     return preservedAnswers;
   }
 
@@ -523,8 +525,8 @@ export class OLXParser {
    */
   getSolutionExplanation(problemType) {
     if (!_.has(this.problem, `${problemType}.solution`) && !_.has(this.problem, 'solution')) { return null; }
-
-    let { solution } = this.richTextProblem[0][problemType].pop();
+    const problemBody = this.richTextProblem.filter(section => Object.keys(section).includes(problemType));
+    let { solution } = problemBody[0][problemType].pop();
     const { div } = solution[0];
     if (solution.length === 1 && div) {
       div.forEach((block) => {

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -25,18 +25,8 @@ class ReactStateOLXParser {
       },
       preserveOrder: true,
     };
-    const builderOptions = {
-      ignoreAttributes: false,
-      attributeNamePrefix: '@_',
-      suppressBooleanAttributes: false,
-      format: true,
-      numberParseOptions: {
-        leadingZeros: false,
-        hex: false,
-      },
-    };
+
     this.richTextParser = new XMLParser(richTextParserOptions);
-    this.builder = new XMLBuilder(builderOptions);
     this.richTextBuilder = new XMLBuilder(richTextBuilderOptions);
     this.editorObject = problemState.editorObject;
     this.problemState = problemState.problem;

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
@@ -22,7 +22,7 @@ import {
 import ReactStateOLXParser from './ReactStateOLXParser';
 
 describe('Check React State OLXParser problem', () => {
-  test('Test checkbox with feedback and hints problem type', () => {
+  test('for checkbox with feedback and hints problem type', () => {
     const olxparser = new OLXParser(checkboxesOLXWithFeedbackAndHintsOLX.rawOLX);
     const problem = olxparser.getParsedOLXData();
     const stateParser = new ReactStateOLXParser({


### PR DESCRIPTION
JIRA Ticket: [TNL-10689](https://2u-internal.atlassian.net/browse/TNL-10689)

Currently if a user formats their text (italicize, bold, etc.) or adds an image all inside the same parent tag, e.g. `<p>`, the order of the text/image will be changed on save and re-open. This causes user to be confused and not trust the visual editor as it is not saving their work as expected. This PR uses `fast-xml-parser`'s attribute `preserve-order` to keep the text in the same order while parsing and building. This attribute is currently used for the question parser, and is now being applied to all places where tinymce is used.