### PR TITLE
fix: empty v2 library studio view

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
@@ -42,7 +42,9 @@ export const VideoSettingsModal = ({
     <ErrorSummary />
     <VideoPreviewWidget />
     <VideoSourceWidget />
-    <SocialShareWidget />
+    {!isLibrary && (
+      <SocialShareWidget />
+    )}
     <ThumbnailWidget />
     <TranscriptWidget />
     <DurationWidget />

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
@@ -4,6 +4,7 @@ import { Button, Icon } from '@edx/paragon';
 import { ArrowBackIos } from '@edx/paragon/icons';
 import {
   FormattedMessage,
+  injectIntl,
 } from '@edx/frontend-platform/i18n';
 
 // import VideoPreview from './components/VideoPreview';
@@ -58,4 +59,4 @@ VideoSettingsModal.propTypes = {
   isLibrary: PropTypes.func.isRequired,
 };
 
-export default VideoSettingsModal;
+export default injectIntl(VideoSettingsModal);

--- a/src/editors/data/redux/app/selectors.js
+++ b/src/editors/data/redux/app/selectors.js
@@ -75,10 +75,14 @@ export const analytics = createSelector(
 export const isRaw = createSelector(
   [module.simpleSelectors.studioView],
   (studioView) => {
-    if (!studioView || !studioView.data || !studioView.data.html) {
+    if (!studioView?.data) {
       return null;
     }
-    if (studioView.data.html.includes('data-editor="raw"')) {
+    const { html, content } = studioView.data;
+    if (html && html.includes('data-editor="raw"')) {
+      return true;
+    }
+    if (content && content.includes('data-editor="raw"')) {
       return true;
     }
     return false;

--- a/src/editors/data/redux/app/selectors.test.js
+++ b/src/editors/data/redux/app/selectors.test.js
@@ -121,9 +121,14 @@ describe('app selectors unit tests', () => {
   });
 
   describe('isRaw', () => {
-    const studioViewRaw = {
+    const studioViewCourseRaw = {
       data: {
         html: 'data-editor="raw"',
+      },
+    };
+    const studioViewV2LibraryRaw = {
+      data: {
+        content: 'data-editor="raw"',
       },
     };
     const studioViewVisual = {
@@ -139,8 +144,11 @@ describe('app selectors unit tests', () => {
     it('returns null if studioView is null', () => {
       expect(selectors.isRaw.cb(null)).toEqual(null);
     });
-    it('returns true if studioView is raw', () => {
-      expect(selectors.isRaw.cb(studioViewRaw)).toEqual(true);
+    it('returns true if course studioView is raw', () => {
+      expect(selectors.isRaw.cb(studioViewCourseRaw)).toEqual(true);
+    });
+    it('returns true if v2 library studioView is raw', () => {
+      expect(selectors.isRaw.cb(studioViewV2LibraryRaw)).toEqual(true);
     });
     it('returns false if the studioView is not Raw', () => {
       expect(selectors.isRaw.cb(studioViewVisual)).toEqual(false);
@@ -150,7 +158,7 @@ describe('app selectors unit tests', () => {
   describe('isLibrary', () => {
     const learningContextIdLibrary = 'library-v1:name';
     const learningContextIdCourse = 'course-v1:name';
-    it('is memoized based on studioView', () => {
+    it('is memoized based on isLibrary', () => {
       expect(selectors.isLibrary.preSelectors).toEqual([
         simpleSelectors.learningContextId,
         simpleSelectors.blockId,

--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-cycle */
-import _ from 'lodash-es';
+import _, { isEmpty } from 'lodash-es';
 import { actions, selectors } from '..';
 import { removeItemOnce } from '../../../utils';
 import * as requests from './requests';
@@ -32,7 +32,11 @@ export const loadVideoData = (selectedVideoId, selectedVideoUrl) => (dispatch, g
   }
 
   const courseData = state.app.courseDetails.data ? state.app.courseDetails.data : {};
-  const studioView = state.app.studioView?.data?.html;
+  let studioView = state.app.studioView?.data?.html;
+  if (state.app.blockId.startsWith('lb:')) {
+    studioView = state.app.studioView?.data?.content;
+  }
+
   const {
     videoId,
     videoUrl,
@@ -46,6 +50,7 @@ export const loadVideoData = (selectedVideoId, selectedVideoUrl) => (dispatch, g
   // Use the selected video url first
   const videoSourceUrl = selectedVideoUrl != null ? selectedVideoUrl : videoUrl;
   const [licenseType, licenseOptions] = module.parseLicense({ licenseData: studioView, level: 'block' });
+  console.log(licenseType);
   const transcripts = rawVideoData.transcriptsFromSelected ? rawVideoData.transcriptsFromSelected
     : module.parseTranscripts({ transcriptsData: studioView });
 
@@ -282,7 +287,7 @@ export const importTranscript = () => (dispatch, getState) => {
   const state = getState();
   const { transcripts, videoSource } = state.video;
   // Remove the placeholder '' from the unset language from the list of transcripts.
-  const transcriptsPlaceholderRemoved = (transcripts === []) ? transcripts : removeItemOnce(transcripts, '');
+  const transcriptsPlaceholderRemoved = isEmpty(transcripts) ? transcripts : removeItemOnce(transcripts, '');
 
   dispatch(requests.importTranscript({
     youTubeId: parseYoutubeId(videoSource),
@@ -306,8 +311,7 @@ export const uploadTranscript = ({ language, file }) => (dispatch, getState) => 
   const state = getState();
   const { transcripts, videoId } = state.video;
   // Remove the placeholder '' from the unset language from the list of transcripts.
-  const transcriptsPlaceholderRemoved = (transcripts === []) ? transcripts : removeItemOnce(transcripts, '');
-
+  const transcriptsPlaceholderRemoved = isEmpty(transcripts) ? transcripts : removeItemOnce(transcripts, '');
   dispatch(requests.uploadTranscript({
     language,
     videoId,

--- a/src/editors/data/redux/thunkActions/video.test.js
+++ b/src/editors/data/redux/thunkActions/video.test.js
@@ -269,7 +269,7 @@ describe('video thunkActions', () => {
     it('dispatches actions.video.load with different selectedVideoId', () => {
       getState = jest.fn(() => ({
         app: {
-          blockId: 'soMEBloCk',
+          blockId: 'lb:soMEBloCk',
           studioEndpointUrl: 'soMEeNDPoiNT',
           blockValue: { data: { metadata: {} } },
           courseDetails: { data: { license: null } },

--- a/src/editors/data/redux/thunkActions/video.test.js
+++ b/src/editors/data/redux/thunkActions/video.test.js
@@ -273,7 +273,7 @@ describe('video thunkActions', () => {
           studioEndpointUrl: 'soMEeNDPoiNT',
           blockValue: { data: { metadata: {} } },
           courseDetails: { data: { license: null } },
-          studioView: { data: { html: 'sOMeHTml' } },
+          studioView: { data: { content: 'sOMeHTml' } },
           videos: testVideosState,
         },
       }));


### PR DESCRIPTION
JIRA Ticket: [TNL-11024](https://2u-internal.atlassian.net/browse/TNL-11024)

Currently, video license info does not appear in v2 content libraries after saving a block with the data. This is because the `studio_view` in v2 libraries has a different attribute name for the html. v2 libraries use "content" instead of "html". This PR adds an additional check for `studio_view.data.content` whenever `studio_view.data.html` is checked.

Testing

1. Open a v2 library.
2. Create a video block and edit the license widget
3. Save block.
4. Reopen block and check that the license widget loads as expected
5. Open a unit.
6. Create a video block and edit the license widget
7. Save block.
8. Reopen block and check that the license widget loads as expected
9. Should render without errors.
10. Create a raw text block and save it.
11. Reopen block and it should load in the raw editor.
12. Open a v1 library.
13. Create a video block and edit the license widget
14. Save block.
15. Reopen block and check that the license widget loads as expected
16. Should render without errors.
17. Create a raw text block and save it.
18. Reopen block and it should load in the raw editor.
