### PR TITLE
fix: remove imports breaking build

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.scss
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/DurationWidget/index.scss
@@ -1,8 +1,3 @@
-// do NOT @import "@openedx/paragon/scss/core/core"; in any files in this repo, or it will add 400 kB of extra CSS
-// to the MFE each time you do so. The following are OK because they are only defining variables like $grey-500:
-@import "@edx/brand/paragon/variables";
-@import "@openedx/paragon/scss/core/_variables";
-
 .total-label {
-    border: 1px solid $gray-500;
+    border: 1px solid #707070;
 }

--- a/src/editors/containers/VideoUploadEditor/index.scss
+++ b/src/editors/containers/VideoUploadEditor/index.scss
@@ -1,8 +1,3 @@
-// do NOT @import "@openedx/paragon/scss/core/core"; in any files in this repo, or it will add 400 kB of extra CSS
-// to the MFE each time you do so. The following are OK because they are only defining variables like $grey-500:
-@import "@edx/brand/paragon/variables";
-@import "@openedx/paragon/scss/core/_variables";
-
 .dropzone-middle {
   border: 2px dashed #ccc;
 
@@ -34,7 +29,7 @@
     &, &:active, &:hover {
       background-color: transparent !important;
       border: none !important;
-      color: $gray-500 !important;
+      color: #707070 !important;
     }
   }
 


### PR DESCRIPTION
This PR removes paragon scss variable imports from `.scss` files. These imports break the build of the course authoring MFE because of a `ModuleErrorBuild`. The only variable used is `$gray-500` and the hex code for the variable is the same in the openedX and edX themes, `#707070`, so replacement will have no affect on the UI