### PR TITLE
fix: editor container can scroll again

### DIFF
--- a/src/editors/Editor.jsx
+++ b/src/editors/Editor.jsx
@@ -33,14 +33,6 @@ export const Editor = ({
   return (
     <div
       className="d-flex flex-column"
-      style={{
-        /* Positioned as a proper Paragon FullscreenModal should have been. */
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        height: '100%',
-      }}
     >
       <div
         className="pgn__modal-fullscreen h-100"

--- a/src/editors/__snapshots__/Editor.test.jsx.snap
+++ b/src/editors/__snapshots__/Editor.test.jsx.snap
@@ -3,15 +3,6 @@
 exports[`Editor render presents error message if no relevant editor found and ref ready 1`] = `
 <div
   className="d-flex flex-column"
-  style={
-    Object {
-      "height": "100%",
-      "left": 0,
-      "position": "fixed",
-      "right": 0,
-      "top": 0,
-    }
-  }
 >
   <div
     aria-label="fAkEBlock"
@@ -30,15 +21,6 @@ exports[`Editor render presents error message if no relevant editor found and re
 exports[`Editor render snapshot: renders correct editor given blockType (html -> TextEditor) 1`] = `
 <div
   className="d-flex flex-column"
-  style={
-    Object {
-      "height": "100%",
-      "left": 0,
-      "position": "fixed",
-      "right": 0,
-      "top": 0,
-    }
-  }
 >
   <div
     aria-label="html"

--- a/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/EditorContainer/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EditorContainer component render snapshot: initialized. enable save and pass to header 1`] = `
 <div
-  className="d-flex flex-column position-relative zindex-0"
+  className="editor-container d-flex flex-column position-relative zindex-0"
   style={
     Object {
       "minHeight": "100%",
@@ -83,7 +83,7 @@ exports[`EditorContainer component render snapshot: initialized. enable save and
 
 exports[`EditorContainer component render snapshot: not initialized. disable save and pass to header 1`] = `
 <div
-  className="d-flex flex-column position-relative zindex-0"
+  className="editor-container d-flex flex-column position-relative zindex-0"
   style={
     Object {
       "minHeight": "100%",

--- a/src/editors/containers/EditorContainer/index.jsx
+++ b/src/editors/containers/EditorContainer/index.jsx
@@ -13,6 +13,7 @@ import EditorFooter from './components/EditorFooter';
 import TitleHeader from './components/TitleHeader';
 import * as hooks from './hooks';
 import messages from './messages';
+import './index.scss';
 
 export const EditorContainer = ({
   children,
@@ -29,7 +30,7 @@ export const EditorContainer = ({
   const handleCancel = hooks.handleCancel({ onClose, returnFunction });
   return (
     <div
-      className="d-flex flex-column position-relative zindex-0"
+      className="editor-container d-flex flex-column position-relative zindex-0"
       style={{ minHeight: '100%' }}
     >
       <BaseModal

--- a/src/editors/containers/EditorContainer/index.scss
+++ b/src/editors/containers/EditorContainer/index.scss
@@ -1,0 +1,6 @@
+// fix double scrollbars
+.editor-container {
+  .pgn__modal-body {
+    overflow: visible;
+  }
+}


### PR DESCRIPTION
Testing instructions:

- open editors and paste a huge amount of text into it so you need to scroll down
- Text editor scrolls normally, doesn't have double scroll bar, and behaves / looks normal
- Video editor scrolls normally, doesn't have double scroll bar, and behaves / looks normal
- Problem editor scrolls normally, doesn't have double scroll bar, and behaves / looks normal

Note that you may encounter a problem I have been having locally, where you cannot open the tinyMceEditor but get `SyntaxError: unknown <`. This is to my knowledge only a local problem. To temporarily ignore it, go to src/editors/data/constants/tinyMCE.js and comment out this. Please only locally for yourself, don't commit:

`  'a11ychecker',
  'powerpaste',`