### PR TITLE
fix: answer range validation in Numerical input

### DIFF
--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -418,7 +418,7 @@ export class OLXParser {
         [type]: defaultValue,
       };
     }
-    const isAnswerRange = /[([]\d*,\d*[)\]]/gm.test(numericalresponse['@_answer']);
+    const isAnswerRange = /[([]\s*\d*,\s*\d*\s*[)\]]/gm.test(numericalresponse['@_answer']);
     answers.push({
       id: indexToLetterMap[answers.length],
       title: numericalresponse['@_answer'],


### PR DESCRIPTION
### Description
The regular expression for parsing isAnswerRange has been extended; it accepts the following response forms: `[1,10]`, `[1, 10]`, `[ 1,10 ]`, `[ 1, 10 ]`, `[1, 10 ] `, `[ 1, 10]`.

### Steps to reproduce
1) Go to studio -> unit -> problem -> Numerical input - check that Tolerance field is active
<img width="1233" alt="image" src="https://github.com/openedx/frontend-lib-content-components/assets/17108583/98cfd9d2-c403-4d04-88da-bf3a71140d9d">
2) In Answers block click on "+ Add answer" -> Add answer range - check that Tolerance field became inactive
<img width="1230" alt="image" src="https://github.com/openedx/frontend-lib-content-components/assets/17108583/fff00a73-13f5-4bfe-be65-76bfa3145c7c">
3) In answer range field fill in for example [1, 10] (space after comma is necessary), save changes
<img width="1223" alt="image" src="https://github.com/openedx/frontend-lib-content-components/assets/17108583/d0c8d9be-1e7f-471d-8aa3-864abc3b2cba">
4) Click on Edit for problem.

### Actual result
Tolerance became active, possible in "+ Add answer" click on Add answer
<img width="1230" alt="image" src="https://github.com/openedx/frontend-lib-content-components/assets/17108583/1837fb32-e4b1-4c62-b5de-8c30b52704d8">

### Expected result
Behaviour should be like when there's no space after comma in range
<img width="1219" alt="image" src="https://github.com/openedx/frontend-lib-content-components/assets/17108583/739d9b21-2afe-4e9d-a193-62f13a257c31">
