### PR TITLE
fix: HTML screen expands with content

### DIFF
--- a/src/editors/sharedComponents/SourceCodeModal/index.jsx
+++ b/src/editors/sharedComponents/SourceCodeModal/index.jsx
@@ -34,13 +34,12 @@ export const SourceCodeModal = ({
       isOpen={isOpen}
       title={intl.formatMessage(messages.titleLabel)}
     >
-      <div style={{ padding: '10px 30px', height: '300px' }}>
+      <div style={{ padding: '10px 30px' }}>
         <CodeEditor
           innerRef={ref}
           value={value}
         />
       </div>
-
     </BaseModal>
   );
 };


### PR DESCRIPTION
HTML screen in text editor would not expand vertically when there is more content. This PR lets HTML screen expand vertically when more text is entered.

Testing:
1. Edit/create a text editor block in studio.
2. Click the `HTML` button to popup the Edit Source Code window.
3. Enter new lines of text until the screen should scroll.
4. The window should expand vertically to hold the newly entered text.