### PR TITLE
fix: persisting title from previous editor load

### DIFF
--- a/src/editors/data/redux/app/reducer.js
+++ b/src/editors/data/redux/app/reducer.js
@@ -32,6 +32,7 @@ const app = createSlice({
       blockId: payload.blockId,
       learningContextId: payload.learningContextId,
       blockType: payload.blockType,
+      blockValue: null,
     }),
     setUnitUrl: (state, { payload }) => ({ ...state, unitUrl: payload }),
     setBlockValue: (state, { payload }) => ({


### PR DESCRIPTION
This PR sets the `blockValue` to `null` when the editor is initializing. Reference [this comment](https://github.com/openedx/frontend-app-course-authoring/pull/510#pullrequestreview-1489201114) from course authoring PR 510 for testing details.