### PR TITLE
fix: failure toast and close modal bugs

### DIFF
--- a/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
@@ -9,14 +9,7 @@ exports[`EditorContainer component render snapshot: initialized. enable save and
     close={[MockFunction closeCancelConfirmModal]}
     confirmAction={
       <Button
-        onClick={
-          Object {
-            "handleCancel": Object {
-              "onClose": [MockFunction props.onClose],
-              "returnFunction": [MockFunction props.returnFunction],
-            },
-          }
-        }
+        onClick={[Function]}
         variant="primary"
       >
         <FormattedMessage
@@ -92,14 +85,7 @@ exports[`EditorContainer component render snapshot: not initialized. disable sav
     close={[MockFunction closeCancelConfirmModal]}
     confirmAction={
       <Button
-        onClick={
-          Object {
-            "handleCancel": Object {
-              "onClose": [MockFunction props.onClose],
-              "returnFunction": [MockFunction props.returnFunction],
-            },
-          }
-        }
+        onClick={[Function]}
         variant="primary"
       >
         <FormattedMessage

--- a/src/editors/containers/EditorContainer/index.jsx
+++ b/src/editors/containers/EditorContainer/index.jsx
@@ -36,7 +36,12 @@ export const EditorContainer = ({
         confirmAction={(
           <Button
             variant="primary"
-            onClick={handleCancel}
+            onClick={() => {
+              handleCancel();
+              if (returnFunction) {
+                closeCancelConfirmModal();
+              }
+            }}
           >
             <FormattedMessage {...messages.okButtonLabel} />
           </Button>

--- a/src/editors/data/redux/thunkActions/app.js
+++ b/src/editors/data/redux/thunkActions/app.js
@@ -64,13 +64,13 @@ export const initialize = (data) => (dispatch) => {
 /**
  * @param {func} onSuccess
  */
-export const saveBlock = ({ content, returnToUnit }) => (dispatch) => {
+export const saveBlock = (content, returnToUnit) => (dispatch) => {
   dispatch(actions.app.setBlockContent(content));
   dispatch(requests.saveBlock({
     content,
     onSuccess: (response) => {
       dispatch(actions.app.setSaveResponse(response));
-      returnToUnit(response.data)();
+      returnToUnit(response.data);
     },
   }));
 };

--- a/src/editors/data/redux/thunkActions/app.test.js
+++ b/src/editors/data/redux/thunkActions/app.test.js
@@ -138,8 +138,8 @@ describe('app thunkActions', () => {
     let returnToUnit;
     let calls;
     beforeEach(() => {
-      returnToUnit = jest.fn((response) => () => response);
-      thunkActions.saveBlock({ content: testValue, returnToUnit })(dispatch);
+      returnToUnit = jest.fn();
+      thunkActions.saveBlock(testValue, returnToUnit)(dispatch);
       calls = dispatch.mock.calls;
     });
     it('dispatches actions.app.setBlockContent with content, before dispatching saveBlock', () => {

--- a/src/editors/hooks.js
+++ b/src/editors/hooks.js
@@ -54,15 +54,15 @@ export const saveBlock = ({
     attemptSave = true;
   }
   if (attemptSave) {
-    dispatch(thunkActions.app.saveBlock({
-      returnToUnit: module.navigateCallback({
+    dispatch(thunkActions.app.saveBlock(
+      content,
+      module.navigateCallback({
         destination,
         analyticsEvent: analyticsEvt.editorSaveClick,
         analytics,
         returnFunction,
       }),
-      content,
-    }));
+    ));
   }
 };
 

--- a/src/editors/hooks.test.jsx
+++ b/src/editors/hooks.test.jsx
@@ -146,14 +146,14 @@ describe('hooks', () => {
         analytics,
         dispatch,
       });
-      expect(dispatch).toHaveBeenCalledWith(thunkActions.app.saveBlock({
-        returnToUnit: navigateCallback({
+      expect(dispatch).toHaveBeenCalledWith(thunkActions.app.saveBlock(
+        content,
+        navigateCallback({
           destination,
           analyticsEvent: analyticsEvt.editorSaveClick,
           analytics,
         }),
-        content,
-      }));
+      ));
     });
   });
 


### PR DESCRIPTION
This PR resolves the bug that caused the save failure toast to appear without an API save error. The toast was appearing because of a type error and the toast appeared whenever an error is caught during the save, but still allowed the save to continue. Additionally, resolves the bug that causes the close confirmation modal to remain open after closing the modal. The close confirmation modal was previously not closing so it would remain visible when the editor was not is a modal or redirected after closing.