### PR TITLE
feat: add returnUrl prop to editors

### DIFF
--- a/src/editors/Editor.jsx
+++ b/src/editors/Editor.jsx
@@ -15,7 +15,7 @@ export const Editor = ({
   lmsEndpointUrl,
   studioEndpointUrl,
   onClose,
-  returnUrl,
+  returnFunction,
 }) => {
   const dispatch = useDispatch();
   hooks.initializeApp({
@@ -38,7 +38,7 @@ export const Editor = ({
         aria-label={blockType}
       >
         {(EditorComponent !== undefined)
-          ? <EditorComponent {...{ onClose, returnUrl }} />
+          ? <EditorComponent {...{ onClose, returnFunction }} />
           : <FormattedMessage {...messages.couldNotFindEditor} />}
       </div>
     </div>
@@ -49,7 +49,7 @@ Editor.defaultProps = {
   learningContextId: null,
   lmsEndpointUrl: null,
   onClose: null,
-  returnUrl: null,
+  returnFunction: null,
   studioEndpointUrl: null,
 };
 
@@ -59,7 +59,7 @@ Editor.propTypes = {
   learningContextId: PropTypes.string,
   lmsEndpointUrl: PropTypes.string,
   onClose: PropTypes.func,
-  returnUrl: PropTypes.string,
+  returnFunction: PropTypes.func,
   studioEndpointUrl: PropTypes.string,
 };
 

--- a/src/editors/Editor.jsx
+++ b/src/editors/Editor.jsx
@@ -15,6 +15,7 @@ export const Editor = ({
   lmsEndpointUrl,
   studioEndpointUrl,
   onClose,
+  returnUrl,
 }) => {
   const dispatch = useDispatch();
   hooks.initializeApp({
@@ -37,7 +38,7 @@ export const Editor = ({
         aria-label={blockType}
       >
         {(EditorComponent !== undefined)
-          ? <EditorComponent onClose={onClose} />
+          ? <EditorComponent {...{ onClose, returnUrl }} />
           : <FormattedMessage {...messages.couldNotFindEditor} />}
       </div>
     </div>
@@ -48,6 +49,7 @@ Editor.defaultProps = {
   learningContextId: null,
   lmsEndpointUrl: null,
   onClose: null,
+  returnUrl: null,
   studioEndpointUrl: null,
 };
 
@@ -57,6 +59,7 @@ Editor.propTypes = {
   learningContextId: PropTypes.string,
   lmsEndpointUrl: PropTypes.string,
   onClose: PropTypes.func,
+  returnUrl: PropTypes.string,
   studioEndpointUrl: PropTypes.string,
 };
 

--- a/src/editors/EditorPage.jsx
+++ b/src/editors/EditorPage.jsx
@@ -13,7 +13,7 @@ export const EditorPage = ({
   lmsEndpointUrl,
   studioEndpointUrl,
   onClose,
-  returnUrl,
+  returnFunction,
 }) => (
   <Provider store={store}>
     <ErrorBoundary
@@ -30,7 +30,7 @@ export const EditorPage = ({
           blockId,
           lmsEndpointUrl,
           studioEndpointUrl,
-          returnUrl,
+          returnFunction,
         }}
       />
     </ErrorBoundary>
@@ -41,7 +41,7 @@ EditorPage.defaultProps = {
   courseId: null,
   lmsEndpointUrl: null,
   onClose: null,
-  returnUrl: null,
+  returnFunction: null,
   studioEndpointUrl: null,
 };
 
@@ -51,7 +51,7 @@ EditorPage.propTypes = {
   courseId: PropTypes.string,
   lmsEndpointUrl: PropTypes.string,
   onClose: PropTypes.func,
-  returnUrl: PropTypes.string,
+  returnFunction: PropTypes.func,
   studioEndpointUrl: PropTypes.string,
 };
 

--- a/src/editors/EditorPage.jsx
+++ b/src/editors/EditorPage.jsx
@@ -13,6 +13,7 @@ export const EditorPage = ({
   lmsEndpointUrl,
   studioEndpointUrl,
   onClose,
+  returnUrl,
 }) => (
   <Provider store={store}>
     <ErrorBoundary
@@ -29,6 +30,7 @@ export const EditorPage = ({
           blockId,
           lmsEndpointUrl,
           studioEndpointUrl,
+          returnUrl,
         }}
       />
     </ErrorBoundary>
@@ -39,6 +41,7 @@ EditorPage.defaultProps = {
   courseId: null,
   lmsEndpointUrl: null,
   onClose: null,
+  returnUrl: null,
   studioEndpointUrl: null,
 };
 
@@ -48,6 +51,7 @@ EditorPage.propTypes = {
   courseId: PropTypes.string,
   lmsEndpointUrl: PropTypes.string,
   onClose: PropTypes.func,
+  returnUrl: PropTypes.string,
   studioEndpointUrl: PropTypes.string,
 };
 

--- a/src/editors/__snapshots__/Editor.test.jsx.snap
+++ b/src/editors/__snapshots__/Editor.test.jsx.snap
@@ -29,6 +29,7 @@ exports[`Editor render snapshot: renders correct editor given blockType (html ->
   >
     <TextEditor
       onClose={[MockFunction props.onClose]}
+      returnUrl={null}
     />
   </div>
 </div>

--- a/src/editors/__snapshots__/Editor.test.jsx.snap
+++ b/src/editors/__snapshots__/Editor.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`Editor render snapshot: renders correct editor given blockType (html ->
   >
     <TextEditor
       onClose={[MockFunction props.onClose]}
-      returnUrl={null}
+      returnFunction={null}
     />
   </div>
 </div>

--- a/src/editors/__snapshots__/EditorPage.test.jsx.snap
+++ b/src/editors/__snapshots__/EditorPage.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`Editor Page snapshots props besides blockType default to null 1`] = `
       learningContextId={null}
       lmsEndpointUrl={null}
       onClose={null}
-      returnUrl={null}
+      returnFunction={null}
       studioEndpointUrl={null}
     />
   </ErrorBoundary>
@@ -51,7 +51,7 @@ exports[`Editor Page snapshots rendering correctly with expected Input 1`] = `
       learningContextId="course-v1:edX+DemoX+Demo_Course"
       lmsEndpointUrl="evenfakerurl.com"
       onClose={[MockFunction props.onClose]}
-      returnUrl={null}
+      returnFunction={null}
       studioEndpointUrl="fakeurl.com"
     />
   </ErrorBoundary>

--- a/src/editors/__snapshots__/EditorPage.test.jsx.snap
+++ b/src/editors/__snapshots__/EditorPage.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`Editor Page snapshots props besides blockType default to null 1`] = `
       learningContextId={null}
       lmsEndpointUrl={null}
       onClose={null}
+      returnUrl={null}
       studioEndpointUrl={null}
     />
   </ErrorBoundary>
@@ -50,6 +51,7 @@ exports[`Editor Page snapshots rendering correctly with expected Input 1`] = `
       learningContextId="course-v1:edX+DemoX+Demo_Course"
       lmsEndpointUrl="evenfakerurl.com"
       onClose={[MockFunction props.onClose]}
+      returnUrl={null}
       studioEndpointUrl="fakeurl.com"
     />
   </ErrorBoundary>

--- a/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`EditorContainer component render snapshot: initialized. enable save and
           Object {
             "handleCancel": Object {
               "onClose": [MockFunction props.onClose],
-              "returnUrl": "someString",
+              "returnFunction": [MockFunction props.returnFunction],
             },
           }
         }
@@ -74,7 +74,7 @@ exports[`EditorContainer component render snapshot: initialized. enable save and
         "handleSaveClicked": Object {
           "dispatch": [MockFunction react-redux.dispatch],
           "getContent": [MockFunction props.getContent],
-          "returnUrl": "someString",
+          "returnFunction": [MockFunction props.returnFunction],
           "validateEntry": [MockFunction props.validateEntry],
         },
       }
@@ -96,7 +96,7 @@ exports[`EditorContainer component render snapshot: not initialized. disable sav
           Object {
             "handleCancel": Object {
               "onClose": [MockFunction props.onClose],
-              "returnUrl": "someString",
+              "returnFunction": [MockFunction props.returnFunction],
             },
           }
         }
@@ -153,7 +153,7 @@ exports[`EditorContainer component render snapshot: not initialized. disable sav
         "handleSaveClicked": Object {
           "dispatch": [MockFunction react-redux.dispatch],
           "getContent": [MockFunction props.getContent],
-          "returnUrl": "someString",
+          "returnFunction": [MockFunction props.returnFunction],
           "validateEntry": [MockFunction props.validateEntry],
         },
       }

--- a/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`EditorContainer component render snapshot: initialized. enable save and
           Object {
             "handleCancel": Object {
               "onClose": [MockFunction props.onClose],
+              "returnUrl": "someString",
             },
           }
         }
@@ -73,6 +74,7 @@ exports[`EditorContainer component render snapshot: initialized. enable save and
         "handleSaveClicked": Object {
           "dispatch": [MockFunction react-redux.dispatch],
           "getContent": [MockFunction props.getContent],
+          "returnUrl": "someString",
           "validateEntry": [MockFunction props.validateEntry],
         },
       }
@@ -94,6 +96,7 @@ exports[`EditorContainer component render snapshot: not initialized. disable sav
           Object {
             "handleCancel": Object {
               "onClose": [MockFunction props.onClose],
+              "returnUrl": "someString",
             },
           }
         }
@@ -150,6 +153,7 @@ exports[`EditorContainer component render snapshot: not initialized. disable sav
         "handleSaveClicked": Object {
           "dispatch": [MockFunction react-redux.dispatch],
           "getContent": [MockFunction props.getContent],
+          "returnUrl": "someString",
           "validateEntry": [MockFunction props.validateEntry],
         },
       }

--- a/src/editors/containers/EditorContainer/hooks.js
+++ b/src/editors/containers/EditorContainer/hooks.js
@@ -23,12 +23,9 @@ export const handleSaveClicked = ({
   dispatch,
   getContent,
   validateEntry,
-  returnUrl,
+  returnFunction,
 }) => {
-  let destination = useSelector(selectors.app.returnUrl);
-  if (returnUrl) {
-    destination = returnUrl;
-  }
+  const destination = useSelector(selectors.app.returnUrl);
   const analytics = useSelector(selectors.app.analytics);
 
   return () => saveBlock({
@@ -36,6 +33,7 @@ export const handleSaveClicked = ({
     content: getContent({ dispatch }),
     destination,
     dispatch,
+    returnFunction,
     validateEntry,
   });
 };
@@ -49,17 +47,13 @@ export const cancelConfirmModalToggle = () => {
   };
 };
 
-export const handleCancel = ({ onClose, returnUrl }) => {
+export const handleCancel = ({ onClose, returnFunction }) => {
   if (onClose) {
     return onClose;
   }
-  let destination = useSelector(selectors.app.returnUrl);
-  console.log(returnUrl);
-  if (returnUrl) {
-    destination = returnUrl;
-  }
   return navigateCallback({
-    destination,
+    returnFunction,
+    destination: useSelector(selectors.app.returnUrl),
     analyticsEvent: analyticsEvt.editorCancelClick,
     analytics: useSelector(selectors.app.analytics),
   });

--- a/src/editors/containers/EditorContainer/hooks.js
+++ b/src/editors/containers/EditorContainer/hooks.js
@@ -19,8 +19,16 @@ export const state = StrictDict({
   isCancelConfirmModalOpen: (val) => useState(val),
 });
 
-export const handleSaveClicked = ({ dispatch, getContent, validateEntry }) => {
-  const destination = useSelector(selectors.app.returnUrl);
+export const handleSaveClicked = ({
+  dispatch,
+  getContent,
+  validateEntry,
+  returnUrl,
+}) => {
+  let destination = useSelector(selectors.app.returnUrl);
+  if (returnUrl) {
+    destination = returnUrl;
+  }
   const analytics = useSelector(selectors.app.analytics);
 
   return () => saveBlock({
@@ -41,12 +49,17 @@ export const cancelConfirmModalToggle = () => {
   };
 };
 
-export const handleCancel = ({ onClose }) => {
+export const handleCancel = ({ onClose, returnUrl }) => {
   if (onClose) {
     return onClose;
   }
+  let destination = useSelector(selectors.app.returnUrl);
+  console.log(returnUrl);
+  if (returnUrl) {
+    destination = returnUrl;
+  }
   return navigateCallback({
-    destination: useSelector(selectors.app.returnUrl),
+    destination,
     analyticsEvent: analyticsEvt.editorCancelClick,
     analytics: useSelector(selectors.app.analytics),
   });

--- a/src/editors/containers/EditorContainer/index.jsx
+++ b/src/editors/containers/EditorContainer/index.jsx
@@ -19,13 +19,14 @@ export const EditorContainer = ({
   getContent,
   onClose,
   validateEntry,
+  returnUrl,
   // injected
   intl,
 }) => {
   const dispatch = useDispatch();
   const isInitialized = hooks.isInitialized();
   const { isCancelConfirmOpen, openCancelConfirmModal, closeCancelConfirmModal } = hooks.cancelConfirmModalToggle();
-  const handleCancel = hooks.handleCancel({ onClose });
+  const handleCancel = hooks.handleCancel({ onClose, returnUrl });
   return (
     <div
       className="position-relative zindex-0"
@@ -65,7 +66,12 @@ export const EditorContainer = ({
         clearSaveFailed={hooks.clearSaveError({ dispatch })}
         disableSave={!isInitialized}
         onCancel={openCancelConfirmModal}
-        onSave={hooks.handleSaveClicked({ dispatch, getContent, validateEntry })}
+        onSave={hooks.handleSaveClicked({
+          dispatch,
+          getContent,
+          validateEntry,
+          returnUrl,
+        })}
         saveFailed={hooks.saveFailed()}
       />
     </div>
@@ -73,12 +79,14 @@ export const EditorContainer = ({
 };
 EditorContainer.defaultProps = {
   onClose: null,
+  returnUrl: null,
   validateEntry: null,
 };
 EditorContainer.propTypes = {
   children: PropTypes.node.isRequired,
   getContent: PropTypes.func.isRequired,
   onClose: PropTypes.func,
+  returnUrl: PropTypes.string,
   validateEntry: PropTypes.func,
   // injected
   intl: intlShape.isRequired,

--- a/src/editors/containers/EditorContainer/index.jsx
+++ b/src/editors/containers/EditorContainer/index.jsx
@@ -19,14 +19,14 @@ export const EditorContainer = ({
   getContent,
   onClose,
   validateEntry,
-  returnUrl,
+  returnFunction,
   // injected
   intl,
 }) => {
   const dispatch = useDispatch();
   const isInitialized = hooks.isInitialized();
   const { isCancelConfirmOpen, openCancelConfirmModal, closeCancelConfirmModal } = hooks.cancelConfirmModalToggle();
-  const handleCancel = hooks.handleCancel({ onClose, returnUrl });
+  const handleCancel = hooks.handleCancel({ onClose, returnFunction });
   return (
     <div
       className="position-relative zindex-0"
@@ -70,7 +70,7 @@ export const EditorContainer = ({
           dispatch,
           getContent,
           validateEntry,
-          returnUrl,
+          returnFunction,
         })}
         saveFailed={hooks.saveFailed()}
       />
@@ -79,14 +79,14 @@ export const EditorContainer = ({
 };
 EditorContainer.defaultProps = {
   onClose: null,
-  returnUrl: null,
+  returnFunction: null,
   validateEntry: null,
 };
 EditorContainer.propTypes = {
   children: PropTypes.node.isRequired,
   getContent: PropTypes.func.isRequired,
   onClose: PropTypes.func,
-  returnUrl: PropTypes.string,
+  returnFunction: PropTypes.func,
   validateEntry: PropTypes.func,
   // injected
   intl: intlShape.isRequired,

--- a/src/editors/containers/EditorContainer/index.test.jsx
+++ b/src/editors/containers/EditorContainer/index.test.jsx
@@ -9,6 +9,7 @@ const props = {
   getContent: jest.fn().mockName('props.getContent'),
   onClose: jest.fn().mockName('props.onClose'),
   validateEntry: jest.fn().mockName('props.validateEntry'),
+  returnUrl: 'someString',
   // inject
   intl: { formatMessage },
 };
@@ -51,6 +52,7 @@ describe('EditorContainer component', () => {
           dispatch: useDispatch(),
           getContent: props.getContent,
           validateEntry: props.validateEntry,
+          returnUrl: props.returnUrl,
         });
         expect(el.children().at(3)
           .props().onSave).toEqual(expected);

--- a/src/editors/containers/EditorContainer/index.test.jsx
+++ b/src/editors/containers/EditorContainer/index.test.jsx
@@ -9,7 +9,7 @@ const props = {
   getContent: jest.fn().mockName('props.getContent'),
   onClose: jest.fn().mockName('props.onClose'),
   validateEntry: jest.fn().mockName('props.validateEntry'),
-  returnUrl: 'someString',
+  returnFunction: jest.fn().mockName('props.returnFunction'),
   // inject
   intl: { formatMessage },
 };
@@ -52,7 +52,7 @@ describe('EditorContainer component', () => {
           dispatch: useDispatch(),
           getContent: props.getContent,
           validateEntry: props.validateEntry,
-          returnUrl: props.returnUrl,
+          returnFunction: props.returnFunction,
         });
         expect(el.children().at(3)
           .props().onSave).toEqual(expected);

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`EditorProblemView component renders raw editor 1`] = `
 <injectIntl(ShimmedIntlComponent)
   getContent={[Function]}
+  returnUrl={null}
 >
   <Component
     footerNode={
@@ -71,6 +72,7 @@ exports[`EditorProblemView component renders raw editor 1`] = `
 exports[`EditorProblemView component renders simple view 1`] = `
 <injectIntl(ShimmedIntlComponent)
   getContent={[Function]}
+  returnUrl={null}
 >
   <Component
     footerNode={

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/__snapshots__/index.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`EditorProblemView component renders raw editor 1`] = `
 <injectIntl(ShimmedIntlComponent)
   getContent={[Function]}
-  returnUrl={null}
+  returnFunction={null}
 >
   <Component
     footerNode={
@@ -72,7 +72,7 @@ exports[`EditorProblemView component renders raw editor 1`] = `
 exports[`EditorProblemView component renders simple view 1`] = `
 <injectIntl(ShimmedIntlComponent)
   getContent={[Function]}
-  returnUrl={null}
+  returnFunction={null}
 >
   <Component
     footerNode={

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -25,13 +25,13 @@ import ExplanationWidget from './ExplanationWidget';
 import { saveBlock } from '../../../../hooks';
 
 export const EditProblemView = ({
-  returnUrl,
+  returnFunction,
   // redux
   problemType,
   problemState,
   assets,
   lmsEndpointUrl,
-  reduxReturnUrl,
+  returnUrl,
   analytics,
   // injected
   intl,
@@ -51,7 +51,7 @@ export const EditProblemView = ({
         assets,
         lmsEndpointUrl,
       })}
-      returnUrl={returnUrl}
+      returnFunction={returnFunction}
     >
       <AlertModal
         title={isAdvancedProblemType ? (
@@ -73,7 +73,8 @@ export const EditProblemView = ({
                   assets,
                   lmsEndpointUrl,
                 })(),
-                destination: reduxReturnUrl,
+                returnFunction,
+                destination: returnUrl,
                 dispatch,
                 analytics,
               })}
@@ -119,18 +120,18 @@ export const EditProblemView = ({
 EditProblemView.defaultProps = {
   assets: null,
   lmsEndpointUrl: null,
-  returnUrl: null,
+  returnFunction: null,
 };
 
 EditProblemView.propTypes = {
   problemType: PropTypes.string.isRequired,
-  returnUrl: PropTypes.string,
+  returnFunction: PropTypes.func,
   // eslint-disable-next-line
   problemState: PropTypes.any.isRequired,
   assets: PropTypes.shape({}),
   analytics: PropTypes.shape({}).isRequired,
   lmsEndpointUrl: PropTypes.string,
-  reduxReturnUrl: PropTypes.string.isRequired,
+  returnUrl: PropTypes.string.isRequired,
   // injected
   intl: intlShape.isRequired,
 };
@@ -139,7 +140,7 @@ export const mapStateToProps = (state) => ({
   assets: selectors.app.assets(state),
   analytics: selectors.app.analytics(state),
   lmsEndpointUrl: selectors.app.lmsEndpointUrl(state),
-  reduxReturnUrl: selectors.app.returnUrl(state),
+  returnUrl: selectors.app.returnUrl(state),
   problemType: selectors.problem.problemType(state),
   problemState: selectors.problem.completeState(state),
 });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.jsx
@@ -25,12 +25,13 @@ import ExplanationWidget from './ExplanationWidget';
 import { saveBlock } from '../../../../hooks';
 
 export const EditProblemView = ({
+  returnUrl,
   // redux
   problemType,
   problemState,
   assets,
   lmsEndpointUrl,
-  returnUrl,
+  reduxReturnUrl,
   analytics,
   // injected
   intl,
@@ -50,6 +51,7 @@ export const EditProblemView = ({
         assets,
         lmsEndpointUrl,
       })}
+      returnUrl={returnUrl}
     >
       <AlertModal
         title={isAdvancedProblemType ? (
@@ -71,7 +73,7 @@ export const EditProblemView = ({
                   assets,
                   lmsEndpointUrl,
                 })(),
-                destination: returnUrl,
+                destination: reduxReturnUrl,
                 dispatch,
                 analytics,
               })}
@@ -117,16 +119,18 @@ export const EditProblemView = ({
 EditProblemView.defaultProps = {
   assets: null,
   lmsEndpointUrl: null,
+  returnUrl: null,
 };
 
 EditProblemView.propTypes = {
   problemType: PropTypes.string.isRequired,
+  returnUrl: PropTypes.string,
   // eslint-disable-next-line
   problemState: PropTypes.any.isRequired,
   assets: PropTypes.shape({}),
   analytics: PropTypes.shape({}).isRequired,
   lmsEndpointUrl: PropTypes.string,
-  returnUrl: PropTypes.string.isRequired,
+  reduxReturnUrl: PropTypes.string.isRequired,
   // injected
   intl: intlShape.isRequired,
 };
@@ -135,7 +139,7 @@ export const mapStateToProps = (state) => ({
   assets: selectors.app.assets(state),
   analytics: selectors.app.analytics(state),
   lmsEndpointUrl: selectors.app.lmsEndpointUrl(state),
-  returnUrl: selectors.app.returnUrl(state),
+  reduxReturnUrl: selectors.app.returnUrl(state),
   problemType: selectors.problem.problemType(state),
   problemState: selectors.problem.completeState(state),
 });

--- a/src/editors/containers/ProblemEditor/index.jsx
+++ b/src/editors/containers/ProblemEditor/index.jsx
@@ -11,7 +11,7 @@ import messages from './messages';
 
 export const ProblemEditor = ({
   onClose,
-  returnUrl,
+  returnFunction,
   // Redux
   problemType,
   blockFinished,
@@ -51,16 +51,16 @@ export const ProblemEditor = ({
   if (problemType === null) {
     return (<SelectTypeModal {...{ onClose }} />);
   }
-  return (<EditProblemView {...{ onClose, returnUrl }} />);
+  return (<EditProblemView {...{ onClose, returnFunction }} />);
 };
 
 ProblemEditor.defaultProps = {
   assetsFinished: null,
-  returnUrl: null,
+  returnFunction: null,
 };
 ProblemEditor.propTypes = {
   onClose: PropTypes.func.isRequired,
-  returnUrl: PropTypes.string,
+  returnFunction: PropTypes.func,
   // redux
   assetsFinished: PropTypes.bool,
   advancedSettingsFinished: PropTypes.bool.isRequired,

--- a/src/editors/containers/ProblemEditor/index.jsx
+++ b/src/editors/containers/ProblemEditor/index.jsx
@@ -11,6 +11,7 @@ import messages from './messages';
 
 export const ProblemEditor = ({
   onClose,
+  returnUrl,
   // Redux
   problemType,
   blockFinished,
@@ -48,16 +49,18 @@ export const ProblemEditor = ({
   }
 
   if (problemType === null) {
-    return (<SelectTypeModal onClose={onClose} />);
+    return (<SelectTypeModal {...{ onClose }} />);
   }
-  return (<EditProblemView onClose={onClose} />);
+  return (<EditProblemView {...{ onClose, returnUrl }} />);
 };
 
 ProblemEditor.defaultProps = {
   assetsFinished: null,
+  returnUrl: null,
 };
 ProblemEditor.propTypes = {
   onClose: PropTypes.func.isRequired,
+  returnUrl: PropTypes.string,
   // redux
   assetsFinished: PropTypes.bool,
   advancedSettingsFinished: PropTypes.bool.isRequired,

--- a/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
@@ -20,6 +20,7 @@ exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
+  returnUrl={null}
 >
   <div
     className="editor-body h-75 overflow-auto"
@@ -73,6 +74,7 @@ exports[`TextEditor snapshots loaded, raw editor 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
+  returnUrl={null}
 >
   <div
     className="editor-body h-75 overflow-auto"
@@ -128,6 +130,7 @@ exports[`TextEditor snapshots not yet loaded, Spinner appears 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
+  returnUrl={null}
 >
   <div
     className="editor-body h-75 overflow-auto"
@@ -175,6 +178,7 @@ exports[`TextEditor snapshots renders as expected with default behavior 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
+  returnUrl={null}
 >
   <div
     className="editor-body h-75 overflow-auto"

--- a/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/TextEditor/__snapshots__/index.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`TextEditor snapshots block failed to load, Toast is shown 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
-  returnUrl={null}
+  returnFunction={null}
 >
   <div
     className="editor-body h-75 overflow-auto"
@@ -74,7 +74,7 @@ exports[`TextEditor snapshots loaded, raw editor 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
-  returnUrl={null}
+  returnFunction={null}
 >
   <div
     className="editor-body h-75 overflow-auto"
@@ -130,7 +130,7 @@ exports[`TextEditor snapshots not yet loaded, Spinner appears 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
-  returnUrl={null}
+  returnFunction={null}
 >
   <div
     className="editor-body h-75 overflow-auto"
@@ -178,7 +178,7 @@ exports[`TextEditor snapshots renders as expected with default behavior 1`] = `
     }
   }
   onClose={[MockFunction props.onClose]}
-  returnUrl={null}
+  returnFunction={null}
 >
   <div
     className="editor-body h-75 overflow-auto"

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -20,7 +20,7 @@ import { prepareEditorRef } from '../../sharedComponents/TinyMceWidget/hooks';
 
 export const TextEditor = ({
   onClose,
-  returnUrl,
+  returnFunction,
   // redux
   isRaw,
   blockValue,
@@ -61,7 +61,7 @@ export const TextEditor = ({
     <EditorContainer
       getContent={hooks.getContent({ editorRef, isRaw, assets })}
       onClose={onClose}
-      returnUrl={returnUrl}
+      returnFunction={returnFunction}
     >
       <div className="editor-body h-75 overflow-auto">
         <Toast show={blockFailed} onClose={hooks.nullMethod}>
@@ -87,11 +87,11 @@ TextEditor.defaultProps = {
   isRaw: null,
   assetsFinished: null,
   assets: null,
-  returnUrl: null,
+  returnFunction: null,
 };
 TextEditor.propTypes = {
   onClose: PropTypes.func.isRequired,
-  returnUrl: PropTypes.string,
+  returnFunction: PropTypes.func,
   // redux
   blockValue: PropTypes.shape({
     data: PropTypes.shape({ data: PropTypes.string }),

--- a/src/editors/containers/TextEditor/index.jsx
+++ b/src/editors/containers/TextEditor/index.jsx
@@ -20,6 +20,7 @@ import { prepareEditorRef } from '../../sharedComponents/TinyMceWidget/hooks';
 
 export const TextEditor = ({
   onClose,
+  returnUrl,
   // redux
   isRaw,
   blockValue,
@@ -60,6 +61,7 @@ export const TextEditor = ({
     <EditorContainer
       getContent={hooks.getContent({ editorRef, isRaw, assets })}
       onClose={onClose}
+      returnUrl={returnUrl}
     >
       <div className="editor-body h-75 overflow-auto">
         <Toast show={blockFailed} onClose={hooks.nullMethod}>
@@ -85,9 +87,11 @@ TextEditor.defaultProps = {
   isRaw: null,
   assetsFinished: null,
   assets: null,
+  returnUrl: null,
 };
 TextEditor.propTypes = {
   onClose: PropTypes.func.isRequired,
+  returnUrl: PropTypes.string,
   // redux
   blockValue: PropTypes.shape({
     data: PropTypes.shape({ data: PropTypes.string }),

--- a/src/editors/containers/VideoEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/__snapshots__/index.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`VideoEditor snapshots renders as expected with default behavior 1`] = `
 >
   <EditorContainer
     onClose={[MockFunction props.onClose]}
+    returnUrl={null}
     validateEntry={[MockFunction validateEntry]}
   >
     <div
@@ -34,6 +35,7 @@ exports[`VideoEditor snapshots renders as expected with default behavior 2`] = `
 >
   <EditorContainer
     onClose={[MockFunction props.onClose]}
+    returnUrl={null}
     validateEntry={[MockFunction validateEntry]}
   >
     <div

--- a/src/editors/containers/VideoEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/__snapshots__/index.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`VideoEditor snapshots renders as expected with default behavior 1`] = `
 >
   <EditorContainer
     onClose={[MockFunction props.onClose]}
-    returnUrl={null}
+    returnFunction={null}
     validateEntry={[MockFunction validateEntry]}
   >
     <div
@@ -35,7 +35,7 @@ exports[`VideoEditor snapshots renders as expected with default behavior 2`] = `
 >
   <EditorContainer
     onClose={[MockFunction props.onClose]}
-    returnUrl={null}
+    returnFunction={null}
     validateEntry={[MockFunction validateEntry]}
   >
     <div

--- a/src/editors/containers/VideoEditor/index.jsx
+++ b/src/editors/containers/VideoEditor/index.jsx
@@ -17,6 +17,7 @@ import messages from './messages';
 
 export const VideoEditor = ({
   onClose,
+  returnUrl,
   // injected
   intl,
   // redux
@@ -31,6 +32,7 @@ export const VideoEditor = ({
       <EditorContainer
         getContent={fetchVideoContent()}
         onClose={onClose}
+        returnUrl={returnUrl}
         validateEntry={validateEntry}
       >
         {studioViewFinished ? (
@@ -59,9 +61,11 @@ export const VideoEditor = ({
 
 VideoEditor.defaultProps = {
   onClose: null,
+  returnUrl: null,
 };
 VideoEditor.propTypes = {
   onClose: PropTypes.func,
+  returnUrl: PropTypes.string,
   // injected
   intl: intlShape.isRequired,
   // redux

--- a/src/editors/containers/VideoEditor/index.jsx
+++ b/src/editors/containers/VideoEditor/index.jsx
@@ -17,7 +17,7 @@ import messages from './messages';
 
 export const VideoEditor = ({
   onClose,
-  returnUrl,
+  returnFunction,
   // injected
   intl,
   // redux
@@ -32,7 +32,7 @@ export const VideoEditor = ({
       <EditorContainer
         getContent={fetchVideoContent()}
         onClose={onClose}
-        returnUrl={returnUrl}
+        returnFunction={returnFunction}
         validateEntry={validateEntry}
       >
         {studioViewFinished ? (
@@ -61,11 +61,11 @@ export const VideoEditor = ({
 
 VideoEditor.defaultProps = {
   onClose: null,
-  returnUrl: null,
+  returnFunction: null,
 };
 VideoEditor.propTypes = {
   onClose: PropTypes.func,
-  returnUrl: PropTypes.string,
+  returnFunction: PropTypes.func,
   // injected
   intl: intlShape.isRequired,
   // redux

--- a/src/editors/hooks.js
+++ b/src/editors/hooks.js
@@ -17,12 +17,17 @@ export const navigateTo = (destination) => {
 };
 
 export const navigateCallback = ({
+  returnFunction,
   destination,
   analyticsEvent,
   analytics,
 }) => () => {
   if (process.env.NODE_ENV !== 'development' && analyticsEvent && analytics) {
     sendTrackEvent(analyticsEvent, analytics);
+  }
+  if (returnFunction) {
+    returnFunction();
+    return;
   }
   module.navigateTo(destination);
 };
@@ -34,6 +39,7 @@ export const saveBlock = ({
   content,
   destination,
   dispatch,
+  returnFunction,
   validateEntry,
 }) => {
   if (!content) {
@@ -53,6 +59,7 @@ export const saveBlock = ({
         destination,
         analyticsEvent: analyticsEvt.editorSaveClick,
         analytics,
+        returnFunction,
       }),
       content,
     }));

--- a/src/editors/hooks.test.jsx
+++ b/src/editors/hooks.test.jsx
@@ -74,6 +74,7 @@ describe('hooks', () => {
     let output;
     const SAVED_ENV = process.env;
     const destination = 'hOmE';
+    const returnFunction = jest.fn();
     beforeEach(() => {
       jest.resetModules();
       process.env = { ...SAVED_ENV };
@@ -100,6 +101,15 @@ describe('hooks', () => {
       output();
       expect(spy).toHaveBeenCalledWith(destination);
     });
+    it('should call returnFunction and return null', () => {
+      output = hooks.navigateCallback({
+        destination,
+        returnFunction,
+      });
+      const returnedOutput = output();
+      expect(returnFunction).toHaveBeenCalled();
+      expect(returnedOutput).toEqual(undefined);
+    })
   });
 
   describe('nullMethod', () => {

--- a/src/editors/hooks.test.jsx
+++ b/src/editors/hooks.test.jsx
@@ -109,7 +109,7 @@ describe('hooks', () => {
       const returnedOutput = output();
       expect(returnFunction).toHaveBeenCalled();
       expect(returnedOutput).toEqual(undefined);
-    })
+    });
   });
 
   describe('nullMethod', () => {


### PR DESCRIPTION
This PR adds a new prop, `returnFunction` to editors. This new prop is necessary for pages that use an editor, but are not connected to a Studio Unit page. This prop is used when exiting an editor (save or cancel).