### PR TITLE
fix: form group controls alignment

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/index.scss
@@ -7,6 +7,19 @@
   .advancedEditorTopMargin {
     margin-top: 40px;
   }
+  .answer-option {
+    .pgn__form-checkbox,
+    .pgn__form-radio {
+      & + .pgn__form-label {
+        min-width: 1.1rem;
+      }
+    }
+  }
+  .settingsOption {
+    .pgn__form-checkbox .pgn__form-label {
+      min-width: .8rem;
+    }
+  }
 }
 
 .tinyMceWidget {


### PR DESCRIPTION
**TL;DR -**

This pull request contains minor fixes to the display and alignment of form elements for the response options and group feedback block.

**What changed?**
|  Before |  After |
|---|---|
|  ![image](https://github.com/openedx/frontend-lib-content-components/assets/17108583/e4d0eef0-3e6d-48a2-abfe-737e228af14d)  |  ![image](https://github.com/openedx/frontend-lib-content-components/assets/17108583/9df18fd1-c209-40ba-a947-c4665ba8b41e) |