### PR TITLE
fix: remove useEffect that fires before search params

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoEditorModal.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoEditorModal.jsx
@@ -5,7 +5,6 @@ import * as appHooks from '../../../hooks';
 import { thunkActions, selectors } from '../../../data/redux';
 import VideoSettingsModal from './VideoSettingsModal';
 // import SelectVideoModal from './SelectVideoModal';
-import * as module from './VideoEditorModal';
 
 export const {
   navigateTo,
@@ -14,9 +13,7 @@ export const {
 export const hooks = {
   initialize: (dispatch, selectedVideoId, selectedVideoUrl) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      dispatch(thunkActions.video.loadVideoData(selectedVideoId, selectedVideoUrl));
-    }, []);
+    dispatch(thunkActions.video.loadVideoData(selectedVideoId, selectedVideoUrl));
   },
   returnToGallery: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -36,8 +33,8 @@ const VideoEditorModal = ({
   const searchParams = new URLSearchParams(document.location.search);
   const selectedVideoId = searchParams.get('selectedVideoId');
   const selectedVideoUrl = searchParams.get('selectedVideoUrl');
-  const onReturn = module.hooks.returnToGallery();
-  module.hooks.initialize(dispatch, selectedVideoId, selectedVideoUrl);
+  const onReturn = hooks.returnToGallery();
+  hooks.initialize(dispatch, selectedVideoId, selectedVideoUrl);
   return (
     <VideoSettingsModal {...{
       close,

--- a/src/editors/containers/VideoEditor/components/VideoEditorModal.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoEditorModal.jsx
@@ -12,13 +12,10 @@ export const {
 
 export const hooks = {
   initialize: (dispatch, selectedVideoId, selectedVideoUrl) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     dispatch(thunkActions.video.loadVideoData(selectedVideoId, selectedVideoUrl));
   },
-  returnToGallery: () => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
+  useReturnToGallery: () => {
     const learningContextId = useSelector(selectors.app.learningContextId);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const blockId = useSelector(selectors.app.blockId);
     return () => (navigateTo(`/course/${learningContextId}/editor/course-videos/${blockId}`));
   },
@@ -33,7 +30,7 @@ const VideoEditorModal = ({
   const searchParams = new URLSearchParams(document.location.search);
   const selectedVideoId = searchParams.get('selectedVideoId');
   const selectedVideoUrl = searchParams.get('selectedVideoUrl');
-  const onReturn = hooks.returnToGallery();
+  const onReturn = hooks.useReturnToGallery();
   hooks.initialize(dispatch, selectedVideoId, selectedVideoUrl);
   return (
     <VideoSettingsModal {...{


### PR DESCRIPTION
JIRA Ticket: [TNL-11505](https://2u-internal.atlassian.net/browse/TNL-11505)

> It was reported an issue regarding videos not populating the Video ID field when uploading a video via the video component. This issue results in the display of an error message stating, “No playable video source found,” due to the absence of the video ID in the designated field. A workaround for this video issue is to manually copy the video ID from the video block and paste it into the Video ID field.

Testing
1. Open a course.
2. Edit to the video component.
3. Click "Replace video"
4. Select the desired video for the unit.
5. The video will upload with the Video ID