### PR TITLE
fix: default setting not updating with updated default settings

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/hooks.test.js
@@ -1,4 +1,4 @@
-import { ProblemTypeKeys } from '../../../../data/constants/problem';
+import { ProblemTypeKeys, ShowAnswerTypesKeys } from '../../../../data/constants/problem';
 import * as hooks from './hooks';
 import { MockUseState } from '../../../../../testUtils';
 
@@ -7,26 +7,27 @@ const mockBuiltOLX = 'builtOLX';
 const mockGetSettings = {
   max_attempts: 1,
   weight: 2,
-  showanswer: 'finished',
+  showanswer: ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
   show_reset_button: false,
   rerandomize: 'never',
 };
 const mockParseRawOlxSettingsDiscrepancy = {
   max_attempts: 1,
   weight: 2,
-  showanswer: 'finished',
+  showanswer: ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
   show_reset_button: true,
   rerandomize: 'never',
 };
 const mockParseRawOlxSettings = {
   max_attempts: 1,
   weight: 2,
-  showanswer: 'finished',
+  showanswer: ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
   show_reset_button: false,
   rerandomize: 'never',
 };
 const problemState = {
   problemType: ProblemTypeKeys.ADVANCED,
+  defaultSettings: {},
   settings: {
     randomization: null,
     scoring: {
@@ -38,7 +39,7 @@ const problemState = {
     },
     timeBetween: 0,
     showAnswer: {
-      on: 'finished',
+      on: ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
       afterAttempts: 0,
     },
     showResetButton: false,
@@ -281,7 +282,7 @@ describe('EditProblemView hooks parseState', () => {
     const expectedSettings = {
       max_attempts: '',
       weight: 1,
-      showanswer: 'finished',
+      showanswer: ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
       show_reset_button: false,
       submission_wait_seconds: 0,
       attempts_before_showanswer_button: 0,
@@ -303,6 +304,34 @@ describe('EditProblemView hooks parseState', () => {
         settings: expectedSettings,
       });
     });
+
+    it('returned parseState content.settings should not include default values', () => {
+      const problem = {
+        ...problemState,
+        problemType: ProblemTypeKeys.NUMERIC,
+        answers: [{ id: 'A', title: 'problem', correct: true }],
+        defaultSettings: {
+          maxAttempts: '',
+          showanswer: ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
+          showResetButton: false,
+          rerandomize: 'never',
+        },
+      };
+      const { settings } = hooks.getContent({
+        isAdvancedProblemType: false,
+        problemState: problem,
+        editorRef,
+        assets,
+        lmsEndpointUrl,
+        openSaveWarningModal,
+      });
+      expect(settings).toEqual({
+        attempts_before_showanswer_button: 0,
+        submission_wait_seconds: 0,
+        weight: 1,
+      });
+    });
+
     it('default advanced save and returns parseState data', () => {
       const content = hooks.getContent({
         isAdvancedProblemType: true,

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
@@ -1,4 +1,9 @@
 import { XMLParser } from 'fast-xml-parser';
+import _ from 'lodash-es';
+
+import {
+  ShowAnswerTypesKeys,
+} from '../../../data/constants/problem';
 import { popuplateItem } from './SettingsParser';
 
 const SETTING_KEYS = [
@@ -17,23 +22,30 @@ class ReactStateSettingsParser {
 
   getSettings() {
     let settings = {};
+    const { defaultSettings } = this.problem;
     const stateSettings = this.problem.settings;
 
-    settings = popuplateItem(settings, 'number', 'max_attempts', stateSettings.scoring.attempts, true);
+    const numberOfAttemptsChoice = [
+      ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
+      ShowAnswerTypesKeys.AFTER_ALL_ATTEMPTS,
+      ShowAnswerTypesKeys.AFTER_ALL_ATTEMPTS_OR_CORRECT,
+    ];
+
+    settings = popuplateItem(settings, 'number', 'max_attempts', stateSettings.scoring.attempts, defaultSettings?.maxAttempts, true);
     settings = popuplateItem(settings, 'weight', 'weight', stateSettings.scoring);
-    settings = popuplateItem(settings, 'on', 'showanswer', stateSettings.showAnswer);
-    settings = popuplateItem(settings, 'afterAttempts', 'attempts_before_showanswer_button', stateSettings.showAnswer);
-    settings = popuplateItem(settings, 'showResetButton', 'show_reset_button', stateSettings);
+    settings = popuplateItem(settings, 'on', 'showanswer', stateSettings.showAnswer, defaultSettings?.showanswer);
+    if (_.includes(numberOfAttemptsChoice, stateSettings.showAnswer.on)) {
+      settings = popuplateItem(settings, 'afterAttempts', 'attempts_before_showanswer_button', stateSettings.showAnswer);
+    }
+    settings = popuplateItem(settings, 'showResetButton', 'show_reset_button', stateSettings, defaultSettings?.showResetButton);
     settings = popuplateItem(settings, 'timeBetween', 'submission_wait_seconds', stateSettings);
-    settings = popuplateItem(settings, 'randomization', 'rerandomize', stateSettings);
+    settings = popuplateItem(settings, 'randomization', 'rerandomize', stateSettings, defaultSettings?.rerandomize);
 
     return settings;
   }
 
   parseRawOlxSettings() {
     const rawOlxSettings = this.getSettings();
-    // console.log(rawOlxSettings);
-    // console.log(this.rawOLX);
     const parserOptions = {
       ignoreAttributes: false,
       alwaysCreateTextNode: true,

--- a/src/editors/containers/ProblemEditor/data/SettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/SettingsParser.js
@@ -2,10 +2,11 @@ import _ from 'lodash-es';
 
 import { ShowAnswerTypes, RandomizationTypesKeys } from '../../../data/constants/problem';
 
-export const popuplateItem = (parentObject, itemName, statekey, metadata, allowNull = false) => {
+export const popuplateItem = (parentObject, itemName, statekey, metadata, defaultValue = null, allowNull = false) => {
   let parent = parentObject;
   const item = _.get(metadata, itemName, null);
-  if (!_.isNil(item) || allowNull) {
+  const equalsDefault = item === defaultValue;
+  if ((!_.isNil(item) || allowNull) && !equalsDefault) {
     parent = { ...parentObject, [statekey]: item };
   }
   return parent;


### PR DESCRIPTION
JIRA Ticket: [TNL-10995](https://2u-internal.atlassian.net/browse/TNL-10995)

Description
Currently when a problem is saved with the default setting (focusing on max attempts, show answer, show reset button, and randomization). The current behavior assigns the default values to the block on save; however, this causes issues when a course author changes the default setting values. The author has to go back to all the blocks and manually update the blocks to the new default settings. This PR fixes this bug and does not save the default values to the block. The setting are only saved to the block if they differ from the default values. 

Testing

1. Create a Problem
2. Add content and leave settings untouched.
4. Go to the Advanced Settings page
5. Change the default maximum attempt settings
6. Go back to the problem you just created
7. Open the settings panels
8. Confirm that the maximum attempts setting matches the new value from the Advanced Settings page