### PR TITLE
fix: correct typo in Alert component prop

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/index.jsx
@@ -61,7 +61,7 @@ export const ToleranceCard = ({
       { isAnswerRange
        && (
        <Alert
-         varaint="info"
+         variant="info"
        >
          <FormattedMessage {...messages.toleranceAnswerRangeWarning} />
        </Alert>


### PR DESCRIPTION
Corrected the typo in the prop name of the Alert component from 'varaint' to 'variant'. This change ensures the proper functioning of the alert in informational variant.