### PR TITLE
fix: get library blocks editing to work locally

### DIFF
--- a/src/editors/data/services/cms/api.js
+++ b/src/editors/data/services/cms/api.js
@@ -11,6 +11,11 @@ export const apiMethods = {
   ),
   fetchByUnitId: ({ blockId, studioEndpointUrl }) => get(
     urls.blockAncestor({ studioEndpointUrl, blockId }),
+    {
+      headers: {
+        Accept: '*/*',
+      },
+    },
   ),
   fetchStudioView: ({ blockId, studioEndpointUrl }) => get(
     urls.blockStudioView({ studioEndpointUrl, blockId }),

--- a/src/editors/data/services/cms/api.test.js
+++ b/src/editors/data/services/cms/api.test.js
@@ -15,18 +15,18 @@ jest.mock('../../../utils', () => {
 });
 
 jest.mock('./urls', () => ({
-  block: jest.fn().mockName('urls.block'),
-  blockAncestor: jest.fn().mockName('urls.blockAncestor'),
-  blockStudioView: jest.fn().mockName('urls.StudioView'),
-  courseAssets: jest.fn().mockName('urls.courseAssets'),
-  videoTranscripts: jest.fn().mockName('urls.videoTranscripts'),
-  allowThumbnailUpload: jest.fn().mockName('urls.allowThumbnailUpload'),
-  thumbnailUpload: jest.fn().mockName('urls.thumbnailUpload'),
-  checkTranscriptsForImport: jest.fn().mockName('urls.checkTranscriptsForImport'),
-  courseDetailsUrl: jest.fn().mockName('urls.courseDetailsUrl'),
-  courseAdvanceSettings: jest.fn().mockName('urls.courseAdvanceSettings'),
-  replaceTranscript: jest.fn().mockName('urls.replaceTranscript'),
-  videoFeatures: jest.fn().mockName('urls.videoFeatures'),
+  block: jest.fn().mockReturnValue('urls.block'),
+  blockAncestor: jest.fn().mockReturnValue('urls.blockAncestor'),
+  blockStudioView: jest.fn().mockReturnValue('urls.StudioView'),
+  courseAssets: jest.fn().mockReturnValue('urls.courseAssets'),
+  videoTranscripts: jest.fn().mockReturnValue('urls.videoTranscripts'),
+  allowThumbnailUpload: jest.fn().mockReturnValue('urls.allowThumbnailUpload'),
+  thumbnailUpload: jest.fn().mockReturnValue('urls.thumbnailUpload'),
+  checkTranscriptsForImport: jest.fn().mockReturnValue('urls.checkTranscriptsForImport'),
+  courseDetailsUrl: jest.fn().mockReturnValue('urls.courseDetailsUrl'),
+  courseAdvanceSettings: jest.fn().mockReturnValue('urls.courseAdvanceSettings'),
+  replaceTranscript: jest.fn().mockReturnValue('urls.replaceTranscript'),
+  videoFeatures: jest.fn().mockReturnValue('urls.videoFeatures'),
   courseVideos: jest.fn()
     .mockName('urls.courseVideos')
     .mockImplementation(
@@ -64,7 +64,7 @@ describe('cms api', () => {
     describe('fetchByUnitId', () => {
       it('should call get with url.blockAncestor', () => {
         apiMethods.fetchByUnitId({ blockId, studioEndpointUrl });
-        expect(get).toHaveBeenCalledWith(urls.blockAncestor({ studioEndpointUrl, blockId }));
+        expect(get).toHaveBeenCalledWith(urls.blockAncestor({ studioEndpointUrl, blockId }), { headers: { Accept: '*/*' } });
       });
     });
 


### PR DESCRIPTION
Internal issue: https://2u-internal.atlassian.net/browse/TNL-11299

When you go to library-authoring locally and click the edit button on a text or problem block, the tinyMceEditor does not load, but goes to an infinite loading spinner. This is fixed here.

### Testing instructions

- pull latest library-authoring master
- run `make build` in this frontend-lib-content-components repo
- restart library-authoring container
- go to `localhost:3001`, open a library, and try to edit a text block.
- You may get an error `Syntax Error: unexpected token <`. This is an unrelated error. To ignore this, go to file `src/editors/data/constants/tinyMCE.js`, to line 57 with `export const plugins = listKeyStore([`, and then down to the lines 70-71 with `  'a11ychecker',
  'powerpaste',` and comment out both lines. Then run `make build` and if necessary restart the library-authoring container.
  - The editor should open normally, you should be able to edit the text inside a block.