### PR TITLE
fix: partner portal typo

### DIFF
--- a/src/footer/Footer.jsx
+++ b/src/footer/Footer.jsx
@@ -53,7 +53,7 @@ const Footer = ({
             {platformName === 'edX' ? (
               <Button
                 as="a"
-                href="https://partner.edx.org/"
+                href="https://partners.edx.org/"
                 size="sm"
                 data-testid="edXPortalButton"
               >


### PR DESCRIPTION
Typo in the edX partner portal button link lead to a broken url.