### PR TITLE
feat: remove replace video button for libs

### DIFF
--- a/src/editors/containers/VideoEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/__snapshots__/index.test.jsx.snap
@@ -41,7 +41,9 @@ exports[`VideoEditor snapshots renders as expected with default behavior 2`] = `
     <div
       className="video-editor"
     >
-      <VideoEditorModal />
+      <VideoEditorModal
+        isLibrary={false}
+      />
     </div>
   </EditorContainer>
 </Component>

--- a/src/editors/containers/VideoEditor/components/VideoEditorModal.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoEditorModal.jsx
@@ -30,6 +30,7 @@ export const hooks = {
 const VideoEditorModal = ({
   close,
   isOpen,
+  isLibrary,
 }) => {
   const dispatch = useDispatch();
   const searchParams = new URLSearchParams(document.location.search);
@@ -42,6 +43,7 @@ const VideoEditorModal = ({
       close,
       isOpen,
       onReturn,
+      isLibrary,
     }}
     />
   );
@@ -53,5 +55,6 @@ VideoEditorModal.defaultProps = {
 VideoEditorModal.propTypes = {
   close: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
+  isLibrary: PropTypes.bool.isRequired,
 };
 export default VideoEditorModal;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
@@ -21,21 +21,24 @@ import messages from '../../messages';
 
 export const VideoSettingsModal = ({
   onReturn,
+  isLibrary,
 }) => (
   <>
-    <Button
-      variant="link"
-      className="text-primary-500"
-      size="sm"
-      onClick={onReturn}
-      style={{
-        textDecoration: 'none',
-        marginLeft: '3px',
-      }}
-    >
-      <Icon src={ArrowBackIos} style={{ height: '13px' }} />
-      <FormattedMessage {...messages.replaceVideoButtonLabel} />
-    </Button>
+    {!isLibrary && (
+      <Button
+        variant="link"
+        className="text-primary-500"
+        size="sm"
+        onClick={onReturn}
+        style={{
+          textDecoration: 'none',
+          marginLeft: '3px',
+        }}
+      >
+        <Icon src={ArrowBackIos} style={{ height: '13px' }} />
+        <FormattedMessage {...messages.replaceVideoButtonLabel} />
+      </Button>
+    )}
     <ErrorSummary />
     <VideoPreviewWidget />
     <VideoSourceWidget />
@@ -49,8 +52,8 @@ export const VideoSettingsModal = ({
 );
 
 VideoSettingsModal.propTypes = {
-  showReturn: PropTypes.bool.isRequired,
   onReturn: PropTypes.func.isRequired,
+  isLibrary: PropTypes.func.isRequired,
 };
 
 export default VideoSettingsModal;

--- a/src/editors/containers/VideoEditor/index.jsx
+++ b/src/editors/containers/VideoEditor/index.jsx
@@ -22,6 +22,7 @@ export const VideoEditor = ({
   intl,
   // redux
   studioViewFinished,
+  isLibrary,
 }) => {
   const {
     error,
@@ -37,7 +38,7 @@ export const VideoEditor = ({
       >
         {studioViewFinished ? (
           <div className="video-editor">
-            <VideoEditorModal />
+            <VideoEditorModal {...{ isLibrary }} />
           </div>
         ) : (
           <div style={{
@@ -70,10 +71,12 @@ VideoEditor.propTypes = {
   intl: intlShape.isRequired,
   // redux
   studioViewFinished: PropTypes.bool.isRequired,
+  isLibrary: PropTypes.bool.isRequired,
 };
 
 export const mapStateToProps = (state) => ({
   studioViewFinished: selectors.requests.isFinished(state, { requestKey: RequestKeys.fetchStudioView }),
+  isLibrary: selectors.app.isLibrary(state),
 });
 
 export const mapDispatchToProps = {};

--- a/src/editors/containers/VideoEditor/index.test.jsx
+++ b/src/editors/containers/VideoEditor/index.test.jsx
@@ -25,7 +25,7 @@ jest.mock('../../data/redux', () => ({
     },
     app: {
       isLibrary: jest.fn(state => ({ isLibrary: state })),
-    }
+    },
   },
 }));
 

--- a/src/editors/containers/VideoEditor/index.test.jsx
+++ b/src/editors/containers/VideoEditor/index.test.jsx
@@ -23,6 +23,9 @@ jest.mock('../../data/redux', () => ({
     requests: {
       isFinished: jest.fn((state, params) => ({ isFailed: { state, params } })),
     },
+    app: {
+      isLibrary: jest.fn(state => ({ isLibrary: state })),
+    }
   },
 }));
 
@@ -31,6 +34,7 @@ describe('VideoEditor', () => {
     onClose: jest.fn().mockName('props.onClose'),
     intl: { formatMessage },
     studioViewFinished: false,
+    isLibrary: false,
   };
   describe('snapshots', () => {
     test('renders as expected with default behavior', () => {

--- a/src/editors/containers/VideoEditor/index.test.jsx
+++ b/src/editors/containers/VideoEditor/index.test.jsx
@@ -47,6 +47,11 @@ describe('VideoEditor', () => {
         mapStateToProps(testState).studioViewFinished,
       ).toEqual(selectors.requests.isFinished(testState, { requestKey: RequestKeys.fetchStudioView }));
     });
+    test('isLibrary from app.isLibrary', () => {
+      expect(
+        mapStateToProps(testState).isLibrary,
+      ).toEqual(selectors.app.isLibrary(testState));
+    });
   });
   describe('mapDispatchToProps', () => {
     test('is empty', () => {


### PR DESCRIPTION
JIRA Ticket: [TNL-11022](https://2u-internal.atlassian.net/browse/TNL-11022)

This PR removes the "Replace video" when the video block is used in a v1 and v2 library.

Note: This PR depends on PR #389 

Testing

1. Open a v2 library and check that the replace button is not iat the top.
2. Open a v1 library and check that the replace button is not at the top.
3. Open a course block and check that the replace button is at the top.