### PR TITLE
fix: reset active answers for single answer problem type

### DIFF
--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -60,11 +60,9 @@ const problem = createSlice({
         if (obj.id === id) {
           if (_.has(answer, 'correct') && payload.correct) {
             correctAnswerCount += 1;
-            return { ...obj, ...answer };
           }
-          if (_.has(answer, 'correct') && payload.correct === false) {
+          if (_.has(answer, 'correct') && payload.correct === false && correctAnswerCount > 0) {
             correctAnswerCount -= 1;
-            return { ...obj, ...answer };
           }
           return { ...obj, ...answer };
         }


### PR DESCRIPTION
#### Description:

This pull request contains a fix for an issue where the selected response options (for a single response type - Dropdown) are reset when switching issue types.

During multi-changing problem type and setting correct answers our counter flag `correctAnswerCount` went below zero value, that has been fixed.