### PR TITLE
fix: default display of "Show Answer" and "Show reset option"

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/__snapshots__/index.test.jsx.snap
@@ -62,7 +62,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget for Advanced 
       <div
         className="my-3"
       >
-        <ResetCard />
+        <ResetCard
+          defaultValue={false}
+        />
       </div>
       <div
         className="my-3"
@@ -143,7 +145,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page 1`] = `
       <div
         className="my-3"
       >
-        <ResetCard />
+        <ResetCard
+          defaultValue={false}
+        />
       </div>
       <div
         className="my-3"
@@ -224,7 +228,9 @@ exports[`SettingsWidget snapshot snapshot: renders Settings widget page advanced
       <div
         className="my-3"
       >
-        <ResetCard />
+        <ResetCard
+          defaultValue={false}
+        />
       </div>
       <div
         className="my-3"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -113,7 +113,11 @@ export const SettingsWidget = ({
             />
           </div>
           <div className="my-3">
-            <ResetCard showResetButton={settings.showResetButton} updateSettings={updateSettings} />
+            <ResetCard
+              showResetButton={settings.showResetButton}
+              defaultValue={defaultSettings.showResetButton}
+              updateSettings={updateSettings}
+            />
           </div>
           {
             problemType === ProblemTypeKeys.ADVANCED && (
@@ -165,7 +169,7 @@ SettingsWidget.propTypes = {
   defaultSettings: PropTypes.shape({
     maxAttempts: PropTypes.number,
     showanswer: PropTypes.string,
-    showReseButton: PropTypes.bool,
+    showResetButton: PropTypes.bool,
     rerandomize: PropTypes.string,
   }).isRequired,
   // eslint-disable-next-line

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ResetCard.jsx
@@ -10,6 +10,7 @@ import { selectors } from '../../../../../../data/redux';
 
 export const ResetCard = ({
   showResetButton,
+  defaultValue,
   updateSettings,
   // inject
   intl,
@@ -17,10 +18,11 @@ export const ResetCard = ({
   const isLibrary = useSelector(selectors.app.isLibrary);
   const { setResetTrue, setResetFalse } = resetCardHooks(updateSettings);
   const advancedSettingsLink = `${useSelector(selectors.app.studioEndpointUrl)}/settings/advanced/${useSelector(selectors.app.learningContextId)}#show_reset_button`;
+  const currentResetButton = showResetButton !== null ? showResetButton : defaultValue;
   return (
     <SettingsOption
       title={intl.formatMessage(messages.resetSettingsTitle)}
-      summary={showResetButton
+      summary={currentResetButton
         ? intl.formatMessage(messages.resetSettingsTrue) : intl.formatMessage(messages.resetSettingsFalse)}
       className="resetCard"
     >
@@ -37,10 +39,10 @@ export const ResetCard = ({
         </div>
       )}
       <ButtonGroup size="sm" className="resetSettingsButtons mb-2">
-        <Button variant={showResetButton ? 'outline-primary' : 'primary'} size="sm" onClick={setResetFalse}>
+        <Button variant={currentResetButton ? 'outline-primary' : 'primary'} size="sm" onClick={setResetFalse}>
           <FormattedMessage {...messages.resetSettingsFalse} />
         </Button>
-        <Button variant={showResetButton ? 'primary' : 'outline-primary'} size="sm" onClick={setResetTrue}>
+        <Button variant={currentResetButton ? 'primary' : 'outline-primary'} size="sm" onClick={setResetTrue}>
           <FormattedMessage {...messages.resetSettingsTrue} />
         </Button>
       </ButtonGroup>
@@ -50,6 +52,7 @@ export const ResetCard = ({
 
 ResetCard.propTypes = {
   showResetButton: PropTypes.bool.isRequired,
+  defaultValue: PropTypes.bool.isRequired,
   updateSettings: PropTypes.func.isRequired,
   // injected
   intl: intlShape.isRequired,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ShowAnswerCard.jsx
@@ -26,6 +26,8 @@ export const ShowAnswerCard = ({
     showAttempts,
   } = useAnswerSettings(showAnswer, updateSettings);
 
+  const currentShowAnswer = showAnswer.on || defaultValue;
+
   const showAnswerSection = (
     <>
       <div className="pb-2">
@@ -43,7 +45,7 @@ export const ShowAnswerCard = ({
       <Form.Group className="pb-0 mb-0">
         <Form.Control
           as="select"
-          value={showAnswer.on}
+          value={currentShowAnswer}
           onChange={handleShowAnswerChange}
         >
           {Object.values(ShowAnswerTypesKeys).map((answerType) => {
@@ -79,7 +81,7 @@ export const ShowAnswerCard = ({
   return (
     <SettingsOption
       title={intl.formatMessage(messages.showAnswerSettingsTitle)}
-      summary={intl.formatMessage(ShowAnswerTypes[showAnswer.on])}
+      summary={intl.formatMessage(ShowAnswerTypes[currentShowAnswer])}
     >
       {showAnswerSection}
     </SettingsOption>

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -2,7 +2,7 @@ import _ from 'lodash-es';
 import { createSlice } from '@reduxjs/toolkit';
 import { indexToLetterMap } from '../../../containers/ProblemEditor/data/OLXParser';
 import { StrictDict } from '../../../utils';
-import { ProblemTypeKeys, RichTextProblems, ShowAnswerTypesKeys } from '../../constants/problem';
+import { ProblemTypeKeys, RichTextProblems } from '../../constants/problem';
 import { ToleranceTypes } from '../../../containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/constants';
 
 const nextAlphaId = (lastId) => String.fromCharCode(lastId.charCodeAt(0) + 1);
@@ -28,10 +28,10 @@ const initialState = {
     hints: [],
     timeBetween: 0,
     showAnswer: {
-      on: ShowAnswerTypesKeys.FINISHED,
+      on: '',
       afterAttempts: 0,
     },
-    showResetButton: false,
+    showResetButton: null,
     solutionExplanation: '',
     tolerance: {
       value: null,


### PR DESCRIPTION
### Description:

I created the [issue](https://github.com/openedx/frontend-lib-content-components/issues/401).
Hardcoding values for showAnswer and showResetButton in initialState leads to incorrect selection of additional states specified in Advanced settings.

Advanced Settings:

<img width="1317" alt="2" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/42312533-e749-4d98-bccd-b8086c981a45">


Editor Page:

<img width="1642" alt="1" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/e56f7fcc-499e-45f8-90c0-2b076ff72636">

But the inscription `Default` is correctly attributed:

<img width="763" alt="3" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/6f7a298f-5487-4b12-bfe8-e7da59e2630c">

If you save without changing anything, the value of the `Show answer` field for the course will be set to `Finished`(although the default is “closed”, we didn’t change anything in the selection). And this problem is not only with this field. The same behavior for the `Show reset option` field.

The problem is that the state is being used (_frontend-lib-content-components/src/editors/data/redux/problem/reducers.js_):
```
const initialState = {
  rawOLX: '',
  problemType: null,
  question: '',
  answers: [],
  correctAnswerCount: 0,
  groupFeedbackList: [],
  generalFeedback: '',
  additionalAttributes: {},
  defaultSettings: {},
  settings: {
    randomization: null,
    scoring: {
      weight: 1,
      attempts: {
        unlimited: true,
        number: '',
      },
    },
    hints: [],
    timeBetween: 0,
    showAnswer: {
      on: ShowAnswerTypesKeys.FINISHED,
      afterAttempts: 0,
    },
    showResetButton: false,
    solutionExplanation: '',
    tolerance: {
      value: null,
      type: ToleranceTypes.none.type,
    },
  },
};
```

For `Show reset option`:

<img width="721" alt="5" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/b493a495-9126-4e41-ab9f-706e52d08c71">
