### PR TITLE
feat: update isLibrary check to include v2 libs

### DIFF
--- a/src/editors/data/redux/app/selectors.js
+++ b/src/editors/data/redux/app/selectors.js
@@ -86,12 +86,15 @@ export const isRaw = createSelector(
 );
 
 export const isLibrary = createSelector(
-  [module.simpleSelectors.learningContextId],
-  (learningContextId) => {
-    if (!learningContextId) {
-      return null;
-    }
+  [
+    module.simpleSelectors.learningContextId,
+    module.simpleSelectors.blockId,
+  ],
+  (learningContextId, blockId) => {
     if (learningContextId && learningContextId.startsWith('library-v1')) {
+      return true;
+    }
+    if (blockId && blockId.startsWith('lb:')) {
       return true;
     }
     return false;

--- a/src/editors/data/redux/app/selectors.test.js
+++ b/src/editors/data/redux/app/selectors.test.js
@@ -153,16 +153,40 @@ describe('app selectors unit tests', () => {
     it('is memoized based on studioView', () => {
       expect(selectors.isLibrary.preSelectors).toEqual([
         simpleSelectors.learningContextId,
+        simpleSelectors.blockId,
       ]);
     });
-    it('returns null if blockId is null', () => {
-      expect(selectors.isLibrary.cb(null)).toEqual(null);
+    describe('blockId is null', () => {
+      it('should return false when learningContextId null', () => {
+        expect(selectors.isLibrary.cb(null, null)).toEqual(false);
+      });
+      it('should return false when learningContextId defined', () => {
+        expect(selectors.isLibrary.cb(learningContextIdCourse, null)).toEqual(false);
+      });
     });
-    it('returns true if blockId starts with lib', () => {
-      expect(selectors.isLibrary.cb(learningContextIdLibrary)).toEqual(true);
+    describe('blockId is a course block', () => {
+      it('should return false when learningContextId null', () => {
+        expect(selectors.isLibrary.cb(null, 'block-v1:')).toEqual(false);
+      });
+      it('should return false when learningContextId defined', () => {
+        expect(selectors.isLibrary.cb(learningContextIdCourse, 'block-v1:')).toEqual(false);
+      });
     });
-    it('returns false if the blockId does not start with lib', () => {
-      expect(selectors.isLibrary.cb(learningContextIdCourse)).toEqual(false);
+    describe('blockId is a v2 library block', () => {
+      it('should return true when learningContextId null', () => {
+        expect(selectors.isLibrary.cb(null, 'lb:')).toEqual(true);
+      });
+      it('should return false when learningContextId is a v1 library', () => {
+        expect(selectors.isLibrary.cb(learningContextIdLibrary, 'lb:')).toEqual(true);
+      });
+    });
+    describe('blockId is a v1 library block', () => {
+      it('should return false when learningContextId null', () => {
+        expect(selectors.isLibrary.cb(null, 'library-v1')).toEqual(false);
+      });
+      it('should return true when learningContextId a v1 library', () => {
+        expect(selectors.isLibrary.cb(learningContextIdLibrary, 'library-v1')).toEqual(true);
+      });
     });
   });
 });


### PR DESCRIPTION
JIRA Ticket: [TNL-11019](https://2u-internal.atlassian.net/browse/TNL-11019)

This PR adds a check to the `isLibrary` selector to catch v2 libraries. The `isLibrary` selector controls if images are in tinymce toolbars.

Testing

1. Open a v2 library and check that the image button is not in the toolbar.
2. Open a v1 library and check that the image button is not in the toolbar.
3. Open a course block and check that the image button is in the toolbar.