### PR TITLE
fix: switch to advanced editor for partial credit support

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -181,6 +181,9 @@ export class OLXParser {
     if (_.keys(widget).some((tag) => !permissableTags.includes(tag))) {
       throw new Error('Misc Tags, reverting to Advanced Editor');
     }
+    if (_.get(this.problem, `${problemType}.@_partial_credit`)) {
+      throw new Error('Partial credit not supported by GUI, reverting to Advanced Editor');
+    }
     const choice = _.get(widget, option);
     const isComplexAnswer = RichTextProblems.includes(problemType);
     if (_.isEmpty(choice)) {
@@ -401,6 +404,9 @@ export class OLXParser {
       'correcthint',
     );
     const { numericalresponse } = this.problem;
+    if (_.get(numericalresponse, '@_partial_credit')) {
+      throw new Error('Partial credit not supported by GUI, reverting to Advanced Editor');
+    }
     let answerFeedback = '';
     const answers = [];
     let responseParam = {};

--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -11,15 +11,18 @@ import {
   advancedProblemOlX,
   multipleTextInputProblemOlX,
   multipleNumericProblemOlX,
+  multiSelectPartialCredit,
   NumericAndTextInputProblemOlX,
   blankProblemOLX,
   blankQuestionOLX,
   styledQuestionOLX,
   shuffleProblemOLX,
   scriptProblemOlX,
+  singleSelectPartialCredit,
   labelDescriptionQuestionOLX,
   htmlEntityTestOLX,
   numberParseTestOLX,
+  numericalProblemPartialCredit,
   solutionExplanationTest,
   solutionExplanationWithoutDivTest,
   tablesInRichTextTest,
@@ -42,6 +45,9 @@ const multipleNumericOlxParser = new OLXParser(multipleNumericProblemOlX.rawOLX)
 const numericAndTextInputOlxParser = new OLXParser(NumericAndTextInputProblemOlX.rawOLX);
 const labelDescriptionQuestionOlxParser = new OLXParser(labelDescriptionQuestionOLX.rawOLX);
 const shuffleOlxParser = new OLXParser(shuffleProblemOLX.rawOLX);
+const multiSelectPartialCreditOlxParser = new OLXParser(multiSelectPartialCredit.rawOLX);
+const singleSelectPartialCreditParser = new OLXParser(singleSelectPartialCredit.rawOLX);
+const numericalProblemPartialCreditParser = new OLXParser(numericalProblemPartialCredit.rawOLX);
 
 describe('OLXParser', () => {
   describe('throws error and redirects to advanced editor', () => {
@@ -69,6 +75,36 @@ describe('OLXParser', () => {
       it('should throw error and contain message regarding opening advanced editor', () => {
         const olxparser = new OLXParser(scriptProblemOlX.rawOLX);
         expect(() => olxparser.parseQuestions('numericalresponse')).toThrow(new Error('Script Tag, reverting to Advanced Editor'));
+      });
+    });
+    describe('when multi select problem finds partial_credit attribute', () => {
+      it('should throw error and contain message regarding opening advanced editor', () => {
+        try {
+          multiSelectPartialCreditOlxParser.getParsedOLXData();
+        } catch (e) {
+          expect(e).toBeInstanceOf(Error);
+          expect(e.message).toBe('Partial credit not supported by GUI, reverting to Advanced Editor');
+        }
+      });
+    });
+    describe('when multi select problem finds partial_credit attribute', () => {
+      it('should throw error and contain message regarding opening advanced editor', () => {
+        try {
+          numericalProblemPartialCreditParser.getParsedOLXData();
+        } catch (e) {
+          expect(e).toBeInstanceOf(Error);
+          expect(e.message).toBe('Partial credit not supported by GUI, reverting to Advanced Editor');
+        }
+      });
+    });
+    describe('when multi select problem finds partial_credit attribute', () => {
+      it('should throw error and contain message regarding opening advanced editor', () => {
+        try {
+          singleSelectPartialCreditParser.getParsedOLXData();
+        } catch (e) {
+          expect(e).toBeInstanceOf(Error);
+          expect(e.message).toBe('Partial credit not supported by GUI, reverting to Advanced Editor');
+        }
       });
     });
   });

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -1112,3 +1112,43 @@ export const parseOutExplanationTests = {
         <p>solution meat</p>
       `
 };
+
+export const multiSelectPartialCredit = {
+  rawOLX: `<problem>
+    <choiceresponse partial_credit="EDC">
+      <label>Which of the following is a fruit?</label>
+      <description>Select all that apply.</description>
+      <checkboxgroup>
+        <choice correct="true">apple</choice>
+        <choice correct="true">pumpkin</choice>
+        <choice correct="false">potato</choice>
+        <choice correct="true">tomato</choice>
+      </checkboxgroup>
+    </choiceresponse>
+  </problem>`
+}
+
+export const singleSelectPartialCredit = {
+  rawOLX: `<problem>
+    <multiplechoiceresponse partial_credit="points">
+      <label>What Apple device competed with the portable CD player?</label>
+      <choicegroup type="MultipleChoice">
+        <choice correct="false">The iPad</choice>
+        <choice correct="false">Napster</choice>
+        <choice correct="true">The iPod</choice>
+        <choice correct="partial" point_value="0.25">The vegetable peeler</choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+  </problem>`
+}
+
+export const numericalProblemPartialCredit = {
+  rawOLX: `<problem>
+    <numericalresponse answer="9.3*10^7" partial_credit="close">
+      <label>How many miles away from Earth is the sun?</label>
+      <description>Use scientific notation to answer.</description>
+      <formulaequationinput/>
+      <responseparam type="tolerance" default="1%" partial_range="3"/>
+    </numericalresponse>
+  </problem>`
+}


### PR DESCRIPTION
This commit reverts to advanced editor when partial_credit attribute is added to multichoice, single select and numerical problems. Without this change, the partial_credit attribute is removed from the problem on the next edit.

**Test instructions:**

* Setup master devstack and follow steps provided in the README to use the new problem editor.
* Don't forget to enable `new_core_editors.use_new_text_editor` waffle flag.
* Create a blank advanced problem and paste below olx to create a multiselect with partial credit:
```xml
<problem>
  <choiceresponse partial_credit="EDC">
    <label>Which of the following is a fruit?</label>
    <description>Select all that apply.</description>
    <checkboxgroup>
      <choice correct="true">apple</choice>
      <choice correct="true">pumpkin</choice>
      <choice correct="false">potato</choice>
      <choice correct="true">tomato</choice>
    </checkboxgroup>
  </choiceresponse>
</problem>
```
* Save and test the problem in CMS, it should work as expected.
* Without this commit/change, if you click on edit, it will load default GUI editor. This removes `partial_credit` attribute from the component.
* Checkout this branch and run `make build`.
* Refresh CMS and edit the component. Change to advanced editor and add `partial_credit="EDC"` back to the problem and save.
* Now if you edit this component, it will automatically switch to advanced editor preserving the attribute.
* You can also test other problems like `single select` and `numerical problems` as mentioned in the [documentation here](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/create_problem.html#awarding-partial-credit-for-a-problem).