### PR TITLE
fix: block url conditional

### DIFF
--- a/src/editors/data/services/cms/urls.js
+++ b/src/editors/data/services/cms/urls.js
@@ -29,9 +29,9 @@ export const returnUrl = ({
 };
 
 export const block = ({ studioEndpointUrl, blockId }) => (
-  blockId.includes('block-v1')
-    ? `${studioEndpointUrl}/xblock/${blockId}`
-    : `${studioEndpointUrl}/api/xblock/v2/xblocks/${blockId}/fields/`
+  blockId.startsWith('lb:')
+    ? `${studioEndpointUrl}/api/xblock/v2/xblocks/${blockId}/fields/`
+    : `${studioEndpointUrl}/xblock/${blockId}`
 );
 
 export const blockAncestor = ({ studioEndpointUrl, blockId }) => {


### PR DESCRIPTION
JIRA Ticket: [TNL-10971](https://2u-internal.atlassian.net/browse/TNL-10971)

This PR ensures that if the block id is for a v2 library it will us ethe xblock url for v2 libraries. All other block ids will use the generic xblock url.

Test

1. Open an existing v2 library block.
2. Should render without errors.
3. Open an existing course block.
4. Should render without errors.
5. Open an existing v1 library block.
6. Should render without errors