### PR TITLE
refactor: hide switch to hide selected videos

### DIFF
--- a/src/editors/containers/VideoGallery/hooks.js
+++ b/src/editors/containers/VideoGallery/hooks.js
@@ -46,7 +46,7 @@ export const searchAndSortProps = () => {
     onFilterClick: (key) => () => setFilterBy(key),
     filterKeys,
     filterMessages,
-    showSwitch: true,
+    showSwitch: false,
     hideSelectedVideos,
     switchMessage: messages.hideSelectedCourseVideosSwitchLabel,
     onSwitchClick: () => setHideSelectedVideos(!hideSelectedVideos),


### PR DESCRIPTION
The backend for hiding selected videos is not implemented and it is currently not required, so this commit hides the option.

**Test instructions**

Follow instructions provided in https://github.com/openedx/frontend-lib-content-components/pull/278 to get to video gallery page and make sure that the option `Hide selected videos` is not visible.

Before:
![image](https://github.com/openedx/frontend-lib-content-components/assets/10894099/11b56a2b-3ea4-4a11-89f5-96a7c6cf1362)


After:
![image](https://github.com/openedx/frontend-lib-content-components/assets/10894099/c0680b91-aa4f-46ff-971d-3c304ddba15f)
