### PR TITLE
fix: typeahead sort and styling

### DIFF
--- a/src/editors/containers/VideoUploadEditor/VideoUploader.jsx
+++ b/src/editors/containers/VideoUploadEditor/VideoUploader.jsx
@@ -26,7 +26,7 @@ const URLUploader = () => {
       </div>
       <div className="x-small align-self-center justify-content-center mx-2 text-dark font-weight-normal">OR</div>
       <div className="zindex-9 video-id-prompt p-4">
-        <InputGroup>
+        <InputGroup className="video-upload-input-group">
           <FormControl
             placeholder={intl.formatMessage(messages.pasteURL)}
             aria-label={intl.formatMessage(messages.pasteURL)}

--- a/src/editors/containers/VideoUploadEditor/__snapshots__/VideoUploader.test.jsx.snap
+++ b/src/editors/containers/VideoUploadEditor/__snapshots__/VideoUploader.test.jsx.snap
@@ -107,7 +107,7 @@ Object {
                 class="zindex-9 video-id-prompt p-4"
               >
                 <div
-                  class="input-group"
+                  class="video-upload-input-group input-group"
                 >
                   <div
                     class="pgn__form-control-decorator-group"
@@ -265,7 +265,7 @@ Object {
               class="zindex-9 video-id-prompt p-4"
             >
               <div
-                class="input-group"
+                class="video-upload-input-group input-group"
               >
                 <div
                   class="pgn__form-control-decorator-group"

--- a/src/editors/containers/VideoUploadEditor/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoUploadEditor/__snapshots__/index.test.jsx.snap
@@ -111,7 +111,7 @@ Object {
                     class="zindex-9 video-id-prompt p-4"
                   >
                     <div
-                      class="input-group"
+                      class="video-upload-input-group input-group"
                     >
                       <div
                         class="pgn__form-control-decorator-group"
@@ -275,7 +275,7 @@ Object {
                   class="zindex-9 video-id-prompt p-4"
                 >
                   <div
-                    class="input-group"
+                    class="video-upload-input-group input-group"
                   >
                     <div
                       class="pgn__form-control-decorator-group"

--- a/src/editors/containers/VideoUploadEditor/index.scss
+++ b/src/editors/containers/VideoUploadEditor/index.scss
@@ -37,13 +37,16 @@
   }
 }
 
-.form-control {
-  font-size: 0.875rem !important;
-  width: 308px !important;
-  height: 44px !important;
+.video-upload-input-group{
+  .form-control {
+    font-size: 0.875rem !important;
+    width: 308px !important;
+    height: 44px !important;
+  }
+  
+  .pgn__icon.pgn__icon__lg {
+    width: 3.625rem !important;
+    height: 3.625rem !important;
+  }
 }
 
-.pgn__icon.pgn__icon__lg {
-  width: 3.625rem !important;
-  height: 3.625rem !important;
-}

--- a/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
@@ -7,6 +7,7 @@ import {
 } from '@edx/paragon';
 import { Add, ExpandLess, ExpandMore } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
+import { sortBy } from 'lodash-es';
 // eslint-disable-next-line import/no-unresolved
 import onClickOutside from 'react-onclickoutside';
 import FormGroup from './FormGroup';
@@ -45,7 +46,9 @@ class TypeaheadDropdown extends React.Component {
       options = options.filter((option) => (option.toLowerCase().includes(strToFind.toLowerCase())));
     }
 
-    return options.sort().map((opt) => {
+    const sortedOptions = sortBy(options, (option) => option.toLowerCase());
+
+    return sortedOptions.map((opt) => {
       let value = opt;
       if (value.length > 30) {
         value = value.substring(0, 30).concat('...');


### PR DESCRIPTION
The styles added to the video upload page was forcing all the form controls to be a fixed size and their trailing elements to render outside of the form control. Now the added styling only applies to the video upload page, as was originally intended. This PR also changes the sort method for the typeahead dropdown. The previous sort method was an in-place sorter so half of the time it would throw an error and not render the list of options.

Testing

1. Navigate to the studio home page.
2. Click "New course".
3. All input boxes should span the width of the main body.
4. Click the expand option for in the organization input.
5. Should render list of options with no errors.
6. Begin typing in the input
7. Should update rendered list with no errors