### PR TITLE
fix: removal of content after problem type tags

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.test.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.test.js
@@ -27,6 +27,7 @@ import {
   solutionExplanationWithoutDivTest,
   tablesInRichTextTest,
   parseOutExplanationTests,
+  unexpectOlxAfterProblemTypeTags,
 } from './mockData/olxTestData';
 import { ProblemTypeKeys } from '../../../data/constants/problem';
 
@@ -87,7 +88,7 @@ describe('OLXParser', () => {
         }
       });
     });
-    describe('when multi select problem finds partial_credit attribute', () => {
+    describe('when numerical problem finds partial_credit attribute', () => {
       it('should throw error and contain message regarding opening advanced editor', () => {
         try {
           numericalProblemPartialCreditParser.getParsedOLXData();
@@ -97,13 +98,24 @@ describe('OLXParser', () => {
         }
       });
     });
-    describe('when multi select problem finds partial_credit attribute', () => {
+    describe('when single select problem finds partial_credit attribute', () => {
       it('should throw error and contain message regarding opening advanced editor', () => {
         try {
           singleSelectPartialCreditParser.getParsedOLXData();
         } catch (e) {
           expect(e).toBeInstanceOf(Error);
           expect(e.message).toBe('Partial credit not supported by GUI, reverting to Advanced Editor');
+        }
+      });
+    });
+    describe('when signle select problem has unexpected olx after multiplechoiceresponse tag', () => {
+      it('should throw error and contain message regarding opening advanced editor', () => {
+        const unexpectOlxAfterProblemTypeTagsParser = new OLXParser(unexpectOlxAfterProblemTypeTags.rawOLX);
+        try {
+          unexpectOlxAfterProblemTypeTagsParser.getParsedOLXData();
+        } catch (e) {
+          expect(e).toBeInstanceOf(Error);
+          expect(e.message).toBe('OLX found after the multiplechoiceresponse tags, opening in advanced editor');
         }
       });
     });

--- a/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
+++ b/src/editors/containers/ProblemEditor/data/mockData/olxTestData.js
@@ -1154,3 +1154,21 @@ export const numericalProblemPartialCredit = {
     </numericalresponse>
   </problem>`
 }
+
+export const unexpectOlxAfterProblemTypeTags = {
+  rawOLX: `<problem>
+    <multiplechoiceresponse>
+      <label>What Apple device competed with the portable CD player?</label>
+      <choicegroup type="MultipleChoice">
+        <choice correct="false">The iPad</choice>
+        <choice correct="false">Napster</choice>
+        <choice correct="true">The iPod</choice>
+      </choicegroup>
+    </multiplechoiceresponse>
+    <a href="#">Check out Apple's history for more information.</a>
+    <demandhint>
+      <hint><p>You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</p></hint>
+      <hint><p>If you add more than one hint, a different hint appears each time learners select the hint button.</p></hint>
+    </demandhint>
+  </problem>`
+}


### PR DESCRIPTION
JIRA Ticket: [TNL-10674](https://2u-internal.atlassian.net/browse/TNL-10674)
> Reporting that a pre-existing problem containing a linked image is missing when they go to edit the problem in the visual editor, and also missing if they switch to the advanced editor.

This PR fixes the intermittent problem where there is OLX after the problem type tags, (`multiplechoiceresponse`, `numericalresponse`, etc.) for simple problems. Currently the parser will some times put the OLX inside the question section; other times the parser will remove the OLX. When the OLX is removed, the user switches to the advanced editor expecting to see it, but it is not present. This PR updates the parser to check if there is OLX content after the problem type tags, and if found, redirect to the advanced editor. This change removes the possibility that previous OLX will be blindly removed and that content will be rearranged blindly.

Testing

1. Create a new  problem block
2. Choose one of the simple problem types
3. Add content to the problem
4. Click "Show advanced settings"
5. Click "Switch to advanced editor"
6. Before the closing problem tag (`</problem>`) add `<p>content after problem type tags</p>`
7. Click "Save"
8. Click "Edit" for the problem that you just created
9. Should automatically open the problem in the advanced editor
10. Remove `<p>content after problem type tags</p>`
11. Click "Save"
12. Click "Edit" for the problem that you just created
13. Should automatically open the problem in the visual editor