### PR TITLE
fix: setAssetToStaticUrl regex matcher

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -405,9 +405,9 @@ export const setAssetToStaticUrl = ({ editorValue, lmsEndpointUrl }) => {
   const assetSrcs = typeof content === 'string' ? content.split(/(src="|src=&quot;|href="|href=&quot)/g) : [];
   assetSrcs.filter(src => src.startsWith('/asset')).forEach(src => {
     let nameFromEditorSrc;
-    if (src.match(/\/assets\/.+\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\//)?.length >= 1) {
+    if (src.match(/\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\/\w/)?.length >= 1) {
       const assetBlockName = src.substring(0, src.search(/("|&quot;)/));
-      const dividedSrc = assetBlockName.split(/\/assets\/.+\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\//);
+      const dividedSrc = assetBlockName.split(/\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\//);
       [, nameFromEditorSrc] = dividedSrc;
     } else {
       const assetBlockName = src.substring(src.indexOf('@') + 1, src.search(/("|&quot;)/));

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
@@ -63,6 +63,7 @@ const mockEditorContentHtml = `
     </img>
   </p>
 `;
+const baseAssetUrl = 'asset-v1:org+test+run+type@asset+block';
 
 const mockImagesRef = { current: [mockImage] };
 
@@ -182,17 +183,17 @@ describe('TinyMceEditor hooks', () => {
     });
 
     describe('replaceStaticWithAsset', () => {
-      const initialContent = '<img src="/static/soMEImagEURl1.jpeg"/><a href="/assets/v1/some-key/test.pdf">test</a><img src="/asset-v1:org+test+run+type@asset+block@correct.png" />';
+      const initialContent = `<img src="/static/soMEImagEURl1.jpeg"/><a href="/assets/v1/${baseAssetUrl}/test.pdf">test</a><img src="/${baseAssetUrl}@correct.png" />`;
       const learningContextId = 'course-v1:org+test+run';
       const lmsEndpointUrl = 'sOmEvaLue.cOm';
       it('returns updated src for text editor to update content', () => {
-        const expected = '<img src="/asset-v1:org+test+run+type@asset+block@soMEImagEURl1.jpeg"/><a href="/asset-v1:org+test+run+type@asset+block@test.pdf">test</a><img src="/asset-v1:org+test+run+type@asset+block@correct.png" />';
+        const expected = `<img src="/${baseAssetUrl}@soMEImagEURl1.jpeg"/><a href="/${baseAssetUrl}@test.pdf">test</a><img src="/${baseAssetUrl}@correct.png" />`;
         const actual = module.replaceStaticWithAsset({ initialContent, learningContextId });
         expect(actual).toEqual(expected);
       });
       it('returns updated src with absolute url for expandable editor to update content', () => {
         const editorType = 'expandable';
-        const expected = `<img src="${lmsEndpointUrl}/asset-v1:org+test+run+type@asset+block@soMEImagEURl1.jpeg"/><a href="${lmsEndpointUrl}/asset-v1:org+test+run+type@asset+block@test.pdf">test</a><img src="${lmsEndpointUrl}/asset-v1:org+test+run+type@asset+block@correct.png" />`;
+        const expected = `<img src="${lmsEndpointUrl}/${baseAssetUrl}@soMEImagEURl1.jpeg"/><a href="${lmsEndpointUrl}/${baseAssetUrl}@test.pdf">test</a><img src="${lmsEndpointUrl}/${baseAssetUrl}@correct.png" />`;
         const actual = module.replaceStaticWithAsset({
           initialContent,
           editorType,
@@ -209,7 +210,7 @@ describe('TinyMceEditor hooks', () => {
     });
     describe('setAssetToStaticUrl', () => {
       it('returns content with updated img links', () => {
-        const editorValue = '<img src="/asset@/soME_ImagE_URl1"/> <a href="/asset@soMEImagEURl">testing link</a>';
+        const editorValue = `<img src="/${baseAssetUrl}/soME_ImagE_URl1"/> <a href="/${baseAssetUrl}@soMEImagEURl">testing link</a>`;
         const lmsEndpointUrl = 'sOmEvaLue.cOm';
         const content = module.setAssetToStaticUrl({ editorValue, lmsEndpointUrl });
         expect(content).toEqual('<img src="/static/soME_ImagE_URl1"/> <a href="/static/soMEImagEURl">testing link</a>');


### PR DESCRIPTION
## Description

This PR fixes the error of relative asset urls incorrectly rewriting the conversion to the static url.  The regex matcher was catching all relative asset url formats:

- `/assets/courseware/v1/hash/asset-v1:org+num+run+type@asset+block/image.jpeg`
- `/asset-v1:org+num+run+type@asset+block@image.jpeg`
- `/asset-v1:org+num+run+type@asset+block/image.jpeg`

This resulted in the first two version rewriting correctly as `/static/image.jpeg` and the third rewriting incorrectly as `/static/assetblockimage.jpeg`.

## Testing

1. Open a raw editor
2. Add an image with a static link
3. Save the block
4. Using browser dev tools, copy the link for the image
5. Reopen the block
6. Confirm that the static is unaltered
7. Paste the previously copied image
8. Add images using the second and third bullet points' format from above
9. Save the block
10. Confirm that the newly added images are visible
11. Reopen the block
12. Confirm that all the links appear as static links and their names appear correctly
13. Save block
14. Confirm that all images are still visible

Repeat the steps in the text editor and advanced problem editor. Also, test opening and save existing content for regular problem editor.