### PR TITLE
fix: video thumbnail availability

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where thumbnai
     variant="light"
   >
     <FormattedMessage
-      defaultMessage="Select a video from your library to enable this feature"
+      defaultMessage="Select a video from your library to enable this feature (applies only to courses that run on the edx.org site)."
       description="Message for unavailable thumbnail widget"
       id="authoring.videoeditor.thumbnail.unavailable.message"
     />
@@ -167,6 +167,15 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with a thumbna
       id="authoring.videoeditor.thumbnail.error.fileSizeError"
     />
   </ErrorAlert>
+  <Alert
+    variant="light"
+  >
+    <FormattedMessage
+      defaultMessage="Select a video from your library to enable this feature (applies only to courses that run on the edx.org site)."
+      description="Message for unavailable thumbnail widget"
+      id="authoring.videoeditor.thumbnail.unavailable.message"
+    />
+  </Alert>
   <Stack
     direction="horizontal"
     gap={3}
@@ -204,7 +213,7 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with default p
     variant="light"
   >
     <FormattedMessage
-      defaultMessage="Select a video from your library to enable this feature"
+      defaultMessage="Select a video from your library to enable this feature (applies only to courses that run on the edx.org site)."
       description="Message for unavailable thumbnail widget"
       id="authoring.videoeditor.thumbnail.unavailable.message"
     />

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
@@ -75,7 +75,7 @@ export const ThumbnailWidget = ({
       >
         <FormattedMessage {...messages.fileSizeError} />
       </ErrorAlert>
-      {edxVideo ? null : (
+      {(allowThumbnailUpload && edxVideo) ? null : (
         <Alert variant="light">
           <FormattedMessage {...messages.unavailableMessage} />
         </Alert>
@@ -90,7 +90,7 @@ export const ThumbnailWidget = ({
             src={thumbnailSrc || thumbnail}
             alt={intl.formatMessage(messages.thumbnailAltText)}
           />
-          { (allowThumbnailUpload && edxVideo) ? (
+          {(allowThumbnailUpload && edxVideo) ? (
             <IconButtonWithTooltip
               tooltipPlacement="top"
               tooltipContent={intl.formatMessage(messages.deleteThumbnail)}
@@ -115,7 +115,7 @@ export const ThumbnailWidget = ({
             iconBefore={FileUpload}
             onClick={fileInput.click}
             variant="link"
-            disabled={!edxVideo}
+            disabled={!(allowThumbnailUpload && edxVideo)}
           >
             <FormattedMessage {...messages.uploadButtonLabel} />
           </Button>

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/messages.js
@@ -24,7 +24,8 @@ const messages = defineMessages({
   },
   unavailableMessage: {
     id: 'authoring.videoeditor.thumbnail.unavailable.message',
-    defaultMessage: 'Select a video from your library to enable this feature',
+    defaultMessage:
+      'Select a video from your library to enable this feature (applies only to courses that run on the edx.org site).',
     description: 'Message for unavailable thumbnail widget',
   },
   uploadButtonLabel: {


### PR DESCRIPTION
#### Description:

According to the documentation (https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/video/additional_video_options.html#thumbnail)
video thumbnail is only available for videos uploaded through the "Video Uploads" page (https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/video/upload_video.html).

Additional conditions for the availability of the "Upload thumbnail" button have been added in the case when we upload video transcripts, a unique "Video ID" is created, but the thumbnail should still not be available for downloading since we use third-party video sources.

The text of the message for the thumbnail block was also changed, indicating the specific availability of functionality.