### PR TITLE
feat: update returnToUnit to include api response

### DIFF
--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -70,7 +70,7 @@ export const saveBlock = ({ content, returnToUnit }) => (dispatch) => {
     content,
     onSuccess: (response) => {
       dispatch(actions.app.setSaveResponse(response));
-      returnToUnit();
+      returnToUnit(response.data)();
     },
   }));
 };

--- a/src/editors/data/redux/thunkActions/app.test.js
+++ b/src/editors/data/redux/thunkActions/app.test.js
@@ -138,7 +138,7 @@ describe('app thunkActions', () => {
     let returnToUnit;
     let calls;
     beforeEach(() => {
-      returnToUnit = jest.fn();
+      returnToUnit = jest.fn((response) => () => response);
       thunkActions.saveBlock({ content: testValue, returnToUnit })(dispatch);
       calls = dispatch.mock.calls;
     });

--- a/src/editors/hooks.js
+++ b/src/editors/hooks.js
@@ -21,12 +21,12 @@ export const navigateCallback = ({
   destination,
   analyticsEvent,
   analytics,
-}) => () => {
+}) => (response) => {
   if (process.env.NODE_ENV !== 'development' && analyticsEvent && analytics) {
     sendTrackEvent(analyticsEvent, analytics);
   }
   if (returnFunction) {
-    returnFunction();
+    returnFunction()(response);
     return;
   }
   module.navigateTo(destination);

--- a/src/editors/hooks.test.jsx
+++ b/src/editors/hooks.test.jsx
@@ -74,7 +74,6 @@ describe('hooks', () => {
     let output;
     const SAVED_ENV = process.env;
     const destination = 'hOmE';
-    const returnFunction = jest.fn();
     beforeEach(() => {
       jest.resetModules();
       process.env = { ...SAVED_ENV };
@@ -102,6 +101,7 @@ describe('hooks', () => {
       expect(spy).toHaveBeenCalledWith(destination);
     });
     it('should call returnFunction and return null', () => {
+      const returnFunction = jest.fn(() => (response) => response);
       output = hooks.navigateCallback({
         destination,
         returnFunction,


### PR DESCRIPTION
Related JIRA Ticket: [TNL-10796](https://2u-internal.atlassian.net/browse/TNL-10796)

This PR returns the xblock API response back to the parent component when `returnFunction` is defined. This is necessary when the editor data is changed and the change needs to be reflected on save.