### PR TITLE
feat: allowing studio asides for course-authoring MFE

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -201,7 +201,7 @@ const mapStateToProps = (state) => ({
   asidesURL: `${selectors.app.studioEndpointUrl(state)
   }/asides/${
     selectors.app.blockId(state)}`,
-  asidesEnabled: selectors.problem.defaultSettings(state).advancedModules?.length > 0,
+  asidesEnabled: selectors.problem.hasAsides(state),
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -36,6 +36,8 @@ export const SettingsWidget = ({
   updateField,
   updateAnswer,
   defaultSettings,
+  asidesURL,
+  asidesEnabled,
 }) => {
   const { isAdvancedCardsVisible, showAdvancedCards } = showAdvancedSettingsCards();
 
@@ -88,6 +90,17 @@ export const SettingsWidget = ({
         <HintsCard problemType={problemType} hints={settings.hints} updateSettings={updateSettings} />
       </div>
       {feedbackCard()}
+      {asidesEnabled && (
+      <div>
+        <iframe
+          title="asides-iframe"
+          src={asidesURL}
+          allowFullScreen
+          frameBorder="0"
+          width={500}
+        />
+      </div>
+      )}
       <div>
         <Collapsible.Advanced open={!isAdvancedCardsVisible}>
           <Collapsible.Body className="collapsible-body small">
@@ -174,6 +187,8 @@ SettingsWidget.propTypes = {
   }).isRequired,
   // eslint-disable-next-line
   settings: PropTypes.any.isRequired,
+  asidesURL: PropTypes.string.isRequired,
+  asidesEnabled: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = (state) => ({
@@ -183,6 +198,10 @@ const mapStateToProps = (state) => ({
   blockTitle: selectors.app.blockTitle(state),
   correctAnswerCount: selectors.problem.correctAnswerCount(state),
   defaultSettings: selectors.problem.defaultSettings(state),
+  asidesURL: `${selectors.app.studioEndpointUrl(state)
+  }/asides/${
+    selectors.app.blockId(state)}`,
+  asidesEnabled: selectors.problem.defaultSettings(state).advancedModules?.length > 0,
 });
 
 export const mapDispatchToProps = {

--- a/src/editors/data/redux/problem/selectors.js
+++ b/src/editors/data/redux/problem/selectors.js
@@ -12,6 +12,7 @@ export const simpleSelectors = {
   settings: mkSimpleSelector(problemData => problemData.settings),
   question: mkSimpleSelector(problemData => problemData.question),
   defaultSettings: mkSimpleSelector(problemData => problemData.defaultSettings),
+  hasAsides: mkSimpleSelector(problemData => problemData.hasAsides),
   completeState: mkSimpleSelector(problemData => problemData),
 };
 

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -56,7 +56,7 @@ export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispat
 };
 
 export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
-  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize'];
+  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize', 'advanced_modules'];
   dispatch(requests.fetchAdvancedSettings({
     onSuccess: (response) => {
       const defaultSettings = {};

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -47,16 +47,23 @@ export const getDataFromOlx = ({ rawOLX, rawSettings, defaultSettings }) => {
   return { settings: parsedSettings };
 };
 
-export const loadProblem = ({ rawOLX, rawSettings, defaultSettings }) => (dispatch) => {
+export const loadProblem = ({
+  rawOLX, rawSettings, hasAsides, defaultSettings,
+}) => (dispatch) => {
   if (isBlankProblem({ rawOLX })) {
     dispatch(actions.problem.setEnableTypeSelection(camelizeKeys(defaultSettings)));
   } else {
-    dispatch(actions.problem.load(getDataFromOlx({ rawOLX, rawSettings, defaultSettings })));
+    dispatch(actions.problem.load({
+      ...getDataFromOlx({
+        rawOLX, rawSettings, hasAsides, defaultSettings,
+      }),
+      hasAsides,
+    }));
   }
 };
 
-export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => {
-  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize', 'advanced_modules'];
+export const fetchAdvancedSettings = ({ rawOLX, rawSettings, hasAsides }) => (dispatch) => {
+  const advancedProblemSettingKeys = ['max_attempts', 'showanswer', 'show_reset_button', 'rerandomize'];
   dispatch(requests.fetchAdvancedSettings({
     onSuccess: (response) => {
       const defaultSettings = {};
@@ -66,16 +73,23 @@ export const fetchAdvancedSettings = ({ rawOLX, rawSettings }) => (dispatch) => 
         }
       });
       dispatch(actions.problem.updateField({ defaultSettings: camelizeKeys(defaultSettings) }));
-      loadProblem({ rawOLX, rawSettings, defaultSettings })(dispatch);
+      loadProblem({
+        rawOLX, rawSettings, hasAsides, defaultSettings,
+      })(dispatch);
     },
-    onFailure: () => { loadProblem({ rawOLX, rawSettings, defaultSettings: {} })(dispatch); },
+    onFailure: () => {
+      loadProblem({
+        rawOLX, rawSettings, hasAsides, defaultSettings: {},
+      })(dispatch);
+    },
   }));
 };
 
 export const initializeProblem = (blockValue) => (dispatch) => {
   const rawOLX = _.get(blockValue, 'data.data', {});
   const rawSettings = _.get(blockValue, 'data.metadata', {});
-  dispatch(fetchAdvancedSettings({ rawOLX, rawSettings }));
+  const hasAsides = _.get(blockValue, 'data.has_cms_asides', false);
+  dispatch(fetchAdvancedSettings({ rawOLX, rawSettings, hasAsides }));
 };
 
 export default { initializeProblem, switchToAdvancedEditor, fetchAdvancedSettings };


### PR DESCRIPTION
## Supporting Information
Issue: [Frontend App Course Authoring - Issue #545](https://github.com/openedx/frontend-app-course-authoring/issues/545)
EdX Platform PR: [EdX Platform - Pull Request #34026](https://github.com/openedx/edx-platform/pull/34026)

Note: This pull request should be reviewed concurrently with the EdX Platform PR.

## Description
The current problem editor page lacks options for configuring aside values of the problem xblock. This pull request addresses this by enabling the asides' studio views in the problem editor.

More information in the EdX Platform PR

Note: Styles are not finalized, and suggestions for improvement are welcome.

## Screenshot
<img width="941" alt="Screenshot 2024-01-05 at 3 59 47 PM" src="https://github.com/Anas12091101/frontend-lib-content-components/assets/88967643/6493a0d7-00f3-4cd1-a9d3-36bd94ae2d32">

## How to test locally
- In your local edx-platform, checkout to https://github.com/Anas12091101/edx-platform/tree/MFE-studio-view
- Login to edx-platform.
- In Studio, go to the edX Demo Course. Create a new unit which is a multiple choice problem.
- Configure the [rapid response aside](https://github.com/mitodl/rapid-response-xblock) for this problem.
- Add the [waffle flags](https://github.com/openedx/frontend-app-course-authoring?tab=readme-ov-file#requirements-1) to use the course authoring MFE in the studio admin if not already. 
- Click the edit tab on the problem xblock which will redirect you to the course authoring MFE if properly configured.
- You can see the rapid response aside being rendered in an iframe as shown in image above. 

(Note: The styling of the iframe has not been completed yet. The PR only offers a basic approach to resolve https://github.com/openedx/frontend-app-course-authoring/issues/545. It should be merged after the edx-platform PR is merged.)
