### PR TITLE
fix: library editor not working locally

### DIFF
--- a/src/editors/data/services/cms/api.js
+++ b/src/editors/data/services/cms/api.js
@@ -5,12 +5,23 @@ import * as module from './api';
 import * as mockApi from './mockApi';
 import { durationStringFromValue } from '../../../containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/hooks';
 
+const fetchByUnitIdOptions = {};
+
+// For some reason, the local webpack-dev-server of library-authoring does not accept the normal Accept header.
+// This is a workaround only for that specific case; the idea is to only do this locally and only for library-authoring.
+if (process.env.NODE_ENV === 'development' && process.env.MFE_NAME === 'frontend-app-library-authoring') {
+  fetchByUnitIdOptions.headers = {
+    Accept: '*/*',
+  };
+}
+
 export const apiMethods = {
   fetchBlockById: ({ blockId, studioEndpointUrl }) => get(
     urls.block({ blockId, studioEndpointUrl }),
   ),
   fetchByUnitId: ({ blockId, studioEndpointUrl }) => get(
     urls.blockAncestor({ studioEndpointUrl, blockId }),
+    fetchByUnitIdOptions,
   ),
   fetchStudioView: ({ blockId, studioEndpointUrl }) => get(
     urls.blockStudioView({ studioEndpointUrl, blockId }),


### PR DESCRIPTION
Internal issue: https://2u-internal.atlassian.net/browse/TNL-11299

In library-authoring, content blocks could not be edited locally due to some problem with the Accept header. This caused some 404s. Visually you would get an infinite loading spinner.

This depends on https://github.com/openedx/frontend-app-library-authoring/pull/399.

### Testing:
- add `MFE_NAME='frontend-app-library-authoring'` to .env.development in your local frontend-app-library-authoring. (I'll add an extra PR for that now as well).
- test that your local course-authoring opens text blocks and that you can edit and save them. (In a previous attempt to fix this, the change broke course-authoring.)
- test that your local library-authoring opens text blocks and that you can edit and save them.
- When code reviewing, pay attention that the new code should not affect stage or prod at all and only touch local behavior.