### PR TITLE
fix: asset name parsing in static converter

### DIFF
--- a/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.test.js
@@ -183,17 +183,17 @@ describe('TinyMceEditor hooks', () => {
     });
 
     describe('replaceStaticWithAsset', () => {
-      const initialContent = `<img src="/static/soMEImagEURl1.jpeg"/><a href="/assets/v1/${baseAssetUrl}/test.pdf">test</a><img src="/${baseAssetUrl}@correct.png" />`;
+      const initialContent = `<img src="/static/soMEImagEURl1.jpeg"/><a href="/assets/v1/${baseAssetUrl}/test.pdf">test</a><img src="/${baseAssetUrl}@correct.png" /><img src="/${baseAssetUrl}/correct.png" />`;
       const learningContextId = 'course-v1:org+test+run';
       const lmsEndpointUrl = 'sOmEvaLue.cOm';
       it('returns updated src for text editor to update content', () => {
-        const expected = `<img src="/${baseAssetUrl}@soMEImagEURl1.jpeg"/><a href="/${baseAssetUrl}@test.pdf">test</a><img src="/${baseAssetUrl}@correct.png" />`;
+        const expected = `<img src="/${baseAssetUrl}@soMEImagEURl1.jpeg"/><a href="/${baseAssetUrl}@test.pdf">test</a><img src="/${baseAssetUrl}@correct.png" /><img src="/${baseAssetUrl}@correct.png" />`;
         const actual = module.replaceStaticWithAsset({ initialContent, learningContextId });
         expect(actual).toEqual(expected);
       });
       it('returns updated src with absolute url for expandable editor to update content', () => {
         const editorType = 'expandable';
-        const expected = `<img src="${lmsEndpointUrl}/${baseAssetUrl}@soMEImagEURl1.jpeg"/><a href="${lmsEndpointUrl}/${baseAssetUrl}@test.pdf">test</a><img src="${lmsEndpointUrl}/${baseAssetUrl}@correct.png" />`;
+        const expected = `<img src="${lmsEndpointUrl}/${baseAssetUrl}@soMEImagEURl1.jpeg"/><a href="${lmsEndpointUrl}/${baseAssetUrl}@test.pdf">test</a><img src="${lmsEndpointUrl}/${baseAssetUrl}@correct.png" /><img src="${lmsEndpointUrl}/${baseAssetUrl}@correct.png" />`;
         const actual = module.replaceStaticWithAsset({
           initialContent,
           editorType,

--- a/src/editors/sharedComponents/TinyMceWidget/utils.js
+++ b/src/editors/sharedComponents/TinyMceWidget/utils.js
@@ -13,3 +13,16 @@ export const getRelativeUrl = ({ courseId, displayName }) => {
   }
   return '';
 };
+
+export const parseAssetName = (relativeUrl) => {
+  let assetName = '';
+  if (relativeUrl.match(/\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\/\w/)?.length >= 1) {
+    const assetBlockName = relativeUrl.substring(0, relativeUrl.search(/("|&quot;)/));
+    const dividedSrc = assetBlockName.split(/\/asset-v1:\S+[+]\S+[@]\S+[+]\S+\//);
+    [, assetName] = dividedSrc;
+  } else {
+    const assetBlockName = relativeUrl.substring(relativeUrl.indexOf('@') + 1, relativeUrl.search(/("|&quot;)/));
+    assetName = assetBlockName.substring(assetBlockName.indexOf('@') + 1);
+  }
+  return assetName;
+};


### PR DESCRIPTION
## Description

This PR fixes images not loading in the visual text and problem editor. When assets were loaded with `asset-v1:org+number+run+type@asset+block/image_name.png` asset format, it would incorrectly parse to `asset-v1:org+number+run+type@asset+block/asset-v1:org+number+run+type@asset+block@image_name.png`. A similar issue was fixed in #497. The same src parser is now used for `replaceStaticWithAsset` as was added for `setAssetToStaticUrl`.

## Testing

1. Open an html block
2. Add an image
3. Click the "HTML" button in the toolbar
4. Replace the second "@" with "/"
5. Click "Save"
6. Confirm that the image is still visible