### PR TITLE
feat: react based studio footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@edx/browserslist-config": "^1.1.1",
         "@edx/frontend-build": "12.8.27",
         "@edx/frontend-platform": "4.2.0",
-        "@edx/paragon": "^20.32.0",
+        "@edx/paragon": "^20.45.0",
         "@edx/reactifex": "^2.1.1",
         "@testing-library/dom": "^8.13.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -2439,9 +2439,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.32.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.32.0.tgz",
-      "integrity": "sha512-d2rlYoWyRLvzPMo7MfCojqU/Qvk0cXnBpXW7aOOOQYhTvC3m3Y3yNWjQ8DJhbnWyL1tFEjZG2mjlgXHDHBqtLQ==",
+      "version": "20.45.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.45.0.tgz",
+      "integrity": "sha512-9lHcnSJ36sQ+bsYFhydf/Pvp3Bo5N3go8R3ORPTNtvYnwiKSfjlv11QpURC/xHobXsT2eYHiwl2gNmq1yP09BA==",
       "dev": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@edx/browserslist-config": "^1.1.1",
     "@edx/frontend-build": "12.8.27",
     "@edx/frontend-platform": "4.2.0",
-    "@edx/paragon": "^20.32.0",
+    "@edx/paragon": "^20.45.0",
     "@edx/reactifex": "^2.1.1",
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/footer/Footer.jsx
+++ b/src/footer/Footer.jsx
@@ -38,11 +38,8 @@ const Footer = ({
           iconAfter={isOpen ? ExpandLess : ExpandMore}
           size="sm"
         >
-          {isOpen ? (
-            <FormattedMessage {...messages.closeHelpButtonLabel} />
-          ) : (
-            <FormattedMessage {...messages.openHelpButtonLabel} />
-          )}
+          {isOpen ? intl.formatMessage(messages.closeHelpButtonLabel)
+            : intl.formatMessage(messages.openHelpButtonLabel)}
         </Button>
         <div className="col border-top ml-2" />
       </div>
@@ -113,7 +110,7 @@ const Footer = ({
           Translators: 'edX' and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate
             any of these trademarks and company names.
         */}
-        edX and Open edX, and the edX and Open edX logos are registered trademarks of<Hyperlink destination="https://www.edx.org">edX Inc</Hyperlink>.
+        edX and Open edX, and the edX and Open edX logos are registered trademarks of <Hyperlink className="ml-1" destination="https://www.edx.org">edX Inc</Hyperlink>.
         {/* need to add link to edx.org */}
         <ActionRow.Spacer />
         <Hyperlink destination="https://open.edx.org" className="float-right">

--- a/src/footer/Footer.jsx
+++ b/src/footer/Footer.jsx
@@ -50,9 +50,25 @@ const Footer = ({
             <Button as="a" href="https://docs.edx.org/" size="sm">
               <FormattedMessage {...messages.edxDocumentationButtonLabel} />
             </Button>
-            <Button as="a" href="https://openedx.org/" size="sm">
-              Open edX Portal
-            </Button>
+            {platformName === 'edX' ? (
+              <Button
+                as="a"
+                href="https://partner.edx.org/"
+                size="sm"
+                data-testid="edXPortalButton"
+              >
+                <FormattedMessage {...messages.parnterPortalButtonLabel} />
+              </Button>
+            ) : (
+              <Button
+                as="a"
+                href="https://open.edx.org/"
+                size="sm"
+                data-testid="openEdXPortalButton"
+              >
+                <FormattedMessage {...messages.openEdxPortalButtonLabel} />
+              </Button>
+            )}
             <Button
               as="a"
               href="https://www.edx.org/course/edx101-overview-of-creating-an-edx-course#.VO4eaLPF-n1"
@@ -110,8 +126,8 @@ const Footer = ({
           Translators: 'edX' and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate
             any of these trademarks and company names.
         */}
-        edX and Open edX, and the edX and Open edX logos are registered trademarks of <Hyperlink className="ml-1" destination="https://www.edx.org">edX Inc</Hyperlink>.
-        {/* need to add link to edx.org */}
+        <FormattedMessage {...messages.trademarkMessage} />
+        <Hyperlink className="ml-1" destination="https://www.edx.org">edX Inc</Hyperlink>.
         <ActionRow.Spacer />
         <Hyperlink destination="https://open.edx.org" className="float-right">
           <Image

--- a/src/footer/Footer.jsx
+++ b/src/footer/Footer.jsx
@@ -45,7 +45,7 @@ const Footer = ({
       </div>
       <TransitionReplace>
         {isOpen ? (
-          <ActionRow className="py-4" data-testid="helpButtonRow">
+          <ActionRow key="help-link-button-row" className="py-4" data-testid="helpButtonRow">
             <ActionRow.Spacer />
             <Button as="a" href="https://docs.edx.org/" size="sm">
               <FormattedMessage {...messages.edxDocumentationButtonLabel} />

--- a/src/footer/Footer.jsx
+++ b/src/footer/Footer.jsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash-es';
+import { intlShape, injectIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import {
+  ActionRow,
+  Button,
+  Hyperlink,
+  Image,
+  TransitionReplace,
+} from '@edx/paragon';
+import { ExpandLess, ExpandMore, Help } from '@edx/paragon/icons';
+import messages from './messages';
+
+const Footer = ({
+  marketingBaseUrl,
+  termsOfServiceUrl,
+  privacyPolicyUrl,
+  supportEmail,
+  platformName,
+  lmsBaseUrl,
+  studioBaseUrl,
+  showAccessibilityPage,
+  // injected
+  intl,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <div className="m-0 row align-items-center justify-content-center">
+        <div className="col border-top mr-2" />
+        <Button
+          data-testid="helpToggleButton"
+          variant="outline-primary"
+          onClick={() => setIsOpen(!isOpen)}
+          iconBefore={Help}
+          iconAfter={isOpen ? ExpandLess : ExpandMore}
+          size="sm"
+        >
+          {isOpen ? (
+            <FormattedMessage {...messages.closeHelpButtonLabel} />
+          ) : (
+            <FormattedMessage {...messages.openHelpButtonLabel} />
+          )}
+        </Button>
+        <div className="col border-top ml-2" />
+      </div>
+      <TransitionReplace>
+        {isOpen ? (
+          <ActionRow className="py-4" data-testid="helpButtonRow">
+            <ActionRow.Spacer />
+            <Button as="a" href="https://docs.edx.org/" size="sm">
+              <FormattedMessage {...messages.edxDocumentationButtonLabel} />
+            </Button>
+            <Button as="a" href="https://openedx.org/" size="sm">
+              Open edX Portal
+            </Button>
+            <Button
+              as="a"
+              href="https://www.edx.org/course/edx101-overview-of-creating-an-edx-course#.VO4eaLPF-n1"
+              size="sm"
+            >
+              <FormattedMessage {...messages.edx101ButtonLabel} />
+            </Button>
+            <Button
+              as="a"
+              href="https://www.edx.org/course/studiox-creating-a-course-with-edx-studio"
+              size="sm"
+            >
+              <FormattedMessage {...messages.studioXButtonLabel} />
+            </Button>
+            {!_.isEmpty(supportEmail) && (
+              <Button
+                as="a"
+                href={`mailto:${supportEmail}`}
+                size="sm"
+                data-testid="contactUsButton"
+              >
+                <FormattedMessage {...messages.contactUsButtonLabel} />
+              </Button>
+            )}
+            <ActionRow.Spacer />
+          </ActionRow>
+        ) : null}
+      </TransitionReplace>
+      <ActionRow className="pt-3 px-4 m-0 x-small">
+        © {new Date().getFullYear()} <Hyperlink destination={marketingBaseUrl} target="_blank" className="ml-2">{platformName}</Hyperlink>
+        <ActionRow.Spacer />
+        {!_.isEmpty(termsOfServiceUrl) && (
+          <Hyperlink destination={termsOfServiceUrl} data-testid="termsOfService">
+            {intl.formatMessage(messages.termsOfServiceLinkLabel)}
+          </Hyperlink>
+        )}{!_.isEmpty(privacyPolicyUrl) && (
+          <Hyperlink destination={privacyPolicyUrl} data-testid="privacyPolicy">
+            {intl.formatMessage(messages.privacyPolicyLinkLabel)}
+          </Hyperlink>
+        )}
+        {showAccessibilityPage && (
+          <Hyperlink
+            destination={`${studioBaseUrl}/accessibility`}
+            data-testid="accessibilityRequest"
+          >
+            {intl.formatMessage(messages.accessibilityRequestLinkLabel)}
+          </Hyperlink>
+        )}
+        <Hyperlink destination={lmsBaseUrl}>LMS</Hyperlink>
+      </ActionRow>
+      <ActionRow className="mt-3 mx-4 pb-4 x-small">
+        {/*
+          Site operators: Please do not remove this paragraph! this attributes back to edX and
+            makes your acknowledgement of edX's trademarks clear.
+          Translators: 'edX' and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate
+            any of these trademarks and company names.
+        */}
+        edX and Open edX, and the edX and Open edX logos are registered trademarks of<Hyperlink destination="https://www.edx.org">edX Inc</Hyperlink>.
+        {/* need to add link to edx.org */}
+        <ActionRow.Spacer />
+        <Hyperlink destination="https://open.edx.org" className="float-right">
+          <Image
+            width="120px"
+            alt="Powered by Open edX"
+            src="https://logos.openedx.org/open-edx-logo-tag.png"
+          />
+        </Hyperlink>
+      </ActionRow>
+    </>
+  );
+};
+
+Footer.defaultProps = {
+  marketingBaseUrl: null,
+  termsOfServiceUrl: null,
+  privacyPolicyUrl: null,
+  spanishPrivacyPolicy: null,
+  supportEmail: null,
+};
+
+Footer.propTypes = {
+  marketingBaseUrl: PropTypes.string,
+  termsOfServiceUrl: PropTypes.string,
+  privacyPolicyUrl: PropTypes.string,
+  spanishPrivacyPolicy: PropTypes.string,
+  supportEmail: PropTypes.string,
+  platformName: PropTypes.string.isRequired,
+  lmsBaseUrl: PropTypes.string.isRequired,
+  studioBaseUrl: PropTypes.string.isRequired,
+  showAccessibilityPage: PropTypes.bool.isRequired,
+  // injected
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(Footer);

--- a/src/footer/Footer.test.jsx
+++ b/src/footer/Footer.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { formatMessage } from '../testUtils';
+import Footer from './Footer';
+import messages from './messages';
+
+const renderComponent = (
+  termsOfServiceUrl,
+  privacyPolicyUrl,
+  supportEmail,
+  showAccessibilityPage,
+) => {
+  render(
+    <IntlProvider locale="en">
+      <Footer
+        marketingBaseUrl="#"
+        termsOfServiceUrl={termsOfServiceUrl}
+        privacyPolicyUrl={privacyPolicyUrl}
+        supportEmail={supportEmail}
+        platformName="Test Platform"
+        lmsBaseUrl="#"
+        studioBaseUrl="#"
+        showAccessibilityPage={showAccessibilityPage || false}
+        intl={{ formatMessage }}
+      />
+    </IntlProvider>,
+  );
+};
+
+describe('Footer', () => {
+  describe('help section default view', () => {
+    it('help button should read Looking for help with Studio?', () => {
+      renderComponent();
+      expect(screen.getByText(messages.openHelpButtonLabel.defaultMessage))
+        .toBeVisible();
+    });
+    it('help button link row should not be visible', () => {
+      renderComponent();
+      expect(screen.queryByTestId('helpButtonRow')).toBeNull();
+    });
+  });
+  describe('help section expanded view', () => {
+    it('help button should read Hide Studio help', () => {
+      renderComponent();
+      const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
+      fireEvent.click(helpToggleButton);
+      expect(screen.getByText(messages.closeHelpButtonLabel.defaultMessage))
+        .toBeVisible();
+    });
+    it('help button link row should be visible', () => {
+      renderComponent();
+      const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
+      fireEvent.click(helpToggleButton);
+      expect(screen.getByTestId('helpButtonRow')).toBeVisible();
+    });
+    it('should not show contect us button', () => {
+      renderComponent();
+      const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
+      fireEvent.click(helpToggleButton);
+      expect(screen.queryByTestId('contactUsButton')).toBeNull();
+    });
+    it('should not show contect us button', () => {
+      renderComponent(null, null, 'support@email.com', false);
+      const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
+      fireEvent.click(helpToggleButton);
+      expect(screen.getByTestId('contactUsButton')).toBeVisible();
+    });
+  });
+  describe('policy link row', () => {
+    it('should only show LMS link', () => {
+      renderComponent();
+      expect(screen.getByText('LMS')).toBeVisible();
+      expect(screen.queryByTestId('termsOfService')).toBeNull();
+      expect(screen.queryByTestId('privacyPolicy')).toBeNull();
+      expect(screen.queryByTestId('accessibilityRequest')).toBeNull();
+    });
+    it('should show terms of service link', () => {
+      renderComponent('termsofserviceurl', null, null, false);
+      expect(screen.getByText('LMS')).toBeVisible();
+      expect(screen.queryByTestId('termsOfService')).toBeVisible();
+      expect(screen.queryByTestId('privacyPolicy')).toBeNull();
+      expect(screen.queryByTestId('accessibilityRequest')).toBeNull();
+    });
+    it('should show privacy policy link', () => {
+      renderComponent(null, 'privacypolicyurl', null, false);
+      expect(screen.getByText('LMS')).toBeVisible();
+      expect(screen.queryByTestId('termsOfService')).toBeNull();
+      expect(screen.queryByTestId('privacyPolicy')).toBeVisible();
+      expect(screen.queryByTestId('accessibilityRequest')).toBeNull();
+    });
+    it('should show accessibilty request link', () => {
+      renderComponent(null, null, null, true);
+      expect(screen.getByText('LMS')).toBeVisible();
+      expect(screen.queryByTestId('termsOfService')).toBeNull();
+      expect(screen.queryByTestId('privacyPolicy')).toBeNull();
+      expect(screen.queryByTestId('accessibilityRequest')).toBeVisible();
+    });
+  });
+});

--- a/src/footer/Footer.test.jsx
+++ b/src/footer/Footer.test.jsx
@@ -29,6 +29,8 @@ const renderComponent = (
   );
 };
 
+jest.unmock('@edx/paragon');
+
 describe('Footer', () => {
   describe('help section default view', () => {
     it('help button should read Looking for help with Studio?', () => {

--- a/src/footer/Footer.test.jsx
+++ b/src/footer/Footer.test.jsx
@@ -11,6 +11,7 @@ const renderComponent = (
   privacyPolicyUrl,
   supportEmail,
   showAccessibilityPage,
+  platformName,
 ) => {
   render(
     <IntlProvider locale="en">
@@ -19,7 +20,7 @@ const renderComponent = (
         termsOfServiceUrl={termsOfServiceUrl}
         privacyPolicyUrl={privacyPolicyUrl}
         supportEmail={supportEmail}
-        platformName="Test Platform"
+        platformName={platformName || 'Test Platform'}
         lmsBaseUrl="#"
         studioBaseUrl="#"
         showAccessibilityPage={showAccessibilityPage || false}
@@ -57,14 +58,30 @@ describe('Footer', () => {
       fireEvent.click(helpToggleButton);
       expect(screen.getByTestId('helpButtonRow')).toBeVisible();
     });
-    it('should not show contect us button', () => {
+    describe('portal button', () => {
+      it('should equal edX partner portal and edX equals platform name', () => {
+        renderComponent(null, null, null, false, 'edX');
+        const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
+        fireEvent.click(helpToggleButton);
+        expect(screen.getByTestId('edXPortalButton')).toBeVisible();
+        expect(screen.queryByTestId('openEdXPortalButton')).toBeNull();
+      });
+      it('should equal Open edX portal and edX does not equal platform name', () => {
+        renderComponent();
+        const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
+        fireEvent.click(helpToggleButton);
+        expect(screen.queryByTestId('edXPortalButton')).toBeNull();
+        expect(screen.getByTestId('openEdXPortalButton')).toBeVisible();
+      });
+    });
+    it('should not show contact us button', () => {
       renderComponent();
       const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
       fireEvent.click(helpToggleButton);
       expect(screen.queryByTestId('contactUsButton')).toBeNull();
     });
-    it('should not show contect us button', () => {
-      renderComponent(null, null, 'support@email.com', false);
+    it('should show contact us button', () => {
+      renderComponent(null, null, 'support@email.com', false, null);
       const helpToggleButton = screen.getByText(messages.openHelpButtonLabel.defaultMessage);
       fireEvent.click(helpToggleButton);
       expect(screen.getByTestId('contactUsButton')).toBeVisible();
@@ -79,21 +96,21 @@ describe('Footer', () => {
       expect(screen.queryByTestId('accessibilityRequest')).toBeNull();
     });
     it('should show terms of service link', () => {
-      renderComponent('termsofserviceurl', null, null, false);
+      renderComponent('termsofserviceurl', null, null, false, null);
       expect(screen.getByText('LMS')).toBeVisible();
       expect(screen.queryByTestId('termsOfService')).toBeVisible();
       expect(screen.queryByTestId('privacyPolicy')).toBeNull();
       expect(screen.queryByTestId('accessibilityRequest')).toBeNull();
     });
     it('should show privacy policy link', () => {
-      renderComponent(null, 'privacypolicyurl', null, false);
+      renderComponent(null, 'privacypolicyurl', null, false, null);
       expect(screen.getByText('LMS')).toBeVisible();
       expect(screen.queryByTestId('termsOfService')).toBeNull();
       expect(screen.queryByTestId('privacyPolicy')).toBeVisible();
       expect(screen.queryByTestId('accessibilityRequest')).toBeNull();
     });
     it('should show accessibilty request link', () => {
-      renderComponent(null, null, null, true);
+      renderComponent(null, null, null, true, null);
       expect(screen.getByText('LMS')).toBeVisible();
       expect(screen.queryByTestId('termsOfService')).toBeNull();
       expect(screen.queryByTestId('privacyPolicy')).toBeNull();

--- a/src/footer/index.jsx
+++ b/src/footer/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './Footer';

--- a/src/footer/index.jsx
+++ b/src/footer/index.jsx
@@ -1,1 +1,3 @@
-export { default } from './Footer';
+import Footer from './Footer';
+
+export default Footer;

--- a/src/footer/messages.js
+++ b/src/footer/messages.js
@@ -1,0 +1,56 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  openHelpButtonLabel: {
+    id: 'authoring.footer.help.openHelp.button.label',
+    defaultMessage: 'Looking for help with Studio?',
+    description: 'Label for button that opens the collapsed section with help buttons',
+  },
+  closeHelpButtonLabel: {
+    id: 'authoring.footer.help.closeHelp.button.label',
+    defaultMessage: 'Hide Studio help',
+    description: 'Label for button that closes the collapsed section with help buttons',
+  },
+  edxDocumentationButtonLabel: {
+    id: 'authoring.footer.help.edxDocumentation.button.label',
+    defaultMessage: 'edX Documentation',
+    description: 'Label for button that links to the edX documentation site',
+  },
+  openEdxPortalButtonLabel: {
+    id: 'authoring.footer.help.edxDocumentation.button.label',
+    defaultMessage: 'edX Documentation',
+    description: 'Label for button that links to the edX documentation site',
+  },
+  edx101ButtonLabel: {
+    id: 'authoring.footer.help.edx101.button.label',
+    defaultMessage: 'Enroll in edX 101',
+    description: 'Label for button that links to the edX 101 course',
+  },
+  studioXButtonLabel: {
+    id: 'authoring.footer.help.studioX.button.label',
+    defaultMessage: 'Enroll in StudioX',
+    description: 'Label for button that links to the edX StudioX course',
+  },
+  contactUsButtonLabel: {
+    id: 'authoring.footer.help.contactUs.button.label',
+    defaultMessage: 'Contact us',
+    description: 'Label for button that links to the email for partner support',
+  },
+  termsOfServiceLinkLabel: {
+    id: 'authoring.footer.termsOfService.link.label',
+    defaultMessage: 'Terms of Service',
+    description: 'Label for button that links to the terms of service page',
+  },
+  privacyPolicyLinkLabel: {
+    id: 'authoring.footer.privacyPolicy.link.label',
+    defaultMessage: 'Privacy Policy',
+    description: 'Label for button that links to the privacy policy page',
+  },
+  accessibilityRequestLinkLabel: {
+    id: 'authoring.footer.accessibilityRequest.link.label',
+    defaultMessage: 'Accessibility Accomodation Request',
+    description: 'Label for button that links to the accessibility accomodation requests page',
+  },
+});
+
+export default messages;

--- a/src/footer/messages.js
+++ b/src/footer/messages.js
@@ -13,13 +13,18 @@ const messages = defineMessages({
   },
   edxDocumentationButtonLabel: {
     id: 'authoring.footer.help.edxDocumentation.button.label',
-    defaultMessage: 'edX Documentation',
+    defaultMessage: 'edX documentation',
     description: 'Label for button that links to the edX documentation site',
   },
+  parnterPortalButtonLabel: {
+    id: 'authoring.footer.help.parnterPortal.button.label',
+    defaultMessage: 'edX partner portal',
+    description: 'Label for button that links to the edX partner portal',
+  },
   openEdxPortalButtonLabel: {
-    id: 'authoring.footer.help.edxDocumentation.button.label',
-    defaultMessage: 'edX Documentation',
-    description: 'Label for button that links to the edX documentation site',
+    id: 'authoring.footer.help.openEdxPortal.button.label',
+    defaultMessage: 'Open edX portal',
+    description: 'Label for button that links to the Open edX portal',
   },
   edx101ButtonLabel: {
     id: 'authoring.footer.help.edx101.button.label',
@@ -50,6 +55,11 @@ const messages = defineMessages({
     id: 'authoring.footer.accessibilityRequest.link.label',
     defaultMessage: 'Accessibility Accomodation Request',
     description: 'Label for button that links to the accessibility accomodation requests page',
+  },
+  trademarkMessage: {
+    id: 'authoring.footer.trademark.message',
+    defaultMessage: 'edX and Open edX, and the edX and Open edX logos are registered trademarks of',
+    description: 'Message about the use of logos and names edX and Open edX',
   },
 });
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,7 @@ import EditorPage from './editors/EditorPage';
 import VideoSelectorPage from './editors/VideoSelectorPage';
 import DraggableList, { SortableItem } from './editors/sharedComponents/DraggableList';
 import ErrorAlert from './editors/sharedComponents/ErrorAlerts/ErrorAlert';
+import Footer from './footer';
 
 export {
   messages,
@@ -12,5 +13,6 @@ export {
   DraggableList,
   SortableItem,
   ErrorAlert,
+  Footer,
 };
 export default Placeholder;

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -60,76 +60,76 @@ jest.mock('@edx/frontend-platform/i18n', () => {
   };
 });
 
-// jest.mock('@edx/paragon', () => jest.requireActual('testUtils').mockNestedComponents({
-//   Alert: {
-//     Heading: 'Alert.Heading',
-//   },
-//   ActionRow: {
-//     Spacer: 'ActionRow.Spacer',
-//   },
-//   Button: 'Button',
-//   ButtonGroup: 'ButtonGroup',
-//   Collapsible: {
-//     Advanced: 'Advanced',
-//     Body: 'Body',
-//     Trigger: 'Trigger',
-//     Visible: 'Visible',
-//   },
-//   Card: {
-//     Header: 'Card.Header',
-//     Section: 'Card.Section',
-//     Footer: 'Card.Footer',
-//     Body: 'Card.Body',
-//   },
-//   Col: 'Col',
-//   Container: 'Container',
-//   Dropdown: {
-//     Item: 'Dropdown.Item',
-//     Menu: 'Dropdown.Menu',
-//     Toggle: 'Dropdown.Toggle',
-//   },
-//   ErrorContext: {
-//     Provider: 'ErrorContext.Provider',
-//   },
-//   Hyperlink: 'Hyperlink',
-//   Icon: 'Icon',
-//   IconButton: 'IconButton',
-//   IconButtonWithTooltip: 'IconButtonWithTooltip',
-//   Image: 'Image',
-//   MailtoLink: 'MailtoLink',
-//   ModalDialog: {
-//     Footer: 'ModalDialog.Footer',
-//     Header: 'ModalDialog.Header',
-//     Title: 'ModalDialog.Title',
-//     Body: 'ModalDialog.Body',
-//     CloseButton: 'ModalDialog.CloseButton',
-//   },
-//   Form: {
-//     Checkbox: 'Form.Checkbox',
-//     Control: {
-//       Feedback: 'Form.Control.Feedback',
-//     },
-//     Group: 'Form.Group',
-//     Label: 'Form.Label',
-//     Text: 'Form.Text',
-//     Row: 'Form.Row',
-//     Radio: 'Radio',
-//     RadioSet: 'RadioSet',
-//   },
-//   OverlayTrigger: 'OverlayTrigger',
-//   Tooltip: 'Tooltip',
-//   FullscreenModal: 'FullscreenModal',
-//   Row: 'Row',
-//   Scrollable: 'Scrollable',
-//   SelectableBox: {
-//     Set: 'SelectableBox.Set',
-//   },
+jest.mock('@edx/paragon', () => jest.requireActual('testUtils').mockNestedComponents({
+  Alert: {
+    Heading: 'Alert.Heading',
+  },
+  ActionRow: {
+    Spacer: 'ActionRow.Spacer',
+  },
+  Button: 'Button',
+  ButtonGroup: 'ButtonGroup',
+  Collapsible: {
+    Advanced: 'Advanced',
+    Body: 'Body',
+    Trigger: 'Trigger',
+    Visible: 'Visible',
+  },
+  Card: {
+    Header: 'Card.Header',
+    Section: 'Card.Section',
+    Footer: 'Card.Footer',
+    Body: 'Card.Body',
+  },
+  Col: 'Col',
+  Container: 'Container',
+  Dropdown: {
+    Item: 'Dropdown.Item',
+    Menu: 'Dropdown.Menu',
+    Toggle: 'Dropdown.Toggle',
+  },
+  ErrorContext: {
+    Provider: 'ErrorContext.Provider',
+  },
+  Hyperlink: 'Hyperlink',
+  Icon: 'Icon',
+  IconButton: 'IconButton',
+  IconButtonWithTooltip: 'IconButtonWithTooltip',
+  Image: 'Image',
+  MailtoLink: 'MailtoLink',
+  ModalDialog: {
+    Footer: 'ModalDialog.Footer',
+    Header: 'ModalDialog.Header',
+    Title: 'ModalDialog.Title',
+    Body: 'ModalDialog.Body',
+    CloseButton: 'ModalDialog.CloseButton',
+  },
+  Form: {
+    Checkbox: 'Form.Checkbox',
+    Control: {
+      Feedback: 'Form.Control.Feedback',
+    },
+    Group: 'Form.Group',
+    Label: 'Form.Label',
+    Text: 'Form.Text',
+    Row: 'Form.Row',
+    Radio: 'Radio',
+    RadioSet: 'RadioSet',
+  },
+  OverlayTrigger: 'OverlayTrigger',
+  Tooltip: 'Tooltip',
+  FullscreenModal: 'FullscreenModal',
+  Row: 'Row',
+  Scrollable: 'Scrollable',
+  SelectableBox: {
+    Set: 'SelectableBox.Set',
+  },
 
-//   Spinner: 'Spinner',
-//   Stack: 'Stack',
-//   Toast: 'Toast',
-//   Truncate: 'Truncate',
-// }));
+  Spinner: 'Spinner',
+  Stack: 'Stack',
+  Toast: 'Toast',
+  Truncate: 'Truncate',
+}));
 
 jest.mock('@edx/paragon/icons', () => ({
   Close: jest.fn().mockName('icons.Close'),

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -60,76 +60,76 @@ jest.mock('@edx/frontend-platform/i18n', () => {
   };
 });
 
-jest.mock('@edx/paragon', () => jest.requireActual('testUtils').mockNestedComponents({
-  Alert: {
-    Heading: 'Alert.Heading',
-  },
-  ActionRow: {
-    Spacer: 'ActionRow.Spacer',
-  },
-  Button: 'Button',
-  ButtonGroup: 'ButtonGroup',
-  Collapsible: {
-    Advanced: 'Advanced',
-    Body: 'Body',
-    Trigger: 'Trigger',
-    Visible: 'Visible',
-  },
-  Card: {
-    Header: 'Card.Header',
-    Section: 'Card.Section',
-    Footer: 'Card.Footer',
-    Body: 'Card.Body',
-  },
-  Col: 'Col',
-  Container: 'Container',
-  Dropdown: {
-    Item: 'Dropdown.Item',
-    Menu: 'Dropdown.Menu',
-    Toggle: 'Dropdown.Toggle',
-  },
-  ErrorContext: {
-    Provider: 'ErrorContext.Provider',
-  },
-  Hyperlink: 'Hyperlink',
-  Icon: 'Icon',
-  IconButton: 'IconButton',
-  IconButtonWithTooltip: 'IconButtonWithTooltip',
-  Image: 'Image',
-  MailtoLink: 'MailtoLink',
-  ModalDialog: {
-    Footer: 'ModalDialog.Footer',
-    Header: 'ModalDialog.Header',
-    Title: 'ModalDialog.Title',
-    Body: 'ModalDialog.Body',
-    CloseButton: 'ModalDialog.CloseButton',
-  },
-  Form: {
-    Checkbox: 'Form.Checkbox',
-    Control: {
-      Feedback: 'Form.Control.Feedback',
-    },
-    Group: 'Form.Group',
-    Label: 'Form.Label',
-    Text: 'Form.Text',
-    Row: 'Form.Row',
-    Radio: 'Radio',
-    RadioSet: 'RadioSet',
-  },
-  OverlayTrigger: 'OverlayTrigger',
-  Tooltip: 'Tooltip',
-  FullscreenModal: 'FullscreenModal',
-  Row: 'Row',
-  Scrollable: 'Scrollable',
-  SelectableBox: {
-    Set: 'SelectableBox.Set',
-  },
+// jest.mock('@edx/paragon', () => jest.requireActual('testUtils').mockNestedComponents({
+//   Alert: {
+//     Heading: 'Alert.Heading',
+//   },
+//   ActionRow: {
+//     Spacer: 'ActionRow.Spacer',
+//   },
+//   Button: 'Button',
+//   ButtonGroup: 'ButtonGroup',
+//   Collapsible: {
+//     Advanced: 'Advanced',
+//     Body: 'Body',
+//     Trigger: 'Trigger',
+//     Visible: 'Visible',
+//   },
+//   Card: {
+//     Header: 'Card.Header',
+//     Section: 'Card.Section',
+//     Footer: 'Card.Footer',
+//     Body: 'Card.Body',
+//   },
+//   Col: 'Col',
+//   Container: 'Container',
+//   Dropdown: {
+//     Item: 'Dropdown.Item',
+//     Menu: 'Dropdown.Menu',
+//     Toggle: 'Dropdown.Toggle',
+//   },
+//   ErrorContext: {
+//     Provider: 'ErrorContext.Provider',
+//   },
+//   Hyperlink: 'Hyperlink',
+//   Icon: 'Icon',
+//   IconButton: 'IconButton',
+//   IconButtonWithTooltip: 'IconButtonWithTooltip',
+//   Image: 'Image',
+//   MailtoLink: 'MailtoLink',
+//   ModalDialog: {
+//     Footer: 'ModalDialog.Footer',
+//     Header: 'ModalDialog.Header',
+//     Title: 'ModalDialog.Title',
+//     Body: 'ModalDialog.Body',
+//     CloseButton: 'ModalDialog.CloseButton',
+//   },
+//   Form: {
+//     Checkbox: 'Form.Checkbox',
+//     Control: {
+//       Feedback: 'Form.Control.Feedback',
+//     },
+//     Group: 'Form.Group',
+//     Label: 'Form.Label',
+//     Text: 'Form.Text',
+//     Row: 'Form.Row',
+//     Radio: 'Radio',
+//     RadioSet: 'RadioSet',
+//   },
+//   OverlayTrigger: 'OverlayTrigger',
+//   Tooltip: 'Tooltip',
+//   FullscreenModal: 'FullscreenModal',
+//   Row: 'Row',
+//   Scrollable: 'Scrollable',
+//   SelectableBox: {
+//     Set: 'SelectableBox.Set',
+//   },
 
-  Spinner: 'Spinner',
-  Stack: 'Stack',
-  Toast: 'Toast',
-  Truncate: 'Truncate',
-}));
+//   Spinner: 'Spinner',
+//   Stack: 'Stack',
+//   Toast: 'Toast',
+//   Truncate: 'Truncate',
+// }));
 
 jest.mock('@edx/paragon/icons', () => ({
   Close: jest.fn().mockName('icons.Close'),


### PR DESCRIPTION
This a rebuild of the current studio footer using React. The footer should have the same content as the existing footer.

For testing use course-authoring [PR 532](https://github.com/openedx/frontend-app-course-authoring/pull/532). The footer can be seen on at the bottom of Pages & Resources.