### PR TITLE
feat: video gallery sorting menu redesign

### DIFF
--- a/src/editors/containers/VideoGallery/index.test.jsx
+++ b/src/editors/containers/VideoGallery/index.test.jsx
@@ -124,17 +124,17 @@ describe('VideoGallery', () => {
       expect(window.location.assign).toHaveBeenCalled();
     });
     it.each([
-      [/by date added \(newest\)/i, [2, 1, 3]],
-      [/by date added \(oldest\)/i, [3, 1, 2]],
-      [/by name \(ascending\)/i, [1, 2, 3]],
-      [/by name \(descending\)/i, [3, 2, 1]],
-      [/by duration \(longest\)/i, [3, 1, 2]],
-      [/by duration \(shortest\)/i, [2, 1, 3]],
+      [/newest/i, [2, 1, 3]],
+      [/oldest/i, [3, 1, 2]],
+      [/name A-Z/i, [1, 2, 3]],
+      [/name Z-A/i, [3, 2, 1]],
+      [/longest/i, [3, 1, 2]],
+      [/shortest/i, [2, 1, 3]],
     ])('videos can be sorted %s', async (sortBy, order) => {
       await renderComponent();
 
       fireEvent.click(screen.getByRole('button', {
-        name: /by date added \(newest\)/i,
+        name: /By newest/i,
       }));
       fireEvent.click(screen.getByRole('link', {
         name: sortBy,

--- a/src/editors/containers/VideoGallery/messages.js
+++ b/src/editors/containers/VideoGallery/messages.js
@@ -25,32 +25,32 @@ export const messages = {
   // Sort Dropdown
   sortByDateNewest: {
     id: 'authoring.selectvideomodal.sort.datenewest.label',
-    defaultMessage: 'By date added (newest)',
+    defaultMessage: 'newest',
     description: 'Dropdown label for sorting by date (newest)',
   },
   sortByDateOldest: {
     id: 'authoring.selectvideomodal.sort.dateoldest.label',
-    defaultMessage: 'By date added (oldest)',
+    defaultMessage: 'oldest',
     description: 'Dropdown label for sorting by date (oldest)',
   },
   sortByNameAscending: {
     id: 'authoring.selectvideomodal.sort.nameascending.label',
-    defaultMessage: 'By name (ascending)',
+    defaultMessage: 'name A-Z',
     description: 'Dropdown label for sorting by name (ascending)',
   },
   sortByNameDescending: {
     id: 'authoring.selectvideomodal.sort.namedescending.label',
-    defaultMessage: 'By name (descending)',
+    defaultMessage: 'name Z-A',
     description: 'Dropdown label for sorting by name (descending)',
   },
   sortByDurationShortest: {
     id: 'authoring.selectvideomodal.sort.durationshortest.label',
-    defaultMessage: 'By duration (shortest)',
+    defaultMessage: 'shortest',
     description: 'Dropdown label for sorting by duration (shortest)',
   },
   sortByDurationLongest: {
     id: 'authoring.selectvideomodal.sort.durationlongest.label',
-    defaultMessage: 'By duration (longest)',
+    defaultMessage: 'longest',
     description: 'Dropdown label for sorting by duration (longest)',
   },
 

--- a/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
+++ b/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
@@ -11,6 +11,7 @@ import {
 } from '@edx/frontend-platform/i18n';
 
 import messages from './messages';
+import './index.scss';
 import MultiSelectFilterDropdown from './MultiSelectFilterDropdown';
 import { sortKeys, sortMessages } from '../../containers/VideoGallery/utils';
 
@@ -54,9 +55,13 @@ export const SearchSort = ({
       </Form.Group>
 
       { !showSwitch && <ActionRow.Spacer /> }
-      <SelectMenu variant="link">
+      <SelectMenu variant="link" className="search-sort-menu">
         {Object.keys(sortKeys).map(key => (
           <MenuItem key={key} onClick={onSortClick(key)} defaultSelected={key === sortBy}>
+            <span className="search-sort-menu-by">
+              <FormattedMessage {...messages.sortBy} />
+              &nbsp;
+            </span>
             <FormattedMessage {...sortMessages[key]} />
           </MenuItem>
         ))}

--- a/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
+++ b/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {
   ActionRow, Form, Icon, IconButton, SelectMenu, MenuItem,
 } from '@edx/paragon';
-import { Close, Search } from '@edx/paragon/icons';
+import { Check, Close, Search } from '@edx/paragon/icons';
 import {
   FormattedMessage,
   useIntl,
@@ -57,7 +57,12 @@ export const SearchSort = ({
       { !showSwitch && <ActionRow.Spacer /> }
       <SelectMenu variant="link" className="search-sort-menu">
         {Object.keys(sortKeys).map(key => (
-          <MenuItem key={key} onClick={onSortClick(key)} defaultSelected={key === sortBy}>
+          <MenuItem
+            key={key}
+            onClick={onSortClick(key)}
+            defaultSelected={key === sortBy}
+            iconAfter={(key === sortBy) ? Check : null}
+          >
             <span className="search-sort-menu-by">
               <FormattedMessage {...messages.sortBy} />
               &nbsp;

--- a/src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx
+++ b/src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx
@@ -6,8 +6,9 @@ import {
 } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
-import { sortKeys, sortMessages } from '../ImageUploadModal/SelectImageModal/utils';
-import { filterMessages } from '../../containers/VideoGallery/utils';
+import {
+  filterMessages, sortKeys, sortMessages,
+} from '../../containers/VideoGallery/utils';
 import { SearchSort } from './SearchSort';
 import messages from './messages';
 
@@ -48,23 +49,23 @@ describe('SearchSort component', () => {
     const { getByRole } = getComponent();
     await act(() => {
       fireEvent.click(screen.getByRole('button', {
-        name: /by date added \(oldest\)/i,
+        name: /By oldest/i,
       }));
     });
     Object.values(sortMessages)
       .forEach(({ defaultMessage }) => {
-        expect(getByRole('link', { name: defaultMessage }))
+        expect(getByRole('link', { name: `By ${defaultMessage}` }))
           .toBeInTheDocument();
       });
   });
   test('adds a sort option for each sortKey', async () => {
     const { getByRole } = getComponent();
     await act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /by date added \(oldest\)/i }));
+      fireEvent.click(screen.getByRole('button', { name: /oldest/i }));
     });
     Object.values(sortMessages)
       .forEach(({ defaultMessage }) => {
-        expect(getByRole('link', { name: defaultMessage }))
+        expect(getByRole('link', { name: `By ${defaultMessage}` }))
           .toBeInTheDocument();
       });
   });

--- a/src/editors/sharedComponents/SelectionModal/index.scss
+++ b/src/editors/sharedComponents/SelectionModal/index.scss
@@ -5,3 +5,12 @@
 .search-sort-menu .pgn__menu .search-sort-menu-by {
     display: none;
 }
+
+/* Sort options come in pairs of ascending and descending. */
+.search-sort-menu .pgn__menu > div:nth-child(even) {
+    border-bottom: 1px solid #f4f3f6;
+}
+
+.search-sort-menu .pgn__menu > div:last-child {
+    border-bottom: none;
+}

--- a/src/editors/sharedComponents/SelectionModal/index.scss
+++ b/src/editors/sharedComponents/SelectionModal/index.scss
@@ -1,0 +1,7 @@
+.search-sort-menu .pgn__menu-item-text {
+    text-transform: capitalize;
+}
+
+.search-sort-menu .pgn__menu .search-sort-menu-by {
+    display: none;
+}

--- a/src/editors/sharedComponents/SelectionModal/messages.js
+++ b/src/editors/sharedComponents/SelectionModal/messages.js
@@ -24,6 +24,11 @@ export const messages = {
     defaultMessage: 'Added {date} at {time}',
     description: 'File date-added string',
   },
+  sortBy: {
+    id: 'authoring.selectionmodal.sortBy',
+    defaultMessage: 'By',
+    description: '"By" before sort option',
+  },
 };
 
 export default messages;


### PR DESCRIPTION
## Description

Redesign video gallery sorting menu.

Before: ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/57230775-e3b8-4699-acfa-953e80792c1f)

After: ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/4d8c1af6-3450-4127-a890-ef7df2e26fcc)

## Testing instructions

1. (Optional) Create a mock videos response
   1. Enable mock video uploads (create [waffle flag](http://localhost:18010/admin/waffle/flag/) `contentstore.mock_video_uploads` enabled for everyone)
   2. Modify [videos_index_json()](https://github.com/openedx/edx-platform/blob/565b34e4e0904d1a55e56db403893a207c62e4c3/cms/djangoapps/contentstore/video_storage_handlers.py#L692) as follows:
      ```
      def videos_index_json(course):
          """
          ...
          """
          # index_videos, __ = _get_index_videos(course)
          index_videos = [{
              'edx_video_id': 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
              'client_video_id': 'video.mp4',
              'created': '1970-01-01T00:00:00Z',
              'duration': 42.5,
              'status': 'upload',
              'course_video_image_url': 'https://video/images/1234.jpg'
          }]
          return JsonResponse({"videos": index_videos}, status=200)
      ```
2. Open video gallery
   1. Enable the new video editor (create [waffle flags](http://localhost:18010/admin/waffle/flag/) `new_core_editors.use_new_video_editor` and `new_core_editors.use_video_gallery_flow` enabled for everyone)
   2. Create a course unit with a video
   3. Edit the video (should open in new editor)
   4. Click "< Replace video" to go to the gallery
3. Use sorting menu and see the names and appearance of sorting options