### PR TITLE
fix: v2 libraries default open to advanced editor

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
@@ -14,6 +14,7 @@ export const ResetCard = ({
   // inject
   intl,
 }) => {
+  const isLibrary = useSelector(selectors.app.isLibrary);
   const { setResetTrue, setResetFalse } = resetCardHooks(updateSettings);
   const advancedSettingsLink = `${useSelector(selectors.app.studioEndpointUrl)}/settings/advanced/${useSelector(selectors.app.learningContextId)}#show_reset_button`;
   return (
@@ -28,11 +29,13 @@ export const ResetCard = ({
           <FormattedMessage {...messages.resetSettingText} />
         </span>
       </div>
-      <div className="spacedMessage">
-        <Hyperlink destination={advancedSettingsLink} target="_blank">
-          <FormattedMessage {...messages.advancedSettingsLinkText} />
-        </Hyperlink>
-      </div>
+      {!isLibrary && (
+        <div className="spacedMessage">
+          <Hyperlink destination={advancedSettingsLink} target="_blank">
+            <FormattedMessage {...messages.advancedSettingsLinkText} />
+          </Hyperlink>
+        </div>
+      )}
       <ButtonGroup size="sm" className="resetSettingsButtons mb-2">
         <Button variant={showResetButton ? 'outline-primary' : 'primary'} size="sm" onClick={setResetFalse}>
           <FormattedMessage {...messages.resetSettingsFalse} />

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -17,6 +17,7 @@ export const ScoringCard = ({
   // redux
   studioEndpointUrl,
   learningContextId,
+  isLibrary,
 }) => {
   const {
     handleUnlimitedChange,
@@ -76,9 +77,11 @@ export const ScoringCard = ({
           </div>
         </Form.Checkbox>
       </Form.Group>
-      <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}#max_attempts`} target="_blank">
-        <FormattedMessage {...messages.advancedSettingsLinkText} />
-      </Hyperlink>
+      {!isLibrary && (
+        <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}#max_attempts`} target="_blank">
+          <FormattedMessage {...messages.advancedSettingsLinkText} />
+        </Hyperlink>
+      )}
     </SettingsOption>
   );
 };
@@ -88,15 +91,22 @@ ScoringCard.propTypes = {
   // eslint-disable-next-line
   scoring: PropTypes.any.isRequired,
   updateSettings: PropTypes.func.isRequired,
-  defaultValue: PropTypes.number.isRequired,
+  defaultValue: PropTypes.number,
   // redux
   studioEndpointUrl: PropTypes.string.isRequired,
-  learningContextId: PropTypes.string.isRequired,
+  learningContextId: PropTypes.string,
+  isLibrary: PropTypes.bool.isRequired,
+};
+
+ScoringCard.defaultProps = {
+  learningContextId: null,
+  defaultValue: null,
 };
 
 export const mapStateToProps = (state) => ({
   studioEndpointUrl: selectors.app.studioEndpointUrl(state),
   learningContextId: selectors.app.learningContextId(state),
+  isLibrary: selectors.app.isLibrary(state),
 });
 
 export const mapDispatchToProps = {};

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
@@ -16,13 +16,13 @@ describe('ScoringCard', () => {
       number: 5,
     },
     updateSettings: jest.fn().mockName('args.updateSettings'),
-    defaultValue: 1,
     intl: { formatMessage },
   };
 
   const props = {
     scoring,
     intl: { formatMessage },
+    defaultValue: 1,
   };
 
   const scoringCardHooksProps = {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
@@ -18,6 +18,7 @@ export const ShowAnswerCard = ({
   // redux
   studioEndpointUrl,
   learningContextId,
+  isLibrary,
 }) => {
   const {
     handleShowAnswerChange,
@@ -32,11 +33,13 @@ export const ShowAnswerCard = ({
           <FormattedMessage {...messages.showAnswerSettingText} />
         </span>
       </div>
-      <div className="pb-4">
-        <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}#showanswer`} target="_blank">
-          <FormattedMessage {...messages.advancedSettingsLinkText} />
-        </Hyperlink>
-      </div>
+      {!isLibrary && (
+        <div className="pb-4">
+          <Hyperlink destination={`${studioEndpointUrl}/settings/advanced/${learningContextId}#showanswer`} target="_blank">
+            <FormattedMessage {...messages.advancedSettingsLinkText} />
+          </Hyperlink>
+        </div>
+      )}
       <Form.Group className="pb-0 mb-0">
         <Form.Control
           as="select"
@@ -90,16 +93,20 @@ ShowAnswerCard.propTypes = {
   solutionExplanation: PropTypes.string,
   updateSettings: PropTypes.func.isRequired,
   studioEndpointUrl: PropTypes.string.isRequired,
-  learningContextId: PropTypes.string.isRequired,
-  defaultValue: PropTypes.string.isRequired,
+  learningContextId: PropTypes.string,
+  isLibrary: PropTypes.bool.isRequired,
+  defaultValue: PropTypes.string,
 };
 ShowAnswerCard.defaultProps = {
   solutionExplanation: '',
+  learningContextId: null,
+  defaultValue: 'finished',
 };
 
 export const mapStateToProps = (state) => ({
   studioEndpointUrl: selectors.app.studioEndpointUrl(state),
   learningContextId: selectors.app.learningContextId(state),
+  isLibrary: selectors.app.isLibrary(state),
 });
 
 export const mapDispatchToProps = {};

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.test.jsx
@@ -14,6 +14,7 @@ jest.mock('../../../../../../data/redux', () => ({
     app: {
       studioEndpointUrl: jest.fn(state => ({ studioEndpointUrl: state })),
       learningContextId: jest.fn(state => ({ learningContextId: state })),
+      isLibrary: jest.fn(state => ({ isLibrary: state })),
     },
   },
   thunkActions: {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
@@ -62,7 +62,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
     </Form.Checkbox>
   </Form.Group>
   <Hyperlink
-    destination="undefined/settings/advanced/undefined#max_attempts"
+    destination="undefined/settings/advanced/null#max_attempts"
     target="_blank"
   >
     <FormattedMessage
@@ -136,7 +136,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
     </Form.Checkbox>
   </Form.Group>
   <Hyperlink
-    destination="undefined/settings/advanced/undefined#max_attempts"
+    destination="undefined/settings/advanced/null#max_attempts"
     target="_blank"
   >
     <FormattedMessage
@@ -210,7 +210,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
     </Form.Checkbox>
   </Form.Group>
   <Hyperlink
-    destination="undefined/settings/advanced/undefined#max_attempts"
+    destination="undefined/settings/advanced/null#max_attempts"
     target="_blank"
   >
     <FormattedMessage

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -3,7 +3,7 @@
 
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import _ from 'lodash-es';
-import { ProblemTypeKeys, RichTextProblems } from '../../../data/constants/problem';
+import { ProblemTypeKeys, RichTextProblems, settingsOlxAttributes } from '../../../data/constants/problem';
 
 export const indexToLetterMap = [...Array(26)].map((val, i) => String.fromCharCode(i + 65));
 
@@ -619,7 +619,7 @@ export class OLXParser {
       return {};
     }
 
-    if (Object.keys(this.problem).some((key) => key.indexOf('@_') !== -1)) {
+    if (Object.keys(this.problem).some((key) => key.indexOf('@_') !== -1 && !settingsOlxAttributes.includes(key))) {
       throw new Error('Misc Attributes asscoiated with problem, opening in advanced editor');
     }
 

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -217,3 +217,13 @@ export const RandomizationTypes = StrictDict({
 });
 
 export const RichTextProblems = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT];
+
+export const settingsOlxAttributes = [
+  '@_display_name',
+  '@_weight',
+  '@_max_atempts',
+  '@_showanswer',
+  '@_show_reset_button',
+  '@_submission_wait_seconds',
+  '@_attempts_before_showanswer_button',
+];


### PR DESCRIPTION
JIRA Ticket: [TNL-11023](https://2u-internal.atlassian.net/browse/TNL-11023)

Currently all problems in v2 libraries open in the advanced editor. This is because the problem settings are being added to the wrapping `<problem>` tag and threw a "Misc. Attributes" error. This data is duplicated in the problem metadata. This PR adds a check to the OLX parser to only throw "Misc. Attributes" error if the attributes are not settings.

Testing

**Repeat test in a v2 library, v1 library, and course**

1. Create a new common problem, fill out fields, and save.
2. Edit the block and it should open in the simple editor.
4. Choose to open in the advanced editor.
5. Add an attribute to the `<problem>` tag (e.g guess="no") and save.
6. Edit the block and it should open in the advanced editor.
7. Create a new advanced problem and save.
8. Edit the block.
9. Should open in the advanced editor.
