### PR TITLE
fix: image and paste insert

### DIFF
--- a/src/editors/sharedComponents/ImageUploadModal/index.jsx
+++ b/src/editors/sharedComponents/ImageUploadModal/index.jsx
@@ -87,6 +87,7 @@ export const hooks = {
     updateReactState({ settings, ...args });
 
     close();
+    args.setSelection(null);
   },
   onClose: ({ clearSelection, close }) => () => {
     clearSelection();
@@ -130,7 +131,7 @@ export const ImageUploadModal = ({
       <ImageSettingsModal
         {...{
           isOpen,
-          close: module.hooks.onClose({ editorRef, clearSelection, close }),
+          close: module.hooks.onClose({ clearSelection, close }),
           selection,
           images,
           saveToEditor: module.hooks.createSaveCallback({
@@ -141,6 +142,7 @@ export const ImageUploadModal = ({
             selection,
             setSelection,
             lmsEndpointUrl,
+            clearSelection,
           }),
           returnToSelection: clearSelection,
         }}

--- a/src/editors/sharedComponents/ImageUploadModal/index.test.jsx
+++ b/src/editors/sharedComponents/ImageUploadModal/index.test.jsx
@@ -128,6 +128,7 @@ describe('ImageUploadModal', () => {
           expect(updateImageDimensionsSpy.mock.results[0].value.foundMatch).toBe(false);
           expect(images.current).toEqual([mockImage, newImage]);
           expect(close).toBeCalled();
+          expect(setSelection).toBeCalledWith(null);
         },
       );
     });

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
@@ -182,17 +182,17 @@ describe('TinyMceEditor hooks', () => {
     });
 
     describe('replaceStaticWithAsset', () => {
-      const initialContent = '<img src="/static/soMEImagEURl1.jpeg"/><a href="/assets/v1/some-key/test.pdf">test</a>';
-      const learningContextId = 'course+test+run';
+      const initialContent = '<img src="/static/soMEImagEURl1.jpeg"/><a href="/assets/v1/some-key/test.pdf">test</a><img src="/asset-v1:org+test+run+type@asset+block@correct.png" />';
+      const learningContextId = 'course-v1:org+test+run';
       const lmsEndpointUrl = 'sOmEvaLue.cOm';
-      it('it returns updated src for text editor to update content', () => {
-        const expected = '<img src="/asset+test+run+type@asset+block@soMEImagEURl1.jpeg"/><a href="/asset+test+run+type@asset+block@test.pdf">test</a>';
+      it('returns updated src for text editor to update content', () => {
+        const expected = '<img src="/asset-v1:org+test+run+type@asset+block@soMEImagEURl1.jpeg"/><a href="/asset-v1:org+test+run+type@asset+block@test.pdf">test</a><img src="/asset-v1:org+test+run+type@asset+block@correct.png" />';
         const actual = module.replaceStaticWithAsset({ initialContent, learningContextId });
         expect(actual).toEqual(expected);
       });
-      it('it returs updated src with absolute url for expandable editor to update content', () => {
+      it('returns updated src with absolute url for expandable editor to update content', () => {
         const editorType = 'expandable';
-        const expected = `<img src="${lmsEndpointUrl}/asset+test+run+type@asset+block@soMEImagEURl1.jpeg"/><a href="${lmsEndpointUrl}/asset+test+run+type@asset+block@test.pdf">test</a>`;
+        const expected = `<img src="${lmsEndpointUrl}/asset-v1:org+test+run+type@asset+block@soMEImagEURl1.jpeg"/><a href="${lmsEndpointUrl}/asset-v1:org+test+run+type@asset+block@test.pdf">test</a><img src="${lmsEndpointUrl}/asset-v1:org+test+run+type@asset+block@correct.png" />`;
         const actual = module.replaceStaticWithAsset({
           initialContent,
           editorType,
@@ -200,6 +200,11 @@ describe('TinyMceEditor hooks', () => {
           learningContextId,
         });
         expect(actual).toEqual(expected);
+      });
+      it('returns false when there are no srcs to update', () => {
+        const content = '<div>Hello world!</div>';
+        const actual = module.replaceStaticWithAsset({ initialContent: content, learningContextId });
+        expect(actual).toBeFalsy();
       });
     });
     describe('setAssetToStaticUrl', () => {


### PR DESCRIPTION
## Description

This PR fixes a bug introduced in #480 where content that is inserted like pasting and adding images always inserted it at the beginning of the block, not where the cursor was last placed. This bug appeared because the content was updated before the insert happened so the cursor was moved to the beginning of the block for the new content. This PR fixes the update function to only update the content when the content is actually changed, not on every editor click.

## Supporting Information
JIRA Ticket: [TNL-11663](https://2u-internal.atlassian.net/browse/TNL-11663) 🔒 

## Testing

1. Open a tab for each page that uses the visual editors
   - text editor
   - problem editor
   - course updates
2. Copy and paste text into various parts of the editor
   - in the middle of a sentence
   - end of block
   - highlight and replace
3. Add an image
   - in the middle of a sentence
   - end of block
   - highlight and replace
4. Confirm that each of these additions add content i the expected location
