### PR TITLE
fix: blockId checks for v1 or v2 libraries

### DIFF
--- a/src/editors/data/services/cms/urls.js
+++ b/src/editors/data/services/cms/urls.js
@@ -23,13 +23,13 @@ export const returnUrl = ({ studioEndpointUrl, unitUrl, learningContextId }) => 
 };
 
 export const block = ({ studioEndpointUrl, blockId }) => (
-  blockId.startsWith('block-v1')
+  blockId.includes('block-v1')
     ? `${studioEndpointUrl}/xblock/${blockId}`
     : `${studioEndpointUrl}/api/xblock/v2/xblocks/${blockId}/fields/`
 );
 
 export const blockAncestor = ({ studioEndpointUrl, blockId }) => {
-  if (blockId.startsWith('block-v1')) {
+  if (blockId.includes('block-v1')) {
     return `${block({ studioEndpointUrl, blockId })}?fields=ancestorInfo`;
   }
   // this url only need to get info to build the return url, which isn't used by V2 blocks
@@ -37,7 +37,7 @@ export const blockAncestor = ({ studioEndpointUrl, blockId }) => {
 };
 
 export const blockStudioView = ({ studioEndpointUrl, blockId }) => (
-  blockId.startsWith('block-v1')
+  blockId.includes('block-v1')
     ? `${block({ studioEndpointUrl, blockId })}/studio_view`
     : `${studioEndpointUrl}/api/xblock/v2/xblocks/${blockId}/view/studio_view/`
 );

--- a/src/editors/data/services/cms/urls.test.js
+++ b/src/editors/data/services/cms/urls.test.js
@@ -24,7 +24,7 @@ describe('cms url methods', () => {
   const blockId = 'block-v1-blOckIDTeST123';
   const v2BlockId = 'blOckIDTeST123';
   const learningContextId = 'lEarnIngCOntextId123';
-  const libraryLeearningContextId = 'library-v1:libaryId123';
+  const libraryLearningContextId = 'library-v1:libaryId123';
   const courseId = 'course-v1:courseId123';
   const libraryV1Id = 'lib-block-v1:libaryId123';
   const libraryV2Id = 'lib:libaryId123';
@@ -44,7 +44,7 @@ describe('cms url methods', () => {
       },
     };
     it('returns the library page when given the v1 library', () => {
-      expect(returnUrl({ studioEndpointUrl, unitUrl, learningContextId: libraryLeearningContextId }))
+      expect(returnUrl({ studioEndpointUrl, unitUrl, learningContextId: libraryLearningContextId }))
         .toEqual(`${studioEndpointUrl}/library/${libraryLeearningContextId}`);
     });
     it('throws error when given the v2 library', () => {

--- a/src/editors/data/services/cms/urls.test.js
+++ b/src/editors/data/services/cms/urls.test.js
@@ -24,8 +24,9 @@ describe('cms url methods', () => {
   const blockId = 'block-v1-blOckIDTeST123';
   const v2BlockId = 'blOckIDTeST123';
   const learningContextId = 'lEarnIngCOntextId123';
+  const libraryLeearningContextId = 'library-v1:libaryId123';
   const courseId = 'course-v1:courseId123';
-  const libraryV1Id = 'library-v1:libaryId123';
+  const libraryV1Id = 'lib-block-v1:libaryId123';
   const libraryV2Id = 'lib:libaryId123';
   const language = 'la';
   const handout = '/aSSet@hANdoUt';
@@ -43,8 +44,8 @@ describe('cms url methods', () => {
       },
     };
     it('returns the library page when given the v1 library', () => {
-      expect(returnUrl({ studioEndpointUrl, unitUrl, learningContextId: libraryV1Id }))
-        .toEqual(`${studioEndpointUrl}/library/${libraryV1Id}`);
+      expect(returnUrl({ studioEndpointUrl, unitUrl, learningContextId: libraryLeearningContextId }))
+        .toEqual(`${studioEndpointUrl}/library/${libraryLeearningContextId}`);
     });
     it('throws error when given the v2 library', () => {
       expect(() => { returnUrl({ studioEndpointUrl, unitUrl, learningContextId: libraryV2Id }); })

--- a/src/editors/data/services/cms/urls.test.js
+++ b/src/editors/data/services/cms/urls.test.js
@@ -45,7 +45,7 @@ describe('cms url methods', () => {
     };
     it('returns the library page when given the v1 library', () => {
       expect(returnUrl({ studioEndpointUrl, unitUrl, learningContextId: libraryLearningContextId }))
-        .toEqual(`${studioEndpointUrl}/library/${libraryLeearningContextId}`);
+        .toEqual(`${studioEndpointUrl}/library/${libraryLearningContextId}`);
     });
     it('throws error when given the v2 library', () => {
       expect(() => { returnUrl({ studioEndpointUrl, unitUrl, learningContextId: libraryV2Id }); })


### PR DESCRIPTION
1. open up a library block
2. should render as expected
3. test cancel and save capabilities