### PR TITLE
fix: video upload api fetch body

### DIFF
--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -411,16 +411,22 @@ export const uploadVideo = ({ supportedFiles, setLoadSpinner, postUploadRedirect
           console.error(`Could not find file object with name "${fileName}" in supportedFiles array.`);
           return;
         }
-        const formData = new FormData();
-        formData.append('uploaded-file', uploadFile.get('file'));
+        const file = uploadFile.get('file');
         await fetch(uploadUrl, {
           method: 'PUT',
-          body: formData,
           headers: {
-            'Content-Type': 'multipart/form-data',
+            'Content-Disposition': `attachment; filename="${file.name}"`,
+            'Content-Type': file.type,
           },
+          multipart: false,
+          body: file,
         })
-          .then(() => postUploadRedirect(edxVideoId))
+          .then((resp) => {
+            if (!resp.ok) {
+              throw new Error('Failed to connect with server');
+            }
+            postUploadRedirect(edxVideoId);
+          })
           // eslint-disable-next-line no-console
           .catch((error) => console.error('Error uploading file:', error));
       }));

--- a/src/editors/data/redux/thunkActions/video.test.js
+++ b/src/editors/data/redux/thunkActions/video.test.js
@@ -760,7 +760,7 @@ describe('uploadVideo', () => {
 
   it('should call fetch with correct arguments for each file', async () => {
     const mockResponseData = { success: true };
-    const mockFetchResponse = Promise.resolve({ data: mockResponseData });
+    const mockFetchResponse = Promise.resolve({ data: mockResponseData, ok: true });
     global.fetch = jest.fn().mockImplementation(() => mockFetchResponse);
     const response = {
       files: [

--- a/src/editors/data/redux/thunkActions/video.test.js
+++ b/src/editors/data/redux/thunkActions/video.test.js
@@ -779,7 +779,7 @@ describe('uploadVideo', () => {
     });
     supportedFiles.forEach((file, index) => {
       const fileDataTest = file.get('file');
-      expect(fetch.mock.calls[index][1].body.get('uploaded-file')).toBe(fileDataTest);
+      expect(fetch.mock.calls[index][1].body).toBe(fileDataTest);
     });
   });
 


### PR DESCRIPTION
JIRA Ticket: [TNL-11350](https://2u-internal.atlassian.net/browse/TNL-11350)

> Users can successfully upload videos, but they never leave the processing stage. Looking at the network tab it looks like the upload to AWS fails, but the user is never notified of the failure.

This PR fixes the `PUT` to AWS to more closely align with the legacy API that uses AJAX and JQuery. This PR allow properly handles the failure state of the `PUT` request when the API return a failure message.

Note: This PR requires a successfully set up video pipeline to properly test

Testing

1. Open a course unit
2. Add a new video block
3. Open network tab
4. Upload a video
5. User should be redirected to the video editor
6. Save block
7. Open the Videos page
8. Check that the recently added video is listed
9. Status of video should be "Processing"
10. Check back in a couple of min and refresh the page
11. Status of video should be fully uploaded
12. Navigate back to recently added block
13. Video should play in preview