### PR TITLE
feat: send event on checkbox change

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/constants.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/constants.js
@@ -1,0 +1,5 @@
+export const analyticsEvents = {
+    socialSharingSettingChanged: 'edx.social.video_sharing_setting.changed'
+}
+
+export default analyticsEvents

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/constants.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/constants.js
@@ -1,5 +1,5 @@
 export const analyticsEvents = {
-    socialSharingSettingChanged: 'edx.social.video_sharing_setting.changed'
-}
+  socialSharingSettingChanged: 'edx.social.video_sharing_setting.changed',
+};
 
-export default analyticsEvents
+export default analyticsEvents;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.jsx
@@ -1,0 +1,24 @@
+import { useSelector } from 'react-redux';
+import analyticsEvents from './constants';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+import { selectors } from '../../../../../../data/redux';
+
+export const handleSocialSharingCheckboxChange = ({ updateField }) => {
+  const analytics = useSelector(selectors.app.analytics);
+  const allowVideoSharing = useSelector(selectors.video.allowVideoSharing);
+  return (event) => {
+    sendTrackEvent(
+      analyticsEvents.socialSharingSettingChanged,
+      {
+        ...analytics,
+        value: event.target.checked,
+      }
+    );
+    updateField({
+      allowVideoSharing: {
+        ...allowVideoSharing,
+        value: event.target.checked,
+      },
+    });
+  };
+};

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.jsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
-import analyticsEvents from './constants';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { selectors } from '../../../../../../data/redux';
+import analyticsEvents from './constants';
 
 export const handleSocialSharingCheckboxChange = ({ updateField }) => {
   const analytics = useSelector(selectors.app.analytics);
@@ -12,7 +12,7 @@ export const handleSocialSharingCheckboxChange = ({ updateField }) => {
       {
         ...analytics,
         value: event.target.checked,
-      }
+      },
     );
     updateField({
       allowVideoSharing: {
@@ -22,3 +22,5 @@ export const handleSocialSharingCheckboxChange = ({ updateField }) => {
     });
   };
 };
+
+export default handleSocialSharingCheckboxChange;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.jsx
@@ -3,7 +3,7 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { selectors } from '../../../../../../data/redux';
 import analyticsEvents from './constants';
 
-export const handleSocialSharingCheckboxChange = ({ updateField }) => {
+export const useTrackSocialSharingChange = ({ updateField }) => {
   const analytics = useSelector(selectors.app.analytics);
   const allowVideoSharing = useSelector(selectors.video.allowVideoSharing);
   return (event) => {
@@ -23,4 +23,4 @@ export const handleSocialSharingCheckboxChange = ({ updateField }) => {
   };
 };
 
-export default handleSocialSharingCheckboxChange;
+export default useTrackSocialSharingChange;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.test.jsx
@@ -1,4 +1,3 @@
-import { actions } from '../../../../../../data/redux/app';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import analyticsEvents from './constants';
 import * as hooks from './hooks';
@@ -18,25 +17,25 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackEvent: jest.fn(),
 }));
 
-
 describe('SocialShareWidget hooks', () => {
   describe('handleSocialSharingCheckboxChange when', () => {
-    var onClick, updateField;
+    let onClick;
+    let updateField;
     describe.each([true, false])('box is toggled', (checked) => {
       beforeAll(() => {
-        jest.resetAllMocks()
-        updateField = jest.fn()
+        jest.resetAllMocks();
+        updateField = jest.fn();
         onClick = hooks.handleSocialSharingCheckboxChange({ updateField });
         expect(typeof onClick).toBe('function');
         onClick({ target: { checked } });
       });
-      it("field is updated", () => {
-        expect(updateField).toBeCalledWith({"allowVideoSharing": {"value": checked}});
+      it('field is updated', () => {
+        expect(updateField).toBeCalledWith({ allowVideoSharing: { value: checked } });
       });
-      it("event tracking is called", () => {
+      it('event tracking is called', () => {
         expect(sendTrackEvent).toBeCalledWith(
           analyticsEvents.socialSharingSettingChanged,
-          {"value": checked}
+          { value: checked },
         );
       });
     });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.test.jsx
@@ -1,0 +1,44 @@
+import { actions } from '../../../../../../data/redux/app';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+import analyticsEvents from './constants';
+import * as hooks from './hooks';
+
+jest.mock('../../../../../../data/redux', () => ({
+  selectors: {
+    app: {
+      analytics: jest.fn((state) => ({ analytics: state })),
+    },
+    video: {
+      allowVideoSharing: jest.fn((state) => ({ allowVideoSharing: state })),
+    },
+  },
+}));
+
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendTrackEvent: jest.fn(),
+}));
+
+
+describe('SocialShareWidget hooks', () => {
+  describe('handleSocialSharingCheckboxChange when', () => {
+    var onClick, updateField;
+    describe.each([true, false])('box is toggled', (checked) => {
+      beforeAll(() => {
+        jest.resetAllMocks()
+        updateField = jest.fn()
+        onClick = hooks.handleSocialSharingCheckboxChange({ updateField });
+        expect(typeof onClick).toBe('function');
+        onClick({ target: { checked } });
+      });
+      it("field is updated", () => {
+        expect(updateField).toBeCalledWith({"allowVideoSharing": {"value": checked}});
+      });
+      it("event tracking is called", () => {
+        expect(sendTrackEvent).toBeCalledWith(
+          analyticsEvents.socialSharingSettingChanged,
+          {"value": checked}
+        );
+      });
+    });
+  });
+});

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.test.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/hooks.test.jsx
@@ -18,14 +18,14 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
 }));
 
 describe('SocialShareWidget hooks', () => {
-  describe('handleSocialSharingCheckboxChange when', () => {
+  describe('useTrackSocialSharingChange when', () => {
     let onClick;
     let updateField;
     describe.each([true, false])('box is toggled', (checked) => {
       beforeAll(() => {
         jest.resetAllMocks();
         updateField = jest.fn();
-        onClick = hooks.handleSocialSharingCheckboxChange({ updateField });
+        onClick = hooks.useTrackSocialSharingChange({ updateField });
         expect(typeof onClick).toBe('function');
         onClick({ target: { checked } });
       });

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
@@ -33,7 +33,7 @@ export const SocialShareWidget = ({
   const isSetByCourse = allowVideoSharing.level === 'course';
   const videoSharingEnabled = isLibrary ? videoSharingEnabledForAll : videoSharingEnabledForCourse;
   const learnMoreLink = videoSharingLearnMoreLink || 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/developing_course/social_sharing.html';
-  const onSocialSharingCheckboxChange = hooks.handleSocialSharingCheckboxChange({ updateField });
+  const onSocialSharingCheckboxChange = hooks.useTrackSocialSharingChange({ updateField });
 
   const getSubtitle = () => {
     if (allowVideoSharing.value) {

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
@@ -14,7 +14,7 @@ import {
 import { selectors, actions } from '../../../../../../data/redux';
 import CollapsibleFormWidget from '../CollapsibleFormWidget';
 import messages from './messages';
-import * as hooks from './hooks'
+import * as hooks from './hooks';
 
 /**
  * Collapsible Form widget controlling video thumbnail

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/SocialShareWidget/index.jsx
@@ -14,6 +14,7 @@ import {
 import { selectors, actions } from '../../../../../../data/redux';
 import CollapsibleFormWidget from '../CollapsibleFormWidget';
 import messages from './messages';
+import * as hooks from './hooks'
 
 /**
  * Collapsible Form widget controlling video thumbnail
@@ -32,6 +33,8 @@ export const SocialShareWidget = ({
   const isSetByCourse = allowVideoSharing.level === 'course';
   const videoSharingEnabled = isLibrary ? videoSharingEnabledForAll : videoSharingEnabledForCourse;
   const learnMoreLink = videoSharingLearnMoreLink || 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/developing_course/social_sharing.html';
+  const onSocialSharingCheckboxChange = hooks.handleSocialSharingCheckboxChange({ updateField });
+
   const getSubtitle = () => {
     if (allowVideoSharing.value) {
       return intl.formatMessage(messages.enabledSubtitle);
@@ -52,12 +55,7 @@ export const SocialShareWidget = ({
         className="mt-3"
         checked={allowVideoSharing.value}
         disabled={isSetByCourse}
-        onChange={(e) => updateField({
-          allowVideoSharing: {
-            ...allowVideoSharing,
-            value: e.target.checked,
-          },
-        })}
+        onChange={onSocialSharingCheckboxChange}
       >
         <div className="small text-gray-700">
           {intl.formatMessage(messages.socialSharingCheckboxLabel)}

--- a/src/editors/data/redux/thunkActions/requests.js
+++ b/src/editors/data/redux/thunkActions/requests.js
@@ -290,7 +290,6 @@ export const fetchVideoFeatures = ({ ...rest }) => (dispatch, getState) => {
     requestKey: RequestKeys.fetchVideoFeatures,
     promise: api.fetchVideoFeatures({
       studioEndpointUrl: selectors.app.studioEndpointUrl(getState()),
-      learningContextId: selectors.app.learningContextId(getState()),
     }),
     ...rest,
   }));

--- a/src/editors/data/redux/thunkActions/requests.test.js
+++ b/src/editors/data/redux/thunkActions/requests.test.js
@@ -486,7 +486,6 @@ describe('requests thunkActions module', () => {
           requestKey: RequestKeys.fetchVideoFeatures,
           promise: api.fetchVideoFeatures({
             studioEndpointUrl: selectors.app.studioEndpointUrl(testState),
-            learningContextId: selectors.app.learningContextId(testState),
           }),
         },
       });

--- a/src/editors/data/services/cms/api.js
+++ b/src/editors/data/services/cms/api.js
@@ -204,9 +204,8 @@ export const apiMethods = {
   ),
   fetchVideoFeatures: ({
     studioEndpointUrl,
-    learningContextId,
   }) => get(
-    urls.videoFeatures({ studioEndpointUrl, learningContextId }),
+    urls.videoFeatures({ studioEndpointUrl }),
   ),
   uploadVideo: ({
     data,

--- a/src/editors/data/services/cms/api.test.js
+++ b/src/editors/data/services/cms/api.test.js
@@ -575,7 +575,7 @@ describe('cms api', () => {
   });
   describe('fetchVideoFeatures', () => {
     it('should call get with url.videoFeatures', () => {
-      const args = { studioEndpointUrl, learningContextId };
+      const args = { studioEndpointUrl };
       apiMethods.fetchVideoFeatures({ ...args });
       expect(get).toHaveBeenCalledWith(urls.videoFeatures({ ...args }));
     });

--- a/src/editors/data/services/cms/mockApi.js
+++ b/src/editors/data/services/cms/mockApi.js
@@ -139,7 +139,7 @@ export const fetchAdvanceSettings = ({ studioEndpointUrl, learningContextId }) =
   data: { allow_unsupported_xblocks: { value: true } },
 });
 // eslint-disable-next-line
-export const fetchVideoFeatures = ({ studioEndpointUrl, learningContextId }) => mockPromise({
+export const fetchVideoFeatures = ({ studioEndpointUrl }) => mockPromise({
   data: {
     allowThumbnailUpload: true,
     videoSharingEnabledForCourse: true,

--- a/src/editors/data/services/cms/urls.js
+++ b/src/editors/data/services/cms/urls.js
@@ -63,8 +63,8 @@ export const courseAdvanceSettings = ({ studioEndpointUrl, learningContextId }) 
   `${studioEndpointUrl}/api/contentstore/v0/advanced_settings/${learningContextId}`
 );
 
-export const videoFeatures = ({ studioEndpointUrl, learningContextId }) => (
-  `${studioEndpointUrl}/video_features/${learningContextId}`
+export const videoFeatures = ({ studioEndpointUrl }) => (
+  `${studioEndpointUrl}/video_features/`
 );
 
 export const courseVideos = ({ studioEndpointUrl, learningContextId }) => (

--- a/src/editors/data/services/cms/urls.test.js
+++ b/src/editors/data/services/cms/urls.test.js
@@ -135,8 +135,8 @@ describe('cms url methods', () => {
   });
   describe('videoFeatures', () => {
     it('returns url with studioEndpointUrl and learningContextId', () => {
-      expect(videoFeatures({ studioEndpointUrl, learningContextId }))
-        .toEqual(`${studioEndpointUrl}/video_features/${learningContextId}`);
+      expect(videoFeatures({ studioEndpointUrl }))
+        .toEqual(`${studioEndpointUrl}/video_features/`);
     });
   });
   describe('courseVideos', () => {


### PR DESCRIPTION
When a user toggles the "social sharing" checkbox, sent an analytics event

This also includes a fix to an issue where we were requesting an old URL for the video features URL