### PR TITLE
fix: don't accidentally bundle paragon CSS x2

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.scss
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.scss
@@ -1,4 +1,7 @@
-@import "@openedx/paragon/scss/core/core";
+// do NOT @import "@openedx/paragon/scss/core/core"; in any files in this repo, or it will add 400 kB of extra CSS
+// to the MFE each time you do so. The following are OK because they are only defining variables like $grey-500:
+@import "@edx/brand/paragon/variables";
+@import "@openedx/paragon/scss/core/_variables";
 
 .total-label {
     border: 1px solid $gray-500;

--- a/src/editors/containers/VideoUploadEditor/index.scss
+++ b/src/editors/containers/VideoUploadEditor/index.scss
@@ -1,4 +1,7 @@
-@import "@openedx/paragon/scss/core/core";
+// do NOT @import "@openedx/paragon/scss/core/core"; in any files in this repo, or it will add 400 kB of extra CSS
+// to the MFE each time you do so. The following are OK because they are only defining variables like $grey-500:
+@import "@edx/brand/paragon/variables";
+@import "@openedx/paragon/scss/core/_variables";
 
 .dropzone-middle {
   border: 2px dashed #ccc;


### PR DESCRIPTION
This fixes a bug where 900 kB of redundant CSS was being accidentally built and included in any MFE that uses this.

I was working on the Course Authoring MFE and trying to remove _all_ SCSS from the bundle as part of some [experiments](https://github.com/openedx/frontend-build/pull/566) I was doing. But somehow there was still 900kB+ of CSS in the final bundle! After much head-scratching I finally traced it down to two lines of code buried deep in in this dependency, `frontend-lib-content-components`. Any time you write `@import "@openedx/paragon/scss/core/core";`, it adds a _full_ copy of the entire Paragon CSS to the build (around 400kB).

FYI @ArturGaspar @0x29a 

See https://github.com/openedx/frontend-app-learner-dashboard/issues/325 which is the same problem affecting `learner-dashboard` (but even worse).