### PR TITLE
feat: parse solution text with preserve order

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -20,6 +20,7 @@ import {
   labelDescriptionQuestionOLX,
   htmlEntityTestOLX,
   numberParseTestOLX,
+  orderedSolutionTest,
 } from './mockData/olxTestData';
 import { ProblemTypeKeys } from '../../../data/constants/problem';
 
@@ -245,5 +246,11 @@ describe('Check OLXParser for proper encoding', () => {
     const olxparser = new OLXParser(numberParseTestOLX.rawOLX);
     const answer = olxparser.parseMultipleChoiceAnswers('multiplechoiceresponse', 'choicegroup', 'choice');
     expect(answer).toEqual(numberParseTestOLX.data);
+  });
+  it('should parse solutionExplanation with proper order', () => {
+    const olxparser = new OLXParser(orderedSolutionTest.rawOLX);
+    const problemType = olxparser.getProblemType();
+    const explanation = olxparser.getSolutionExplanation(problemType);
+    expect(explanation).toBe(orderedSolutionTest.solutionExplanation);
   });
 });

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -1,40 +1,38 @@
+/* eslint-disable */
+// lint is disabled for this file due to strict spacing
+
 export const getCheckboxesOLXWithFeedbackAndHintsOLX = () => ({
-  rawOLX: `<problem>
-  <choiceresponse>
-    <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
-  <label>Add the question text, or prompt, here. This text is required.</label>
-  <description>You can add an optional tip or note related to the prompt like this.</description>
-  <checkboxgroup>
-      <choice correct="true"><p>a correct answer</p>
-        <choicehint selected="true"><p>You can specify optional feedback that appears after the learner selects and submits this answer.</p></choicehint>
-        <choicehint selected="false"><p>You can specify optional feedback that appears after the learner clears and submits this answer.</p></choicehint>
-  </choice>
-      <choice correct="false"><p>an incorrect answer</p></choice>
-      <choice correct="false"><p>an incorrect answer</p>
-        <choicehint selected="true"><p>You can specify optional feedback for none, all, or a subset of the answers.</p></choicehint>
-        <choicehint selected="false"><p>You can specify optional feedback for selected answers, cleared answers, or both.</p></choicehint>
-  </choice>
-      <choice correct="true"><p>a correct answer</p></choice>
-      <compoundhint value="A B D">You can specify optional feedback for a combination of answers which appears after the specified set of answers is submitted.</compoundhint>
-      <compoundhint value="A B C D">You can specify optional feedback for one, several, or all answer combinations.</compoundhint>
-    </checkboxgroup>
-    <solution>
-        <div class="detailed-solution">
+  rawOLX: `
+    <problem>
+      <choiceresponse>
+        <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+        <label>Add the question text, or prompt, here. This text is required.</label>
+        <description>You can add an optional tip or note related to the prompt like this.</description>
+        <checkboxgroup>
+          <choice correct="true"><p>a correct answer</p><choicehint selected="true"><p>You can specify optional feedback that appears after the learner selects and submits this answer.</p></choicehint><choicehint selected="false"><p>You can specify optional feedback that appears after the learner clears and submits this answer.</p></choicehint></choice>
+          <choice correct="false"><p>an incorrect answer</p></choice>
+          <choice correct="false"><p>an incorrect answer</p><choicehint selected="true"><p>You can specify optional feedback for none, all, or a subset of the answers.</p></choicehint><choicehint selected="false"><p>You can specify optional feedback for selected answers, cleared answers, or both.</p></choicehint></choice>
+          <choice correct="true"><p>a correct answer</p></choice>
+          <compoundhint value="A B D">You can specify optional feedback for a combination of answers which appears after the specified set of answers is submitted.</compoundhint>
+          <compoundhint value="A B C D">You can specify optional feedback for one, several, or all answer combinations.</compoundhint>
+        </checkboxgroup>
+        <solution>
+          <div class="detailed-solution">
             <p>Explanation</p>
             <p>
-                You can form a voltage divider that evenly divides the input
-                voltage with two identically valued resistors, with the sampled
-                voltage taken in between the two.
+              You can form a voltage divider that evenly divides the input
+              voltage with two identically valued resistors, with the sampled
+              voltage taken in between the two.
             </p>
             <p><img src="/static/images/voltage_divider.png" alt=""></img></p>
-         </div>
-      </solution>
-  </choiceresponse>
-  <demandhint>
-    <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
-    <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
-  </demandhint>
-  </problem>`,
+          </div>
+        </solution>
+      </choiceresponse>
+      <demandhint>
+        <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
+        <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
+      </demandhint>
+    </problem>`,
   hints: [
     {
       id: 0,
@@ -101,7 +99,8 @@ export const getCheckboxesOLXWithFeedbackAndHintsOLX = () => ({
       },
     ],
   },
-  question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
+  question: `
+      <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>\n      \n    `,
   buildOLX: `<problem>
   <choiceresponse>
     <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for checkboxes with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
@@ -164,24 +163,23 @@ export const multipleChoiceWithoutAnswers = {
 };
 
 export const dropdownOLXWithFeedbackAndHintsOLX = {
-  rawOLX: `<problem>
-<optionresponse>
-  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
-<label>Add the question text, or prompt, here. This text is required.</label>
-<description>You can add an optional tip or note related to the prompt like this. </description>
-<optioninput>
-    <option correct="false">an incorrect answer <optionhint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></optionhint>
-</option>
-    <option correct="true">the correct answer</option>
-    <option correct="false">an incorrect answer <optionhint><p>You can specify optional feedback for none, a subset, or all of the answers.</p></optionhint>
-</option>
-  </optioninput>
-</optionresponse>
-<demandhint>
-  <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
-  <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
-</demandhint>
-</problem>`,
+  rawOLX: `
+    <problem>
+      <optionresponse>
+        <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+        <label>Add the question text, or prompt, here. This text is required.</label>
+        <description>You can add an optional tip or note related to the prompt like this. </description>
+        <optioninput>
+          <option correct="false">an incorrect answer<optionhint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></optionhint></option>
+          <option correct="true">the correct answer</option>
+          <option correct="false">an incorrect answer<optionhint><p>You can specify optional feedback for none, a subset, or all of the answers.</p></optionhint></option>
+        </optioninput>
+      </optionresponse>
+      <demandhint>
+        <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
+        <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
+      </demandhint>
+    </problem>`,
   hints: [{
     id: 0,
     value: '<p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p>',
@@ -212,7 +210,8 @@ export const dropdownOLXWithFeedbackAndHintsOLX = {
       },
     ],
   },
-  question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
+  question: `
+      <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this. </em>\n      \n    `,
   buildOLX: `<problem>
   <optionresponse>
     <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
@@ -237,27 +236,26 @@ an incorrect answer        <optionhint><p>You can specify optional feedback for 
 };
 
 export const multipleChoiceWithFeedbackAndHintsOLX = {
-  rawOLX: `<problem>
-<multiplechoiceresponse>
-  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for multiple choice with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
-<label>Add the question text, or prompt, here. This text is required.</label>
-<description>You can add an optional tip or note related to the prompt like this. </description>
-<choicegroup type="MultipleChoice">
-    <choice correct="false"><p>an incorrect answer</p><choicehint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></choicehint>
-</choice>
-    <choice correct="true"><p>the correct answer</p></choice>
-    <choice correct="false"><p>an incorrect answer</p><choicehint><p>You can specify optional feedback for none, a subset, or all of the answers.</></choicehint>
-</choice>
-  </choicegroup>
-  <solution>
-    <p>You can add a solution</p>
-  </solution>
-</multiplechoiceresponse>
-<demandhint>
-  <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
-  <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
-</demandhint>
-</problem>`,
+  rawOLX: `
+  <problem>
+    <multiplechoiceresponse>
+      <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for multiple choice with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+      <label>Add the question text, or prompt, here. This text is required.</label>
+      <description>You can add an optional tip or note related to the prompt like this. </description>
+      <choicegroup type="MultipleChoice">
+        <choice correct="false"><p>an incorrect answer</p><choicehint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></choicehint></choice>
+        <choice correct="true"><p>the correct answer</p></choice>
+        <choice correct="false"><p>an incorrect answer</p><choicehint><p>You can specify optional feedback for none, a subset, or all of the answers.</></choicehint></choice>
+      </choicegroup>
+      <solution>
+        <p>You can add a solution</p>
+      </solution>
+    </multiplechoiceresponse>
+    <demandhint>
+      <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
+      <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
+    </demandhint>
+  </problem>`,
   hints: [{
     id: 0,
     value: '<p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p>',
@@ -289,7 +287,8 @@ export const multipleChoiceWithFeedbackAndHintsOLX = {
       },
     ],
   },
-  question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for multiple choice with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
+  question: `
+    <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for multiple choice with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this. </em>\n    \n  `,
   buildOLX: `<problem>
   <multiplechoiceresponse>
     <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for multiple choice with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
@@ -320,21 +319,22 @@ export const multipleChoiceWithFeedbackAndHintsOLX = {
 };
 
 export const numericInputWithFeedbackAndHintsOLX = {
-  rawOLX: `<problem>
-<numericalresponse answer="100">
-  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
-<label>Add the question text, or prompt, here. This text is required.</label>
-<description>You can add an optional tip or note related to the prompt like this. </description>
-<responseparam type="tolerance" default="5"/>
-  <formulaequationinput/>
-  <correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint>
-  <additional_answer answer="200"><correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint></additional_answer>
-</numericalresponse>
-<demandhint>
-  <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
-  <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
-</demandhint>
-</problem>`,
+  rawOLX: `
+  <problem>
+    <numericalresponse answer="100">
+      <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+      <label>Add the question text, or prompt, here. This text is required.</label>
+      <description>You can add an optional tip or note related to the prompt like this. </description>
+      <responseparam type="tolerance" default="5"/>
+      <formulaequationinput/>
+      <correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint>
+      <additional_answer answer="200"><correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint></additional_answer>
+    </numericalresponse>
+    <demandhint>
+      <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
+      <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
+    </demandhint>
+  </problem>`,
   hints: [{
     id: 0,
     value: '<p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p>',
@@ -363,7 +363,8 @@ export const numericInputWithFeedbackAndHintsOLX = {
       },
     ],
   },
-  question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
+  question: `
+    <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this. </em>\n    \n  `,
   buildOLX: `<problem>
   <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
   <label>Add the question text, or prompt, here. This text is required.</label>
@@ -417,21 +418,22 @@ export const numericInputWithAnswerRangeOLX = {
 };
 
 export const textInputWithFeedbackAndHintsOLX = {
-  rawOLX: `<problem>
-<stringresponse answer="the correct answer" type="ci">
-  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for text input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
-<label>Add the question text, or prompt, here. This text is required.</label>
-<description>You can add an optional tip or note related to the prompt like this. </description>
-<correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint>
-  <additional_answer answer="optional acceptable variant of the correct answer"/>
-  <stringequalhint answer="optional incorrect answer such as a frequent misconception"><p>You can specify optional feedback for none, a subset, or all of the answers.</p></stringequalhint>
-  <textline size="20"/>
-</stringresponse>
-<demandhint>
-  <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
-  <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
-</demandhint>
-</problem>`,
+  rawOLX: `
+  <problem>
+    <stringresponse answer="the correct answer" type="ci">
+      <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for text input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
+      <label>Add the question text, or prompt, here. This text is required.</label>
+      <description>You can add an optional tip or note related to the prompt like this. </description>
+      <correcthint><p>You can specify optional feedback like this, which appears after this answer is submitted.</p></correcthint>
+      <additional_answer answer="optional acceptable variant of the correct answer"/>
+      <stringequalhint answer="optional incorrect answer such as a frequent misconception"><p>You can specify optional feedback for none, a subset, or all of the answers.</p></stringequalhint>
+      <textline size="20"/>
+    </stringresponse>
+    <demandhint>
+      <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
+      <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
+    </demandhint>
+  </problem>`,
   hints: [{
     id: 0,
     value: '<p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p>',
@@ -469,7 +471,8 @@ export const textInputWithFeedbackAndHintsOLX = {
       },
     },
   },
-  question: '<p>You can use this template as a guide to the simple editor markdown and OLX markup to use for text input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this.</em>',
+  question: `
+    <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for text input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p><label>Add the question text, or prompt, here. This text is required.</label><em>You can add an optional tip or note related to the prompt like this. </em>\n    \n  `,
   buildOLX: `<problem>
   <stringresponse answer="the correct answer" type="ci">
     <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for text input with hints and feedback problems. Edit this component to replace this template with your own assessment.</p>
@@ -639,23 +642,32 @@ export const blankQuestionOLX = {
     <textline size="20"/>
   </stringresponse>
 </problem>`,
-  question: '',
+  question: `\n  \n`,
 };
 export const styledQuestionOLX = {
-  rawOLX: `<problem>
-  <p>
-    <strong>
-      <span style="background-color: #e03e2d;">
-        test
-      </span>
-    </strong>
-  </p>
-  <stringresponse type="ci">
-    <additional_answer />
-    <textline size="20"/>
-  </stringresponse>
-</problem>`,
-  question: '<p><strong><span style="background-color: #e03e2d;">test</span></strong></p>',
+  rawOLX: `
+  <problem>
+    <p>
+      <strong>
+        <span style="background-color: #e03e2d;">
+          test
+        </span>
+      </strong>
+    </p>
+    <stringresponse type="ci">
+      <additional_answer />
+      <textline size="20"/>
+    </stringresponse>
+  </problem>
+  `,
+  question: `
+    <p>
+      <strong>
+        <span style="background-color: #e03e2d;">
+          test
+        </span>
+      </strong>
+    </p>\n    \n  `,
 };
 
 export const shuffleProblemOLX = {
@@ -673,45 +685,46 @@ export const shuffleProblemOLX = {
 };
 
 export const labelDescriptionQuestionOLX = {
-  rawOLX:
-`<problem display_name="Eggs b) - Choosing a System" markdown="null" max_attempts="3" weight="0.5">
-  <p style="text-align: center;"><img height="274" width="" src="/static/boiling_eggs_water_system.png" alt="boiling eggs: water system"/></p>
-  <multiplechoiceresponse>
-  <label>Taking the system as just the <b>water</b>, as indicated by the red dashed line, what would be the correct expression for the first law of thermodynamics applied to this system?</label>
-  <description>Watch out, boiling water is hot</description>
-  <choicegroup type="MultipleChoice">
-    <choice correct="true">( Delta E_text{water} = Q )</choice>
-    <choice correct="false">( Delta E_text{water} = - W )</choice>
-    <choice correct="false">( Delta E_text{water} = 0 )</choice>
-  </choicegroup>
-  </multiplechoiceresponse>
-  <solution>
-    <div class="detailed-solution">
-      <h2>Explanation</h2>
-    </div>
-  </solution>
-</problem>`,
-
-  question: '<p style="text-align: center;"><img height="274" width="" src="/static/boiling_eggs_water_system.png" alt="boiling eggs: water system"></img></p><label>Taking the system as just the<b>water</b>, as indicated by the red dashed line, what would be the correct expression for the first law of thermodynamics applied to this system?</label><em>Watch out, boiling water is hot</em>',
+  rawOLX: 
+    `<problem display_name="Eggs b) - Choosing a System" markdown="null" max_attempts="3" weight="0.5">
+      <p style="text-align: center;"><img height="274" width="" src="/static/boiling_eggs_water_system.png" alt="boiling eggs: water system"/></p>
+      <multiplechoiceresponse>
+        <label>Taking the system as just the <b>water</b>, as indicated by the red dashed line, what would be the correct expression for the first law of thermodynamics applied to this system?</label>
+        <description>Watch out, boiling water is hot</description>
+        <choicegroup type="MultipleChoice">
+          <choice correct="true">( Delta E_text{water} = Q )</choice>
+          <choice correct="false">( Delta E_text{water} = - W )</choice>
+          <choice correct="false">( Delta E_text{water} = 0 )</choice>
+        </choicegroup>
+      </multiplechoiceresponse>
+      <solution>
+        <div class="detailed-solution">
+          <h2>Explanation</h2>
+        </div>
+      </solution>
+    </problem>`,
+  question: `
+      <p style="text-align: center;"><img height="274" width="" src="/static/boiling_eggs_water_system.png" alt="boiling eggs: water system"></img></p>
+      <label>Taking the system as just the <b>water</b>, as indicated by the red dashed line, what would be the correct expression for the first law of thermodynamics applied to this system?</label><em>Watch out, boiling water is hot</em>\n      \n    `,
 };
 
 export const htmlEntityTestOLX = {
   rawOLX:
   `<problem>
-  <multiplechoiceresponse>
-  <p>What is the content of the register x2 after executing the following three lines of instructions?</p>
-  <p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions <br />0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br />0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br />0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>
-  <choicegroup type="MultipleChoice">
-      <choice correct="false">answerA</choice>
-      <choice correct="true">answerB</choice>
-    </choicegroup>
-  <solution>
-  <div class="detailed-solution">
-   <p>Explanation</p>
-    <p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions&#160;&#160;&#160;&#160;comment<br />0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = 0x1<br />0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x2 = x1 &lt;&lt; 4 = 0x10<br />0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = x2 - x1 = 0x10 - 0x01 = 0xf</strong></span></p>
-    </div>
-    </solution>
-  </multiplechoiceresponse>
+    <multiplechoiceresponse>
+      <p>What is the content of the register x2 after executing the following three lines of instructions?</p>
+      <p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions <br />0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br />0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br />0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>
+      <choicegroup type="MultipleChoice">
+        <choice correct="false">answerA</choice>
+        <choice correct="true">answerB</choice>
+      </choicegroup>
+      <solution>
+        <div class="detailed-solution">
+        <p>Explanation</p>
+        <p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions&#160;&#160;&#160;&#160;comment<br />0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = 0x1<br />0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x2 = x1 &lt;&lt; 4 = 0x10<br />0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = x2 - x1 = 0x10 - 0x01 = 0xf</strong></span></p>
+        </div>
+      </solution>
+    </multiplechoiceresponse>
   </problem>`,
   data: {
     answers: [
@@ -728,7 +741,9 @@ export const htmlEntityTestOLX = {
     ],
   },
   // eslint-disable-next-line
-  question: `<p>What is the content of the register x2 after executing the following three lines of instructions?</p><p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions<br></br>0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br></br>0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br></br>0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>`,
+  question: `
+    <p>What is the content of the register x2 after executing the following three lines of instructions?</p><p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions <br></br>0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1<br></br>0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4<br></br>0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1</strong></span></p>
+  `,
   // eslint-disable-next-line
   solutionExplanation: `<p><span style="font-family: 'courier new', courier;"><strong>Address&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;assembly instructions&#160;&#160;&#160;&#160;comment<br></br>0x0&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;addi x1, x0, 1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = 0x1<br></br>0x4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;slli x2, x1, 4&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x2 = x1 &lt;&lt; 4 = 0x10<br></br>0x8&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sub x1, x2, x1&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;x1 = x2 - x1 = 0x10 - 0x01 = 0xf</strong></span></p>`,
 };
@@ -781,4 +796,28 @@ export const numberParseTestOLX = {
     </choicegroup>
   </multiplechoiceresponse>
   </problem>`,
+};
+
+export const orderedSolutionTest = {
+  rawOLX: `
+    <problem>
+      How <code class="lang-matlab">99</code> long is the array <code class="lang-matlab">q</code> after the following loop runs?
+      <pre><code class="lang-matlab">for i = 1:99
+      q(2*i - 1) = i;
+      end</code></pre>
+      <numericalresponse answer="197">
+        <label/>
+        <description>Enter your answer below. Type "e" if this code would produce an error</description>
+        <formulaequationinput/>
+        <responseparam default="2%" type="tolerance"/>
+        <solution>
+          <div class="detailed-solution">
+            <p>Explanation</p>
+            This loop will iterate <code class="lang-matlab">99</code> times, but the length of <code class="lang-matlab">q</code> will not be <code class="lang-matlab">99</code> due to indexing with the value <code class="lang-matlab">2*i -1</code>. On the last iteration, <code class="lang-matlab">i = 99</code>, so <code class="lang-matlab">2*i - 1 = 2*78 - 1 = 197</code>. This will be the last position filled in <code class="lang-matlab">q</code>, so the answer is <code class="lang-matlab">197</code>.
+          </div>
+        </solution>
+      </numericalresponse>
+    </problem>`,
+  solutionExplanation: `\n            
+            This loop will iterate <code class="lang-matlab">99</code> times, but the length of <code class="lang-matlab">q</code> will not be <code class="lang-matlab">99</code> due to indexing with the value <code class="lang-matlab">2*i -1</code>. On the last iteration, <code class="lang-matlab">i = 99</code>, so <code class="lang-matlab">2*i - 1 = 2*78 - 1 = 197</code>. This will be the last position filled in <code class="lang-matlab">q</code>, so the answer is <code class="lang-matlab">197</code>.\n          `,
 };

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -43,7 +43,7 @@ export const getDataFromOlx = ({ rawOLX, rawSettings }) => {
   if (!_.isEmpty(rawOLX) && !_.isEmpty(data)) {
     return { ...data, rawOLX, settings: parsedSettings };
   }
-  return {};
+  return { settings: {} };
 };
 
 export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispatch) => {


### PR DESCRIPTION
For the XMLParser, the `preserveOrder` option needs to be set to true for us to capture solutions properly when there are nested tags. Otherwise, the parser will bundle certain texts together in an undesired fashion.

https://2u-internal.atlassian.net/browse/TNL-10728