### PR TITLE
fix: displaying the correct default randomization value

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -118,7 +118,11 @@ export const SettingsWidget = ({
           {
             problemType === ProblemTypeKeys.ADVANCED && (
             <div className="my-3">
-              <Randomization randomization={settings.randomization} updateSettings={updateSettings} />
+              <Randomization
+                randomization={settings.randomization}
+                defaultValue={defaultSettings.rerandomize}
+                updateSettings={updateSettings}
+              />
             </div>
             )
           }
@@ -162,6 +166,7 @@ SettingsWidget.propTypes = {
     maxAttempts: PropTypes.number,
     showanswer: PropTypes.string,
     showReseButton: PropTypes.bool,
+    rerandomize: PropTypes.string,
   }).isRequired,
   // eslint-disable-next-line
   settings: PropTypes.any.isRequired,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RandomizationCard snapshot snapshot: renders randonmization setting card with randomization defined 1`] = `
+exports[`RandomizationCard snapshot snapshot: renders randomization setting card with default randomization 1`] = `
+<SettingsOption
+  className=""
+  extraSections={Array []}
+  hasExpandableTextArea={false}
+  none={true}
+  summary="sUmmary"
+  title="Randomization"
+>
+  <div
+    className="mb-3"
+  >
+    {randomization, select,
+      null {No Python based randomization is present in this problem.}
+      other {Defines when to randomize the variables specified in the associated Python script. For problems that do not randomize values, specify "Never".}
+    }
+  </div>
+  <Form.Group>
+    <Form.Control
+      as="select"
+      onChange={[MockFunction randomizationCardHooks.handleChange]}
+      value="default_vAlUE"
+    >
+      <option
+        key="never"
+        value="never"
+      >
+        Never
+      </option>
+      <option
+        key="always"
+        value="always"
+      >
+        Always
+      </option>
+      <option
+        key="onreset"
+        value="onreset"
+      >
+        On Reset
+      </option>
+      <option
+        key="per_student"
+        value="per_student"
+      >
+        Per Student
+      </option>
+    </Form.Control>
+  </Form.Group>
+</SettingsOption>
+`;
+
+exports[`RandomizationCard snapshot snapshot: renders randomization setting card with randomization defined 1`] = `
 <SettingsOption
   className=""
   extraSections={Array []}
@@ -36,8 +88,8 @@ exports[`RandomizationCard snapshot snapshot: renders randonmization setting car
         Always
       </option>
       <option
-        key="on_reset"
-        value="on_reset"
+        key="onreset"
+        value="onreset"
       >
         On Reset
       </option>
@@ -52,7 +104,7 @@ exports[`RandomizationCard snapshot snapshot: renders randonmization setting car
 </SettingsOption>
 `;
 
-exports[`RandomizationCard snapshot snapshot: renders randonmization setting card with randomization null 1`] = `
+exports[`RandomizationCard snapshot snapshot: renders randomization setting card with randomization null 1`] = `
 <SettingsOption
   className=""
   extraSections={Array []}
@@ -88,8 +140,8 @@ exports[`RandomizationCard snapshot snapshot: renders randonmization setting car
         Always
       </option>
       <option
-        key="on_reset"
-        value="on_reset"
+        key="onreset"
+        value="onreset"
       >
         On Reset
       </option>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.jsx
@@ -9,11 +9,16 @@ import { RandomizationTypesKeys, RandomizationTypes } from '../../../../../../..
 
 export const RandomizationCard = ({
   randomization,
+  defaultValue,
   updateSettings,
   // inject
   intl,
 }) => {
-  const { summary, handleChange } = useRandomizationSettingStatus({ randomization, updateSettings });
+  const curretRandomization = randomization || defaultValue;
+  const { summary, handleChange } = useRandomizationSettingStatus({
+    randomization: curretRandomization,
+    updateSettings,
+  });
   return (
     <SettingsOption
       title={intl.formatMessage(messages.randomizationSettingTitle)}
@@ -27,7 +32,7 @@ export const RandomizationCard = ({
       <Form.Group>
         <Form.Control
           as="select"
-          value={randomization}
+          value={curretRandomization}
           onChange={handleChange}
         >
           {
@@ -48,6 +53,7 @@ export const RandomizationCard = ({
 };
 
 RandomizationCard.propTypes = {
+  defaultValue: PropTypes.string.isRequired,
   randomization: PropTypes.string.isRequired,
   updateSettings: PropTypes.func.isRequired,
   intl: intlShape.isRequired,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Randomization/index.test.jsx
@@ -11,6 +11,7 @@ jest.mock('./hooks', () => ({
 describe('RandomizationCard', () => {
   const props = {
     randomization: 'sOmE_vAlUE',
+    defaultValue: 'default_vAlUE',
     updateSettings: jest.fn().mockName('args.updateSettings'),
     intl: { formatMessage },
   };
@@ -32,11 +33,14 @@ describe('RandomizationCard', () => {
   });
 
   describe('snapshot', () => {
-    test('snapshot: renders randonmization setting card with randomization defined', () => {
+    test('snapshot: renders randomization setting card with randomization defined', () => {
       expect(shallow(<RandomizationCard {...props} />)).toMatchSnapshot();
     });
-    test('snapshot: renders randonmization setting card with randomization null', () => {
+    test('snapshot: renders randomization setting card with default randomization', () => {
       expect(shallow(<RandomizationCard {...props} randomization={null} />)).toMatchSnapshot();
+    });
+    test('snapshot: renders randomization setting card with randomization null', () => {
+      expect(shallow(<RandomizationCard {...props} randomization={null} defaultValue={null} />)).toMatchSnapshot();
     });
   });
 });

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -193,7 +193,7 @@ export const ShowAnswerTypes = StrictDict({
 export const RandomizationTypesKeys = StrictDict({
   NEVER: 'never',
   ALWAYS: 'always',
-  ONRESET: 'on_reset',
+  ONRESET: 'onreset',
   PERSTUDENT: 'per_student',
 });
 

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -32,6 +32,7 @@ export const getDataFromOlx = ({ rawOLX, rawSettings, defaultSettings }) => {
     olxParser = new OLXParser(rawOLX);
     parsedProblem = olxParser.getParsedOLXData();
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('The Problem Could Not Be Parsed from OLX. redirecting to Advanced editor.', error);
     return { problemType: ProblemTypeKeys.ADVANCED, rawOLX, settings: parseSettings(rawSettings, defaultSettings) };
   }
@@ -55,7 +56,7 @@ export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispat
 };
 
 export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
-  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button'];
+  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize'];
   dispatch(requests.fetchAdvancedSettings({
     onSuccess: (response) => {
       const defaultSettings = {};

--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -50,6 +50,7 @@ export const loadVideoData = (selectedVideoId, selectedVideoUrl) => (dispatch, g
   // Use the selected video url first
   const videoSourceUrl = selectedVideoUrl != null ? selectedVideoUrl : videoUrl;
   const [licenseType, licenseOptions] = module.parseLicense({ licenseData: studioView, level: 'block' });
+  // eslint-disable-next-line no-console
   console.log(licenseType);
   const transcripts = rawVideoData.transcriptsFromSelected ? rawVideoData.transcriptsFromSelected
     : module.parseTranscripts({ transcriptsData: studioView });
@@ -168,6 +169,7 @@ export const parseTranscripts = ({ transcriptsData }) => {
     return Object.keys(transcriptsObj.value);
   } catch (error) {
     if (error instanceof SyntaxError) {
+      // eslint-disable-next-line no-console
       console.error('Invalid JSON:', error.message);
     } else {
       throw error;
@@ -265,6 +267,7 @@ export const uploadThumbnail = ({ thumbnail, emptyCanvas }) => (dispatch, getSta
         }));
       }
     },
+    // eslint-disable-next-line no-console
     onFailure: (e) => console.log({ UploadFailure: e }, 'Resampling thumbnail upload'),
   }));
 };
@@ -404,6 +407,7 @@ export const uploadVideo = ({ supportedFiles, setLoadSpinner, postUploadRedirect
         const uploadUrl = fileObj.upload_url;
         const uploadFile = supportedFiles.find((file) => file.get('file').name === fileName);
         if (!uploadFile) {
+          // eslint-disable-next-line no-console
           console.error(`Could not find file object with name "${fileName}" in supportedFiles array.`);
           return;
         }
@@ -417,6 +421,7 @@ export const uploadVideo = ({ supportedFiles, setLoadSpinner, postUploadRedirect
           },
         })
           .then(() => postUploadRedirect(edxVideoId))
+          // eslint-disable-next-line no-console
           .catch((error) => console.error('Error uploading file:', error));
       }));
       setLoadSpinner(false);

--- a/src/editors/data/services/cms/types.js
+++ b/src/editors/data/services/cms/types.js
@@ -64,6 +64,7 @@ export const problemDataProps = {
       max_attempts: PropTypes.number,
       showanswer: PropTypes.string,
       show_reset_button: PropTypes.bool,
+      rerandomize: PropTypes.string,
     }),
   }),
 };


### PR DESCRIPTION
### Description:

No matter what changes we make to the `Advanced Settings` in the `Randomization` field, the default value for the `Randomization` field remains `Never` on the Editor page.

- Advanced Settings:
<img width="1127" alt="Знімок екрана 2023-10-20 о 10 50 39" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/bd7870b1-12f8-48e1-aca5-44f2b803dd95">

- Editor page:

**Before:**

<img width="1652" alt="Знімок екрана 2023-10-20 о 10 59 19" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/c5b8c947-0504-43f7-9000-bfea84867d23">

<img width="1652" alt="Знімок екрана 2023-10-20 о 11 00 20" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/5d4c57f7-e4c3-4aac-b20d-89825f56f343">

**After:**

<img width="1652" alt="Знімок екрана 2023-10-20 о 11 08 34" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/cd4b7fab-05f7-42e9-9295-dac5d74011e4">

