### PR TITLE
fix: selectedVideo undefined error

### DIFF
--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -10,18 +10,21 @@ export const loadVideoData = (selectedVideoId, selectedVideoUrl) => (dispatch, g
   const state = getState();
   const blockValueData = state.app.blockValue.data;
   let rawVideoData = blockValueData.metadata ? blockValueData.metadata : {};
-  const courseData = state.app.courseDetails.data ? state.app.courseDetails.data : {};
   if (selectedVideoId != null) {
     const rawVideos = Object.values(selectors.app.videos(state));
     const selectedVideo = rawVideos.find(video => video.edx_video_id === selectedVideoId);
-    rawVideoData = {
-      edx_video_id: selectedVideo.edx_video_id,
-      thumbnail: selectedVideo.course_video_image_url,
-      duration: selectedVideo.duration,
-      transcriptsFromSelected: selectedVideo.transcripts,
-      selectedVideoTranscriptUrls: selectedVideo.transcript_urls,
-    };
+    if (selectedVideo) {
+      rawVideoData = {
+        edx_video_id: selectedVideo.edx_video_id,
+        thumbnail: selectedVideo.course_video_image_url,
+        duration: selectedVideo.duration,
+        transcriptsFromSelected: selectedVideo.transcripts,
+        selectedVideoTranscriptUrls: selectedVideo.transcript_urls,
+      };
+    }
   }
+
+  const courseData = state.app.courseDetails.data ? state.app.courseDetails.data : {};
   const studioView = state.app.studioView?.data?.html;
   const {
     videoId,


### PR DESCRIPTION
Fix for [new relic error](https://one.newrelic.com/alerts-ai/issue?account=88178&duration=259200000&state=a8934090-9fec-dbdf-14e5-7b0f28b91a5a) type error

Test
1. Open a video block
2. replace the video
3. block should load as expected with video id
4. Navigate back to unit page
5. create new video bloack
6. select video
7. block should load as expected with video id