### PR TITLE
fix: license widget checkbox and link

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDetails.jsx
@@ -123,7 +123,7 @@ export const LicenseDetails = ({
                     </Form.Label>
                     <ActionRow.Spacer />
                     <CheckboxControl
-                      cchecked={details.shareAlike}
+                      checked={details.shareAlike}
                       disabled={level === LicenseLevel.course}
                       onChange={(e) => updateField({
                         licenseDetails: {

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDisplay.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/LicenseDisplay.jsx
@@ -28,13 +28,15 @@ export const LicenseDisplay = ({
           <LicenseBlurb license={license} details={details} />
           <div className="x-small mt-3">{licenseDescription}</div>
         </div>
-        <Hyperlink
-          className="text-primary-500 x-small"
-          destination="https://creativecommons.org/about"
-          target="_blank"
-        >
-          <FormattedMessage {...messages.viewLicenseDetailsLabel} />
-        </Hyperlink>
+        {license === LicenseTypes.creativeCommons && (
+          <Hyperlink
+            className="text-primary-500 x-small"
+            destination="https://creativecommons.org/about"
+            target="_blank"
+          >
+            <FormattedMessage {...messages.viewLicenseDetailsLabel} />
+          </Hyperlink>
+        )}
       </Stack>
     );
   }

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/LicenseDisplay.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/LicenseWidget/__snapshots__/LicenseDisplay.test.jsx.snap
@@ -26,17 +26,6 @@ exports[`LicenseDisplay snapshots snapshots: renders as expected with default pr
       FormattedMessage component with license description
     </div>
   </div>
-  <Hyperlink
-    className="text-primary-500 x-small"
-    destination="https://creativecommons.org/about"
-    target="_blank"
-  >
-    <FormattedMessage
-      defaultMessage="View license details"
-      description="Label for view license details button"
-      id="authoring.videoeditor.license.viewLicenseDetailsLabel.label"
-    />
-  </Hyperlink>
 </Stack>
 `;
 
@@ -66,17 +55,6 @@ exports[`LicenseDisplay snapshots snapshots: renders as expected with level set 
       FormattedMessage component with license description
     </div>
   </div>
-  <Hyperlink
-    className="text-primary-500 x-small"
-    destination="https://creativecommons.org/about"
-    target="_blank"
-  >
-    <FormattedMessage
-      defaultMessage="View license details"
-      description="Label for view license details button"
-      id="authoring.videoeditor.license.viewLicenseDetailsLabel.label"
-    />
-  </Hyperlink>
 </Stack>
 `;
 
@@ -148,16 +126,5 @@ exports[`LicenseDisplay snapshots snapshots: renders as expected with level set 
       FormattedMessage component with license description
     </div>
   </div>
-  <Hyperlink
-    className="text-primary-500 x-small"
-    destination="https://creativecommons.org/about"
-    target="_blank"
-  >
-    <FormattedMessage
-      defaultMessage="View license details"
-      description="Label for view license details button"
-      id="authoring.videoeditor.license.viewLicenseDetailsLabel.label"
-    />
-  </Hyperlink>
 </Stack>
 `;


### PR DESCRIPTION
### Description

- The "Share alike" checkbox now works correctly after selecting and saving it.
- The "View license details" link is only displayed for Creative Commons license type.

### Steps to reproduce

**Basic setup**
Go to `studio -> unit -> Video block -> scroll to the end of editors page and click on the "Add a license for this video" button`.

1. **"Share alike" issue:**

`basic setup -> in the "License type" field select "Creative Commons" -> Check Share alive (No derivatives unchecked) -> save -> open for edit again`

ACTUAL RESULT: Share Alike option is displayed as unchecked

<img width="1010" alt="share_alike_AC" src="https://github.com/openedx/frontend-lib-content-components/assets/40792129/8ec415a7-3d74-4131-8d1b-ae5bfab565a1"><br>

EXPECTED RESULT: Share Alike option is displayed as checked

<img width="1058" alt="License_widget_sharealike" src="https://github.com/openedx/frontend-lib-content-components/assets/40792129/d2fd5505-07eb-4d15-82b9-b11f462ef666"><br>


2. **"View license details link" issue:**

`basic setup -> in the "License type" field select "All Rights Reserved".`

ACTUAL RESULT: View license details with link to https://creativecommons.org/about/ is displayed below

EXPECTED RESULT: this link only displayed for Creative Commons license type

<img width="1050" alt="all_rights_reserved_no_link" src="https://github.com/openedx/frontend-lib-content-components/assets/40792129/39af700b-e3b3-4db6-a2b0-0dfcefd29cf1">
