### PR TITLE
fix: url for video uploads

### DIFF
--- a/src/editors/containers/VideoUploadEditor/VideoUploader.jsx
+++ b/src/editors/containers/VideoUploadEditor/VideoUploader.jsx
@@ -12,7 +12,7 @@ import messages from './messages';
 
 const URLUploader = () => {
   const [textInputValue, setTextInputValue] = React.useState('');
-  const onURLUpload = hooks.onVideoUpload();
+  const onURLUpload = hooks.onVideoUpload('selectedVideoUrl');
   const intl = useIntl();
   return (
     <div className="d-flex flex-column">
@@ -67,7 +67,7 @@ export const VideoUploader = ({ setLoading }) => {
     dispatch(thunkActions.video.uploadVideo({
       supportedFiles: [fileData],
       setLoadSpinner: setLoading,
-      postUploadRedirect: hooks.onVideoUpload(),
+      postUploadRedirect: hooks.onVideoUpload('selectedVideoId'),
     }));
   };
 

--- a/src/editors/containers/VideoUploadEditor/hooks.js
+++ b/src/editors/containers/VideoUploadEditor/hooks.js
@@ -7,15 +7,15 @@ export const {
   navigateTo,
 } = appHooks;
 
-export const postUploadRedirect = (storeState) => {
+export const postUploadRedirect = (storeState, uploadType) => {
   const learningContextId = selectors.app.learningContextId(storeState);
   const blockId = selectors.app.blockId(storeState);
-  return (videoUrl) => navigateTo(`/course/${learningContextId}/editor/video/${blockId}?selectedVideoUrl=${videoUrl}`);
+  return (videoUrl) => navigateTo(`/course/${learningContextId}/editor/video/${blockId}?${uploadType}=${videoUrl}`);
 };
 
-export const onVideoUpload = () => {
+export const onVideoUpload = (uploadType) => {
   const storeState = store.getState();
-  return module.postUploadRedirect(storeState);
+  return module.postUploadRedirect(storeState, uploadType);
 };
 
 export const useUploadVideo = async ({


### PR DESCRIPTION
JIRA Ticket: [TNL-11269](https://2u-internal.atlassian.net/browse/TNL-11269)

> Upload a new video to the block. Note that there is a video id put into the video URL field, which is wrong.

The query parameter that controls whether the id in the url is a video Id or url was always set to be a url even when a video was uploaded instead of a url. Now the query parameter is set dynamically so the appropriate value is add to the url.

Testing
1. Add a video block
2. Click "Upload or embed new video"
3. Add a video url and submit
4. Url should load in url field
5. Click "Replace video"
6. Click "Upload or embed new video"
7. Use dropzone to upload new video file
8. The new video's id should be in the Video Id field.