### PR TITLE
fix: remove deprecated feedback link

### DIFF
--- a/src/editors/containers/EditorContainer/components/EditorFooter/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/EditorContainer/components/EditorFooter/__snapshots__/index.test.jsx.snap
@@ -8,43 +8,6 @@ exports[`EditorFooter render snapshot: default args (disableSave: false, saveFai
     className="shadow-sm"
   >
     <ActionRow>
-      <ActionRow.Spacer />
-      <Button
-        aria-label="Discard changes and return to learning context"
-        onClick={[MockFunction args.onCancel]}
-        variant="tertiary"
-      >
-        <FormattedMessage
-          defaultMessage="Cancel"
-          description="Label for cancel button"
-          id="authoring.editorfooter.cancelButton.label"
-        />
-      </Button>
-      <Button
-        aria-label="Save changes and return to learning context"
-        disabled={false}
-        onClick={[MockFunction args.onSave]}
-      >
-        <FormattedMessage
-          defaultMessage="Save"
-          description="Label for Save button"
-          id="authoring.editorfooter.savebutton.label"
-        />
-      </Button>
-    </ActionRow>
-  </ModalDialog.Footer>
-</div>
-`;
-
-exports[`EditorFooter render snapshot: dont show feedback link 1`] = `
-<div
-  className="editor-footer fixed-bottom"
->
-  <ModalDialog.Footer
-    className="shadow-sm"
-  >
-    <ActionRow>
-      <ActionRow.Spacer />
       <Button
         aria-label="Discard changes and return to learning context"
         onClick={[MockFunction args.onCancel]}
@@ -80,7 +43,6 @@ exports[`EditorFooter render snapshot: save disabled. Show button spinner 1`] = 
     className="shadow-sm"
   >
     <ActionRow>
-      <ActionRow.Spacer />
       <Button
         aria-label="Discard changes and return to learning context"
         onClick={[MockFunction args.onCancel]}
@@ -124,49 +86,6 @@ exports[`EditorFooter render snapshot: save failed.  Show error message 1`] = `
     className="shadow-sm"
   >
     <ActionRow>
-      <ActionRow.Spacer />
-      <Button
-        aria-label="Discard changes and return to learning context"
-        onClick={[MockFunction args.onCancel]}
-        variant="tertiary"
-      >
-        <FormattedMessage
-          defaultMessage="Cancel"
-          description="Label for cancel button"
-          id="authoring.editorfooter.cancelButton.label"
-        />
-      </Button>
-      <Button
-        aria-label="Save changes and return to learning context"
-        disabled={false}
-        onClick={[MockFunction args.onSave]}
-      >
-        <FormattedMessage
-          defaultMessage="Save"
-          description="Label for Save button"
-          id="authoring.editorfooter.savebutton.label"
-        />
-      </Button>
-    </ActionRow>
-  </ModalDialog.Footer>
-</div>
-`;
-
-exports[`EditorFooter render snapshot: show feedback link 1`] = `
-<div
-  className="editor-footer fixed-bottom"
->
-  <ModalDialog.Footer
-    className="shadow-sm"
-  >
-    <ActionRow>
-      <Hyperlink
-        destination="https://docs.google.com/forms/d/e/1FAIpQLSdmtO5at9WWHLcWLrOgk1oMz97gYYYrUq4cvH8Vzd-WQwM0Cg/viewform?usp=sharing"
-        target="_blank"
-      >
-        Share Feedback
-      </Hyperlink>
-      <ActionRow.Spacer />
       <Button
         aria-label="Discard changes and return to learning context"
         onClick={[MockFunction args.onCancel]}

--- a/src/editors/containers/EditorContainer/components/EditorFooter/index.jsx
+++ b/src/editors/containers/EditorContainer/components/EditorFooter/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import {
@@ -8,11 +7,8 @@ import {
   Button,
   ModalDialog,
   Toast,
-  Hyperlink,
 } from '@openedx/paragon';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { selectors } from '../../../../data/redux';
-import { blockTypes } from '../../../../data/constants/app';
 
 import messages from './messages';
 
@@ -24,50 +20,36 @@ export const EditorFooter = ({
   saveFailed,
   // injected
   intl,
-}) => {
-  const blockType = useSelector(selectors.app.blockType);
+}) => (
+  <div className="editor-footer fixed-bottom">
+    {saveFailed && (
+      <Toast show onClose={clearSaveFailed}>
+        <FormattedMessage {...messages.contentSaveFailed} />
+      </Toast>
+    )}
+    <ModalDialog.Footer className="shadow-sm">
+      <ActionRow>
+        <Button
+          aria-label={intl.formatMessage(messages.cancelButtonAriaLabel)}
+          variant="tertiary"
+          onClick={onCancel}
+        >
+          <FormattedMessage {...messages.cancelButtonLabel} />
+        </Button>
+        <Button
+          aria-label={intl.formatMessage(messages.saveButtonAriaLabel)}
+          onClick={onSave}
+          disabled={disableSave}
+        >
+          {disableSave
+            ? <Spinner animation="border" className="mr-3" />
+            : <FormattedMessage {...messages.saveButtonLabel} />}
+        </Button>
+      </ActionRow>
+    </ModalDialog.Footer>
+  </div>
+);
 
-  return (
-    <div className="editor-footer fixed-bottom">
-      {saveFailed && (
-        <Toast show onClose={clearSaveFailed}>
-          <FormattedMessage {...messages.contentSaveFailed} />
-        </Toast>
-      )}
-
-      <ModalDialog.Footer className="shadow-sm">
-        <ActionRow>
-          {
-        // TODO: Remove this code when the problem Editor Beta is complete.
-        blockType === blockTypes.problem
-          && (
-          <Hyperlink destination="https://docs.google.com/forms/d/e/1FAIpQLSdmtO5at9WWHLcWLrOgk1oMz97gYYYrUq4cvH8Vzd-WQwM0Cg/viewform?usp=sharing" target="_blank">
-            Share Feedback
-          </Hyperlink>
-          )
-        }
-          <ActionRow.Spacer />
-          <Button
-            aria-label={intl.formatMessage(messages.cancelButtonAriaLabel)}
-            variant="tertiary"
-            onClick={onCancel}
-          >
-            <FormattedMessage {...messages.cancelButtonLabel} />
-          </Button>
-          <Button
-            aria-label={intl.formatMessage(messages.saveButtonAriaLabel)}
-            onClick={onSave}
-            disabled={disableSave}
-          >
-            {disableSave
-              ? <Spinner animation="border" className="mr-3" />
-              : <FormattedMessage {...messages.saveButtonLabel} />}
-          </Button>
-        </ActionRow>
-      </ModalDialog.Footer>
-    </div>
-  );
-};
 EditorFooter.propTypes = {
   clearSaveFailed: PropTypes.func.isRequired,
   disableSave: PropTypes.bool.isRequired,

--- a/src/editors/containers/EditorContainer/components/EditorFooter/index.test.jsx
+++ b/src/editors/containers/EditorContainer/components/EditorFooter/index.test.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import { shallow } from '@edx/react-unit-test-utils';
 
-import { useSelector } from 'react-redux';
 import { formatMessage } from '../../../../../testUtils';
 import { EditorFooter } from '.';
 
 jest.mock('../../hooks', () => ({
   nullMethod: jest.fn().mockName('hooks.nullMethod'),
-}));
-
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
 }));
 
 describe('EditorFooter', () => {
@@ -25,20 +20,13 @@ describe('EditorFooter', () => {
     test('snapshot: default args (disableSave: false, saveFailed: false)', () => {
       expect(shallow(<EditorFooter {...props} />).snapshot).toMatchSnapshot();
     });
+
     test('snapshot: save disabled. Show button spinner', () => {
       expect(shallow(<EditorFooter {...props} disableSave />).snapshot).toMatchSnapshot();
     });
+
     test('snapshot: save failed.  Show error message', () => {
       expect(shallow(<EditorFooter {...props} saveFailed />).snapshot).toMatchSnapshot();
-    });
-
-    test('snapshot: show feedback link', () => {
-      useSelector.mockReturnValueOnce('problem');
-      expect(shallow(<EditorFooter {...props} />).snapshot).toMatchSnapshot();
-    });
-    test('snapshot: dont show feedback link', () => {
-      useSelector.mockReturnValueOnce('not a Problem');
-      expect(shallow(<EditorFooter {...props} />).snapshot).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
## Description

This PR removes a deprecated feedback form that was used specifically for 2U beta testing.

## Supporting Information

Github Issue #476 

## Testing

1. Open an existing problem block
2. Confirm that the "Share feedback" link is no longer present
