### PR TITLE
fix: video gallery design fixes

### DIFF
--- a/src/editors/containers/VideoGallery/index.test.jsx
+++ b/src/editors/containers/VideoGallery/index.test.jsx
@@ -124,17 +124,17 @@ describe('VideoGallery', () => {
       expect(window.location.assign).toHaveBeenCalled();
     });
     it.each([
-      [/by date added \(newest\)/i, [2, 1, 3]],
-      [/by date added \(oldest\)/i, [3, 1, 2]],
-      [/by name \(ascending\)/i, [1, 2, 3]],
-      [/by name \(descending\)/i, [3, 2, 1]],
-      [/by duration \(longest\)/i, [3, 1, 2]],
-      [/by duration \(shortest\)/i, [2, 1, 3]],
+      [/newest/i, [2, 1, 3]],
+      [/oldest/i, [3, 1, 2]],
+      [/name A-Z/i, [1, 2, 3]],
+      [/name Z-A/i, [3, 2, 1]],
+      [/longest/i, [3, 1, 2]],
+      [/shortest/i, [2, 1, 3]],
     ])('videos can be sorted %s', async (sortBy, order) => {
       await renderComponent();
 
       fireEvent.click(screen.getByRole('button', {
-        name: /by date added \(newest\)/i,
+        name: /By newest/i,
       }));
       fireEvent.click(screen.getByRole('link', {
         name: sortBy,

--- a/src/editors/containers/VideoGallery/messages.js
+++ b/src/editors/containers/VideoGallery/messages.js
@@ -25,32 +25,32 @@ export const messages = {
   // Sort Dropdown
   sortByDateNewest: {
     id: 'authoring.selectvideomodal.sort.datenewest.label',
-    defaultMessage: 'By date added (newest)',
+    defaultMessage: 'newest',
     description: 'Dropdown label for sorting by date (newest)',
   },
   sortByDateOldest: {
     id: 'authoring.selectvideomodal.sort.dateoldest.label',
-    defaultMessage: 'By date added (oldest)',
+    defaultMessage: 'oldest',
     description: 'Dropdown label for sorting by date (oldest)',
   },
   sortByNameAscending: {
     id: 'authoring.selectvideomodal.sort.nameascending.label',
-    defaultMessage: 'By name (ascending)',
+    defaultMessage: 'name A-Z',
     description: 'Dropdown label for sorting by name (ascending)',
   },
   sortByNameDescending: {
     id: 'authoring.selectvideomodal.sort.namedescending.label',
-    defaultMessage: 'By name (descending)',
+    defaultMessage: 'name Z-A',
     description: 'Dropdown label for sorting by name (descending)',
   },
   sortByDurationShortest: {
     id: 'authoring.selectvideomodal.sort.durationshortest.label',
-    defaultMessage: 'By duration (shortest)',
+    defaultMessage: 'shortest',
     description: 'Dropdown label for sorting by duration (shortest)',
   },
   sortByDurationLongest: {
     id: 'authoring.selectvideomodal.sort.durationlongest.label',
-    defaultMessage: 'By duration (longest)',
+    defaultMessage: 'longest',
     description: 'Dropdown label for sorting by duration (longest)',
   },
 

--- a/src/editors/sharedComponents/BaseModal/index.jsx
+++ b/src/editors/sharedComponents/BaseModal/index.jsx
@@ -20,6 +20,7 @@ export const BaseModal = ({
   size,
   isFullscreenScroll,
   bodyStyle,
+  className,
 }) => (
   <ModalDialog
     isOpen={isOpen}
@@ -30,6 +31,7 @@ export const BaseModal = ({
     isFullscreenOnMobile
     isFullscreenScroll={isFullscreenScroll}
     title={title}
+    className={className}
   >
     <ModalDialog.Header style={{ zIndex: 1, boxShadow: '2px 2px 5px rgba(0, 0, 0, 0.3)' }}>
       <ModalDialog.Title>
@@ -59,6 +61,7 @@ BaseModal.defaultProps = {
   size: 'lg',
   isFullscreenScroll: true,
   bodyStyle: null,
+  className: undefined,
 };
 
 BaseModal.propTypes = {
@@ -72,6 +75,7 @@ BaseModal.propTypes = {
   size: PropTypes.string,
   isFullscreenScroll: PropTypes.bool,
   bodyStyle: PropTypes.shape({}),
+  className: PropTypes.string,
 };
 
 export default BaseModal;

--- a/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
+++ b/src/editors/sharedComponents/SelectionModal/SearchSort.jsx
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types';
 import {
   ActionRow, Dropdown, Form, Icon, IconButton, SelectMenu, MenuItem,
 } from '@edx/paragon';
-import { Close, Search } from '@edx/paragon/icons';
+import { Check, Close, Search } from '@edx/paragon/icons';
 import {
   FormattedMessage,
   useIntl,
 } from '@edx/frontend-platform/i18n';
 
 import messages from './messages';
+import './index.scss';
 import { sortKeys, sortMessages } from '../../containers/VideoGallery/utils';
 
 export const SearchSort = ({
@@ -55,9 +56,18 @@ export const SearchSort = ({
       </Form.Group>
 
       { !showSwitch && <ActionRow.Spacer /> }
-      <SelectMenu variant="link">
+      <SelectMenu variant="link" className="search-sort-menu">
         {Object.keys(sortKeys).map(key => (
-          <MenuItem key={key} onClick={onSortClick(key)} defaultSelected={key === sortBy}>
+          <MenuItem
+            key={key}
+            onClick={onSortClick(key)}
+            defaultSelected={key === sortBy}
+            iconAfter={(key === sortBy) ? Check : null}
+          >
+            <span className="search-sort-menu-by">
+              <FormattedMessage {...messages.sortBy} />
+              <span style={{ whiteSpace: 'pre-wrap' }}> </span>
+            </span>
             <FormattedMessage {...sortMessages[key]} />
           </MenuItem>
         ))}

--- a/src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx
+++ b/src/editors/sharedComponents/SelectionModal/SearchSort.test.jsx
@@ -6,8 +6,9 @@ import {
 } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
-import { sortKeys, sortMessages } from '../ImageUploadModal/SelectImageModal/utils';
-import { filterKeys, filterMessages } from '../../containers/VideoGallery/utils';
+import {
+  filterKeys, filterMessages, sortKeys, sortMessages,
+} from '../../containers/VideoGallery/utils';
 import { SearchSort } from './SearchSort';
 import messages from './messages';
 
@@ -51,23 +52,23 @@ describe('SearchSort component', () => {
     const { getByRole } = getComponent();
     await act(() => {
       fireEvent.click(screen.getByRole('button', {
-        name: /by date added \(oldest\)/i,
+        name: /By oldest/i,
       }));
     });
     Object.values(sortMessages)
       .forEach(({ defaultMessage }) => {
-        expect(getByRole('link', { name: defaultMessage }))
+        expect(getByRole('link', { name: `By ${defaultMessage}` }))
           .toBeInTheDocument();
       });
   });
   test('adds a sort option for each sortKey', async () => {
     const { getByRole } = getComponent();
     await act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /by date added \(oldest\)/i }));
+      fireEvent.click(screen.getByRole('button', { name: /oldest/i }));
     });
     Object.values(sortMessages)
       .forEach(({ defaultMessage }) => {
-        expect(getByRole('link', { name: defaultMessage }))
+        expect(getByRole('link', { name: `By ${defaultMessage}` }))
           .toBeInTheDocument();
       });
   });

--- a/src/editors/sharedComponents/SelectionModal/index.jsx
+++ b/src/editors/sharedComponents/SelectionModal/index.jsx
@@ -16,6 +16,8 @@ import ErrorAlert from '../ErrorAlerts/ErrorAlert';
 import FetchErrorAlert from '../ErrorAlerts/FetchErrorAlert';
 import UploadErrorAlert from '../ErrorAlerts/UploadErrorAlert';
 
+import './index.scss';
+
 export const SelectionModal = ({
   isOpen,
   close,
@@ -85,27 +87,32 @@ export const SelectionModal = ({
           <SearchSort {...searchSortProps} />
         </div>
       )}
+      className="selection-modal"
     >
-      {/* Error Alerts */}
-      <FetchErrorAlert isFetchError={isFetchError} message={fetchError} />
-      <UploadErrorAlert isUploadError={isUploadError} message={uploadError} />
-      <ErrorAlert
-        dismissError={inputError.dismiss}
-        hideHeading
-        isError={inputError.show}
-      >
-        <FormattedMessage {...inputError.message} />
-      </ErrorAlert>
+      {/*
+        If the modal dialog content is zero height, it shows a bottom shadow
+        as if there was content to scroll to, so make the min-height 1px.
+      */}
+      <Stack gap={2} style={{ minHeight: '1px' }}>
+        {/* Error Alerts */}
+        <FetchErrorAlert isFetchError={isFetchError} message={fetchError} />
+        <UploadErrorAlert isUploadError={isUploadError} message={uploadError} />
+        <ErrorAlert
+          dismissError={inputError.dismiss}
+          hideHeading
+          isError={inputError.show}
+        >
+          <FormattedMessage {...inputError.message} />
+        </ErrorAlert>
 
-      {/* User Feedback Alerts */}
-      <ErrorAlert
-        dismissError={galleryError.dismiss}
-        hideHeading
-        isError={galleryError.show}
-      >
-        <FormattedMessage {...galleryError.message} />
-      </ErrorAlert>
-      <Stack gap={2}>
+        {/* User Feedback Alerts */}
+        <ErrorAlert
+          dismissError={galleryError.dismiss}
+          hideHeading
+          isError={galleryError.show}
+        >
+          <FormattedMessage {...galleryError.message} />
+        </ErrorAlert>
         {showGallery && <Gallery {...galleryPropsValues} />}
         <FileInput fileInput={fileInput} acceptedFiles={Object.values(acceptedFiles).join()} />
       </Stack>

--- a/src/editors/sharedComponents/SelectionModal/index.scss
+++ b/src/editors/sharedComponents/SelectionModal/index.scss
@@ -1,0 +1,32 @@
+.search-sort-menu .pgn__menu-item-text {
+    text-transform: capitalize;
+}
+
+.search-sort-menu .pgn__menu .search-sort-menu-by {
+    display: none;
+}
+
+/* Sort options come in pairs of ascending and descending. */
+.search-sort-menu .pgn__menu > div:nth-child(even) {
+    border-bottom: 1px solid #f4f3f6;
+}
+
+.search-sort-menu .pgn__menu > div:last-child {
+    border-bottom: none;
+}
+
+.selection-modal .pgn__vstack > .alert {
+    margin-bottom: 0;
+    margin-top: 1.5rem;
+}
+
+/* Set top padding to 0 when there is an alert above. */
+.selection-modal .pgn__vstack > .alert + .gallery > .pgn__scrollable-body-content > .p-4 {
+    padding-top: 0 !important;
+}
+
+.selection-modal .pgn__vstack > .alert > .alert-icon {
+    /* Vertical margin equal to the vertical padding of the "Dismiss" button. */
+    margin-bottom: 0.4375rem;
+    margin-top: 0.4375rem;
+}

--- a/src/editors/sharedComponents/SelectionModal/messages.js
+++ b/src/editors/sharedComponents/SelectionModal/messages.js
@@ -24,6 +24,11 @@ export const messages = {
     defaultMessage: 'Added {date} at {time}',
     description: 'File date-added string',
   },
+  sortBy: {
+    id: 'authoring.selectionmodal.sortBy',
+    defaultMessage: 'By',
+    description: '"By" before sort option',
+  },
 };
 
 export default messages;


### PR DESCRIPTION
## Description

Fix video gallery:
* Ugly shadow when loading
* Sorting menu design
* Layout of alert messages

Before: 
1. Loading:
   ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/fb35a925-1f1d-4122-8ad9-e66a0ce9039c)
2. Sorting menu:
   ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/08c31da4-252e-4da1-8857-bc084fd41309)
3. Alert message:
   ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/b5eac16d-cd81-42dc-adb8-99a3136f905c)

After: 
1. Loading:
   ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/39b98594-939e-4f54-8e5c-4cb2f17e7ce6)
2. Sorting menu:
   ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/69a51f1c-9fcd-4fce-b084-ad7dae617bab)
3. Alert message:
   ![image](https://github.com/openedx/frontend-lib-content-components/assets/1616648/456f7e55-bb1e-42ef-8401-b35ea26d807a)

## Testing instructions

1. (Optional) Create a mock videos response with a noticeable delay and multiple videos
   1. Enable mock video uploads (create [waffle flag](http://localhost:18010/admin/waffle/flag/) `contentstore.mock_video_uploads` enabled for everyone)
   2. Modify [videos_index_json()](https://github.com/openedx/edx-platform/blob/565b34e4e0904d1a55e56db403893a207c62e4c3/cms/djangoapps/contentstore/video_storage_handlers.py#L692) as follows:
      ```
      def videos_index_json(course):
          """
          ...
          """
          # index_videos, __ = _get_index_videos(course)
          import time
          time.sleep(20)
          index_videos = [
              {
                  'edx_video_id': 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
                  'client_video_id': 'video.mp4',
                  'created': '1970-01-01T00:00:00Z',
                  'duration': 42.5,
                  'status': 'upload',
                  'course_video_image_url': 'https://video/images/1234.jpg'
              },
              {
                  'edx_video_id': 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
                  'client_video_id': 'video.mp4',
                  'created': '1970-01-01T00:00:00Z',
                  'duration': 42.5,
                  'status': 'upload',
                  'course_video_image_url': 'https://video/images/1234.jpg'
              }
          ]
          return JsonResponse({"videos": index_videos}, status=200)
      ```
2. Open video gallery
   1. Enable the new video editor (create [waffle flags](http://localhost:18010/admin/waffle/flag/) `new_core_editors.use_new_video_editor` and `new_core_editors.use_video_gallery_flow` enabled for everyone)
   2. Create a course unit with a video
   3. Edit the video (should open in new editor)
   4. Click "< Replace video" to go to the gallery
3. Observe that the shadow does not appear when loading
4. Wait for the videos to load
5. Open sorting menu and see that new design is in effect
6. Click the "Select video" button without selecting a video in order to trigger an alert
7. See that alert has (note that distances may appear to be slightly different due to the alert having a shadow):
   * similar distance from the top as the video item when there is no alert
   * similar distance to the first video item as there is between video items
   * the icon is aligned to the first line of text