### PR TITLE
feat: add conditional for new parser beta testing

### DIFF
--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.js
@@ -37,6 +37,7 @@ export const onSelect = ({
         attempts_before_showanswer_button: 0,
         show_reset_button: null,
         showanswer: null,
+        defaultToAdvanced: false,
       },
       defaultSettings: snakeCaseKeys(defaultSettings),
     });

--- a/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/SelectTypeModal/hooks.test.js
@@ -78,6 +78,7 @@ describe('SelectTypeModal hooks', () => {
           attempts_before_showanswer_button: 0,
           show_reset_button: null,
           showanswer: null,
+          defaultToAdvanced: false,
         },
         defaultSettings: mockDefaultSettings,
       });

--- a/src/editors/containers/ProblemEditor/data/OLXParser.js
+++ b/src/editors/containers/ProblemEditor/data/OLXParser.js
@@ -738,4 +738,13 @@ export class OLXParser {
       groupFeedbackList,
     };
   }
+
+  getBetaParsedOLXData() {
+    /* TODO: Replace olxParser.getParsedOLXData() with new parser function
+    * and remove console.log()
+    */
+    // eslint-disable-next-line no-console
+    console.log('Should default to the advanced editor');
+    return this.getParsedOLXData();
+  }
 }

--- a/src/editors/data/redux/thunkActions/problem.js
+++ b/src/editors/data/redux/thunkActions/problem.js
@@ -28,9 +28,14 @@ export const isBlankProblem = ({ rawOLX }) => {
 export const getDataFromOlx = ({ rawOLX, rawSettings, defaultSettings }) => {
   let olxParser;
   let parsedProblem;
+  const { default_to_advanced: defaultToAdvanced } = rawSettings;
   try {
     olxParser = new OLXParser(rawOLX);
-    parsedProblem = olxParser.getParsedOLXData();
+    if (defaultToAdvanced) {
+      parsedProblem = olxParser.getBetaParsedOLXData();
+    } else {
+      parsedProblem = olxParser.getParsedOLXData();
+    }
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('The Problem Could Not Be Parsed from OLX. redirecting to Advanced editor.', error);


### PR DESCRIPTION
## Description

This PR sets up future work for a new OLX parser. Since releasing the react based problem editor, there have been various bugs that come from the OLX parser not catching all the nuanced tags. Currently the default experience for the editor is the visual (TinyMCE) editor. The problem is navigated to the advanced editor if it uses an advanced problem tags, has multiple questions in a problem, and a non-default tag or attribute is found. This approach requires updates to the problem editor parser each time a new tag or attribute is brought to the developers attention so that the content that it is referencing is not lost by accidentally rendering the wrong editor. To simply the need for constant updates for new tags or attributes, the new OLX parser will have a specific list of tags and attributes that are allowed in the visual editor. The array of supported tags and attributes will generated from the Read The Docs site. If there is a tag or attribute that is not in the supported list the advanced problem editor will be displayed to ensure that no OLX was lost when between the last save and opening of the problem.

To confirm the new parser is an improvement, we need a conditional statement based on waffle flag that will control which users will have the problem editor with the new parser or the current parser. This change impacts "Authors" and "Developers".

## Supporting information

JIRA Tickets: [TNL-11667 🔒](https://2u-internal.atlassian.net/browse/TNL-11667) and [TNL-11694 🔒](https://2u-internal.atlassian.net/browse/TNL-11694)

## Testing instructions

1. Open a course
2. Create a new problem block
3. Confirm that the problem can be opened and edited
4. Save the problem
5. Reopen the problem
6. Confirm that the problem can be opened and edited

## Deadline

None

## Other information

This PR is dependent of `edx-platform` PR #[35184](https://github.com/openedx/edx-platform/pull/35184)
