### PR TITLE
fix: Not used Number of attempts field for "After all attempts" and "After all attempts or correct"

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -180,8 +180,6 @@ export const useAnswerSettings = (showAnswer, updateSettings) => {
 
   const numberOfAttemptsChoice = [
     ShowAnswerTypesKeys.AFTER_SOME_NUMBER_OF_ATTEMPTS,
-    ShowAnswerTypesKeys.AFTER_ALL_ATTEMPTS,
-    ShowAnswerTypesKeys.AFTER_ALL_ATTEMPTS_OR_CORRECT,
   ];
 
   useEffect(() => {


### PR DESCRIPTION
For legacy, the `Number of attempts` parameter does not affect `After all attempts` and `After all attempts` or correct.
Therefore, this field should not appear when these options are selected.
Even the name of these options contradicts the appearance of this field.

![atemp_1](https://github.com/openedx/frontend-lib-content-components/assets/98233552/4f8e7a88-5515-4804-88e8-2c5d7c1f480e)

Now the "**NUMBER OF ATTEMPTS**" field is available only for the "**AFTER SOME NUMBER OF ATTEMPTS**" option

<img width="2021" alt="attemp_2" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/8330c034-a25e-432f-915f-10e5620f2986">

<img width="2021" alt="attemp_3" src="https://github.com/openedx/frontend-lib-content-components/assets/98233552/25c0f7ac-2b8c-4b38-8bec-ca9989b5bf77">




