### PR TITLE
Fix  disable tinymce powerpaste and a11ychecker plugins

### DIFF
--- a/src/editors/data/constants/tinyMCE.js
+++ b/src/editors/data/constants/tinyMCE.js
@@ -67,7 +67,7 @@ export const plugins = listKeyStore([
   'image',
   'imagetools',
   'quickbars',
-  // We are disabling these plugins for now until local development and stubbed versions work
+  // temporarily disable these plugins since they throw a bug in local development
   // 'a11ychecker',
   // 'powerpaste',
 ]);


### PR DESCRIPTION
Previous commit didn't create a release. So I prefixed the commit with "fix: ".