### PR TITLE
fix: sort items in typeahead dropdown

### DIFF
--- a/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
@@ -45,7 +45,7 @@ class TypeaheadDropdown extends React.Component {
       options = options.filter((option) => (option.toLowerCase().includes(strToFind.toLowerCase())));
     }
 
-    return options.map((opt) => {
+    return options.sort().map((opt) => {
       let value = opt;
       if (value.length > 30) {
         value = value.substring(0, 30).concat('...');
@@ -220,6 +220,7 @@ class TypeaheadDropdown extends React.Component {
             data-testid="dropdown-container"
             className="dropdown-container mt-2 rounded bg-light-100 box-shadow-centered-1 mr-2"
             style={{ maxHeight: '300px', overflowY: 'scroll' }}
+            role="listbox"
           >
             { this.state.dropDownItems.length > 0 ? this.state.dropDownItems : dropDownEmptyList }
           </div>

--- a/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
@@ -220,7 +220,6 @@ class TypeaheadDropdown extends React.Component {
             data-testid="dropdown-container"
             className="dropdown-container mt-2 rounded bg-light-100 box-shadow-centered-1 mr-2"
             style={{ maxHeight: '300px', overflowY: 'scroll' }}
-            role="listbox"
           >
             { this.state.dropDownItems.length > 0 ? this.state.dropDownItems : dropDownEmptyList }
           </div>

--- a/src/editors/sharedComponents/TypeaheadDropdown/index.test.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.test.jsx
@@ -3,6 +3,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -50,11 +51,11 @@ describe('common/OrganizationDropdown.jsx', () => {
     fireEvent.focusOut(formInput);
     expect(mockHandleBlur).toHaveBeenCalled();
   });
-  it('renders component with options', () => {
-    const newProps = { ...defaultProps, options: ['opt1', 'opt2'] };
+  it('renders component with options', async () => {
+    const newProps = { ...defaultProps, options: ['opt2', 'opt1'] };
     renderComponent(newProps);
     const formInput = screen.getByTestId('formControl');
-    fireEvent.click(formInput);
+    await waitFor(() => fireEvent.click(formInput));
     const optionsList = within(screen.getByTestId('dropdown-container')).getAllByRole('button');
     expect(optionsList.length).toEqual(newProps.options.length);
   });


### PR DESCRIPTION
JIRA Ticket: [TNL-11018](https://2u-internal.atlassian.net/browse/TNL-11018)

This PR sorts the items for the typeahead dropdown before the items are rendered into buttons.