### PR TITLE
feat: Validation for Start time and Stop time fields

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/hooks.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/hooks.js
@@ -114,6 +114,25 @@ export const updateDuration = ({
   if (newValue > 86399000) {
     newValue = 86399000;
   }
+
+  // stopTime must not be equal to 24:00:00, so when the user types 23:59:59 in the startTime field and stopTime field -
+  // set the startTime field to 23:59:58.
+  if (index === 'stopTime' && duration.startTime === 86399000) {
+    const startTime = 86399000 - 1000;
+
+    setUnsavedDuration({
+      startTime: module.durationStringFromValue(startTime),
+      stopTime: module.durationStringFromValue(newValue),
+    });
+    setDuration({
+      ...duration,
+      startTime,
+      stopTime: newValue,
+    });
+
+    return;
+  }
+
   // stopTime must be at least 1 second, if not zero
   if (index === 'stopTime' && newValue > 0 && newValue < 1000) {
     newValue = 1000;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/hooks.test.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/hooks.test.js
@@ -248,6 +248,26 @@ describe('Video Settings DurationWidget hooks', () => {
         });
       });
     });
+    describe('if the passed stopTime = startTime', () => {
+      it('sets the startTime value less than stopTime value', () => {
+        testMethod({
+          ...props,
+          duration: { startTime: 86399000, stopTime: 86399000 },
+          unsavedDuration: { startTime: '23:59:59', stopTime: '23:59:59' },
+          index: testStopIndex,
+          inputString: '23:59:59',
+        });
+        expect(props.setUnsavedDuration).toHaveBeenCalledWith({
+          startTime: '23:59:58',
+          stopTime: '23:59:59',
+        });
+        expect(props.setDuration).toHaveBeenCalledWith({
+          ...props.duration,
+          startTime: 86399000 - 1000,
+          stopTime: 86399000,
+        });
+      });
+    });
   });
   describe('onDurationChange', () => {
     beforeEach(() => {

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.jsx
@@ -71,17 +71,15 @@ export const DurationWidget = ({
           </Form.Control.Feedback>
         </Form.Group>
       </Form.Row>
-      {Boolean(duration) && (
-        <div className="mt-4 mx-2 text-right">
-          <span className="p-2 total-label rounded">
-            {getTotalLabel({
-              durationString: duration,
-              subtitle: false,
-              intl,
-            })}
-          </span>
-        </div>
-      )}
+      <div className="mt-4 mx-2 text-right">
+        <span className="p-2 total-label rounded">
+          {getTotalLabel({
+            durationString: duration,
+            subtitle: false,
+            intl,
+          })}
+        </span>
+      </div>
     </CollapsibleFormWidget>
   );
 };

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.jsx
@@ -71,15 +71,17 @@ export const DurationWidget = ({
           </Form.Control.Feedback>
         </Form.Group>
       </Form.Row>
-      <div className="mt-4 mx-2 text-right">
-        <span className="p-2 total-label rounded">
-          {getTotalLabel({
-            durationString: duration,
-            subtitle: false,
-            intl,
-          })}
-        </span>
-      </div>
+      {Boolean(duration) && (
+        <div className="mt-4 mx-2 text-right">
+          <span className="p-2 total-label rounded">
+            {getTotalLabel({
+              durationString: duration,
+              subtitle: false,
+              intl,
+            })}
+          </span>
+        </div>
+      )}
     </CollapsibleFormWidget>
   );
 };


### PR DESCRIPTION
- Fixed validations for startTime and stopTime fields. 

stopTime value must not be equal to 24:00:00, because this value is not valid so when the user types 23:59:59 in the startTime field and stopTime field - set the startTime field to 23:59:58.

![Screenshot 2023-11-05 at 16 22 51](https://github.com/openedx/frontend-lib-content-components/assets/138868841/de8e75c4-4709-4641-aef6-762e0c90bdd7)

![Screenshot 2023-11-05 at 16 23 09](https://github.com/openedx/frontend-lib-content-components/assets/138868841/6b5199c7-0019-415a-9e10-1c394cc4ec77)
