### PR TITLE
fix: resolve  #360 make style consistent across outlines

### DIFF
--- a/src/editors/data/constants/tinyMCEStyles.js
+++ b/src/editors/data/constants/tinyMCEStyles.js
@@ -120,6 +120,7 @@ const getStyles = () => (
       font-size: 2em;
       line-height: 1.4em;
       margin: 0 0 1.41575em 0;
+      text-transform: initial;
   }
   .mce-content-body h2,
   .mce-content-body .hd-2 {
@@ -129,7 +130,7 @@ const getStyles = () => (
       font-weight: 300;
       font-size: 1.2em;
       line-height: 1.2em;
-      text-transform: uppercase;
+      text-transform: initial;
   }
   .mce-content-body h3,
   .mce-content-body .hd-3 {


### PR DESCRIPTION
 This changes make the style consistent across the first three
 headline line levels

 1. The first level add CSS prop initial
 2. The second level change prop from capital to inital as describted in #360 
 3. No change