### PR TITLE
[TNL-10888] fix: preformatted content being re-formatted

### DIFF
--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.js
@@ -13,17 +13,26 @@ class ReactStateOLXParser {
         hex: false,
       },
       preserveOrder: true,
+      // Ensure whitespace inside <pre> tags is preserved
+      trimValues: false,
+      // Parse <br> correctly
+      unpairedTags: ['br'],
     };
     const richTextBuilderOptions = {
       ignoreAttributes: false,
       attributeNamePrefix: '@_',
       suppressBooleanAttributes: false,
-      format: true,
+      // Avoid formatting as it adds unwanted newlines and whitespace,
+      // breaking <pre> tags
+      format: false,
       numberParseOptions: {
         leadingZeros: false,
         hex: false,
       },
       preserveOrder: true,
+      unpairedTags: ['br'],
+      // Output <br/> rather than <br>
+      suppressUnpairedNode: false,
     };
 
     this.richTextParser = new XMLParser(richTextParserOptions);

--- a/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateOLXParser.test.js
@@ -104,5 +104,15 @@ describe('Check React State OLXParser problem', () => {
       const buildOLX = stateParser.buildOLX();
       expect(buildOLX.replace(/\s/g, '')).toEqual(numberParseTestOLX.buildOLX.replace(/\s/g, ''));
     });
+    test('correctly preserves whitespace inside pre tags', () => {
+      const stateParser = new ReactStateOLXParser({
+        problem: { problemType: 'optionresponse', answers: [] },
+        editorObject: { question: '<pre>  1  a<br />  2  b<br /></pre>', hints: [] },
+      });
+      const buildOLX = stateParser.buildOLX();
+      expect(buildOLX).toEqual(
+        '<problem><optionresponse>\n<pre>  1  a<br/>  2  b<br/></pre><optioninput></optioninput></optionresponse>\n</problem>',
+      );
+    });
   });
 });


### PR DESCRIPTION
The XML formatting causes additional newlines and spaces to be added to preformatted content wrapped in `<pre>` tags. This disables the XML formatting to prevent that from happening.

## Testing instructions

1. Create a new problem with the following text in a *Preformatted* block:

```
In the following RISC-V assembly snippet, how many times would the beq instruction execute?
     addi  s0, zero, 10
L1:  beq   s0, zero, L2
     addi  s0, s0, -2
     j     L1
L2:
```

2. Ensure that the problem is displayed correctly with no additional spaces or newlines:

![Screenshot 2023-08-22 at 2 59 03 PM](https://user-images.githubusercontent.com/1823771/262329609-af6c7a21-ab85-4a06-8ee1-6061f4b98cee.png)