### PR TITLE
feat: add blockId to return url

### DIFF
--- a/src/editors/data/services/cms/urls.js
+++ b/src/editors/data/services/cms/urls.js
@@ -2,8 +2,8 @@ export const libraryV1 = ({ studioEndpointUrl, learningContextId }) => (
   `${studioEndpointUrl}/library/${learningContextId}`
 );
 
-export const unit = ({ studioEndpointUrl, unitUrl }) => (
-  `${studioEndpointUrl}/container/${unitUrl.data.ancestors[0]?.id}`
+export const unit = ({ studioEndpointUrl, unitUrl, blockId }) => (
+  `${studioEndpointUrl}/container/${unitUrl.data.ancestors[0]?.id}#${blockId}`
 );
 
 export const returnUrl = ({
@@ -23,7 +23,7 @@ export const returnUrl = ({
   // when the learning context is a course, return to the unit page
   // only do this for v1 blocks
   if (unitUrl && blockId.includes('block-v1')) {
-    return unit({ studioEndpointUrl, unitUrl });
+    return unit({ studioEndpointUrl, unitUrl, blockId });
   }
   return '';
 };
@@ -52,7 +52,7 @@ export const blockStudioView = ({ studioEndpointUrl, blockId }) => (
 );
 
 export const courseAssets = ({ studioEndpointUrl, learningContextId }) => (
-  `${studioEndpointUrl}/assets/${learningContextId}/?page_size=500`
+  `${studioEndpointUrl}/assets/${learningContextId}/`
 );
 
 export const thumbnailUpload = ({ studioEndpointUrl, learningContextId, videoId }) => (


### PR DESCRIPTION
JIRA Ticket: [TNL-10036](https://2u-internal.atlassian.net/browse/TNL-10036)

> Since many units can be quite long, let’s see if we can return the user to the edited component on reload, after Editor Save/Cancel.

edx-platform PR #[33855](https://github.com/openedx/edx-platform/pull/33855) added an id to each xblock. This PR adds the blockId as the hash in the url so the page knows where to scroll to after the page loads.

Testing

1. Edit a block that uses the text, problem, or video editor.
2. Cancel the edit
3. Unit page should scroll to the xblock that you were editing.
4. Choose another block to edit
5. Save the edit
6. Unit page should scroll to the xblock that you were editing.