### PR TITLE
fix: Show advanced settings button color

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -92,7 +92,7 @@ export const SettingsWidget = ({
         <Collapsible.Advanced open={!isAdvancedCardsVisible}>
           <Collapsible.Body className="collapsible-body small">
             <Button
-              className="my-3 px-0 text-info-500"
+              className="my-3 px-0"
               variant="link"
               size="inline"
               onClick={showAdvancedCards}


### PR DESCRIPTION
Cosmetic adjustment: We removed the 'text-info-500' class that was conflicting with the styles of the 'Show advanced settings' button, preventing us from applying a different color to it. We believe that the 'text-info-500' class is unnecessary for this button. Even without this class, the button will appear correctly, and you'll still have the ability to change its color in branded themes.

Without a specific theme, we don't have a difference with or without this class
<img width="1840" alt="Снимок экрана 2023-11-02 в 18 20 45" src="https://github.com/openedx/frontend-lib-content-components/assets/19806032/3e0cb6f4-849c-4689-94e0-3ee656227f21">
<img width="1840" alt="Снимок экрана 2023-11-02 в 18 21 20" src="https://github.com/openedx/frontend-lib-content-components/assets/19806032/72ab86df-e46d-4196-99c0-39ba35c8bc6b">

But with branded theme this fix will help us to override blue color with custom brand color
<img width="1840" alt="Снимок экрана 2023-11-02 в 18 24 38" src="https://github.com/openedx/frontend-lib-content-components/assets/19806032/f63210d6-3bbc-4712-b077-520cdc0f3b8d">