### PR TITLE
refactor: remove thumbnail for non-edX videos & allow removing fallback URLs

### DIFF
--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/__snapshots__/index.test.jsx.snap
@@ -1,46 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ThumbnailWidget snapshots snapshots: renders as expected where thumbnail uploads are allowed 1`] = `
-<injectIntl(ShimmedIntlComponent)
-  fontSize="x-small"
-  isError={true}
-  subtitle="Unavailable"
-  title="Thumbnail"
->
-  <ErrorAlert
-    dismissError={[Function]}
-    hideHeading={true}
-    isError={false}
-  >
-    <FormattedMessage
-      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again."
-      description=" Message presented to user when file size of image is less than 2 KB or larger than 2 MB"
-      id="authoring.videoeditor.thumbnail.error.fileSizeError"
-    />
-  </ErrorAlert>
-  <Alert
-    variant="light"
-  >
-    <FormattedMessage
-      defaultMessage="Select a video from your library to enable this feature (applies only to courses that run on the edx.org site)."
-      description="Message for unavailable thumbnail widget"
-      id="authoring.videoeditor.thumbnail.unavailable.message"
-    />
-  </Alert>
-  <Stack
-    direction="horizontal"
-    gap={3}
-  >
-    <Image
-      alt="Image used as thumbnail for video"
-      className="w-75"
-      fluid={true}
-      src="sOMeUrl"
-      thumbnail={true}
-    />
-  </Stack>
-</injectIntl(ShimmedIntlComponent)>
-`;
+exports[`ThumbnailWidget snapshots snapshots: renders as expected where thumbnail uploads are allowed 1`] = `null`;
 
 exports[`ThumbnailWidget snapshots snapshots: renders as expected where videoId is valid 1`] = `
 <injectIntl(ShimmedIntlComponent)
@@ -123,10 +83,10 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected where videoId 
     <FileInput
       acceptedFiles=".gif,.jpg,.jpeg,.png,.bmp,.bmp2"
       fileInput={
-        {
+        Object {
           "addFile": [Function],
           "click": [Function],
-          "ref": {
+          "ref": Object {
             "current": undefined,
           },
         }
@@ -191,81 +151,6 @@ exports[`ThumbnailWidget snapshots snapshots: renders as expected with a thumbna
 </injectIntl(ShimmedIntlComponent)>
 `;
 
-exports[`ThumbnailWidget snapshots snapshots: renders as expected with default props 1`] = `
-<injectIntl(ShimmedIntlComponent)
-  fontSize="x-small"
-  isError={true}
-  subtitle="Unavailable"
-  title="Thumbnail"
->
-  <ErrorAlert
-    dismissError={[Function]}
-    hideHeading={true}
-    isError={false}
-  >
-    <FormattedMessage
-      defaultMessage="The file size for thumbnails must be larger than 2 KB or less than 2 MB. Please resize your image and try again."
-      description=" Message presented to user when file size of image is less than 2 KB or larger than 2 MB"
-      id="authoring.videoeditor.thumbnail.error.fileSizeError"
-    />
-  </ErrorAlert>
-  <Alert
-    variant="light"
-  >
-    <FormattedMessage
-      defaultMessage="Select a video from your library to enable this feature (applies only to courses that run on the edx.org site)."
-      description="Message for unavailable thumbnail widget"
-      id="authoring.videoeditor.thumbnail.unavailable.message"
-    />
-  </Alert>
-  <Stack
-    gap={4}
-  >
-    <div
-      className="text-center"
-    >
-      <FormattedMessage
-        defaultMessage="Upload an image for learners to see before playing the video."
-        description="Message for adding thumbnail"
-        id="authoring.videoeditor.thumbnail.upload.message"
-      />
-      <div
-        className="text-primary-300"
-      >
-        <FormattedMessage
-          defaultMessage="Images must have an aspect ratio of 16:9 (1280x720 px recommended)"
-          description="Message for thumbnail aspectRequirements"
-          id="authoring.videoeditor.thumbnail.upload.aspectRequirements"
-        />
-      </div>
-    </div>
-    <FileInput
-      acceptedFiles=".gif,.jpg,.jpeg,.png,.bmp,.bmp2"
-      fileInput={
-        {
-          "addFile": [Function],
-          "click": [Function],
-          "ref": {
-            "current": undefined,
-          },
-        }
-      }
-    />
-    <Button
-      className="text-primary-500 font-weight-bold justify-content-start pl-0"
-      disabled={true}
-      onClick={[Function]}
-      size="sm"
-      variant="link"
-    >
-      <FormattedMessage
-        defaultMessage="Upload thumbnail"
-        description="Label for upload button"
-        id="authoring.videoeditor.thumbnail.upload.label"
-      />
-    </Button>
-  </Stack>
-</injectIntl(ShimmedIntlComponent)>
-`;
+exports[`ThumbnailWidget snapshots snapshots: renders as expected with default props 1`] = `null`;
 
 exports[`ThumbnailWidget snapshots snapshots: renders as expected with isLibrary true 1`] = `null`;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/ThumbnailWidget/index.jsx
@@ -61,7 +61,7 @@ export const ThumbnailWidget = ({
     }
     return intl.formatMessage(messages.unavailableSubtitle);
   };
-  return (!isLibrary ? (
+  return (!isLibrary && edxVideo ? (
     <CollapsibleFormWidget
       fontSize="x-small"
       isError={Object.keys(error).length !== 0}
@@ -75,7 +75,7 @@ export const ThumbnailWidget = ({
       >
         <FormattedMessage {...messages.fileSizeError} />
       </ErrorAlert>
-      {(allowThumbnailUpload && edxVideo) ? null : (
+      {allowThumbnailUpload ? null : (
         <Alert variant="light">
           <FormattedMessage {...messages.unavailableMessage} />
         </Alert>
@@ -90,7 +90,7 @@ export const ThumbnailWidget = ({
             src={thumbnailSrc || thumbnail}
             alt={intl.formatMessage(messages.thumbnailAltText)}
           />
-          {(allowThumbnailUpload && edxVideo) ? (
+          {allowThumbnailUpload ? (
             <IconButtonWithTooltip
               tooltipPlacement="top"
               tooltipContent={intl.formatMessage(messages.deleteThumbnail)}
@@ -115,7 +115,7 @@ export const ThumbnailWidget = ({
             iconBefore={FileUpload}
             onClick={fileInput.click}
             variant="link"
-            disabled={!(allowThumbnailUpload && edxVideo)}
+            disabled={!allowThumbnailUpload}
           >
             <FormattedMessage {...messages.uploadButtonLabel} />
           </Button>

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/VideoSourceWidget/hooks.jsx
@@ -40,7 +40,7 @@ export const sourceHooks = ({ dispatch, previousVideoId, setAlert }) => ({
 export const fallbackHooks = ({ fallbackVideos, dispatch }) => ({
   addFallbackVideo: () => dispatch(actions.video.updateField({ fallbackVideos: [...fallbackVideos, ''] })),
   deleteFallbackVideo: (videoUrl) => {
-    const updatedFallbackVideos = fallbackVideos.splice(fallbackVideos.indexOf(videoUrl), 1);
+    const updatedFallbackVideos = fallbackVideos.toSpliced(fallbackVideos.indexOf(videoUrl), 1);
     dispatch(actions.video.updateField({ fallbackVideos: updatedFallbackVideos }));
   },
 });


### PR DESCRIPTION
## Description

This PR aims to solve the issue https://github.com/openedx/frontend-app-course-authoring/issues/1016 by showing the thumbnail from the `videoSettingsModal` only when the `Video ID` is one given by edX according to [this method](https://github.com/openedx/frontend-lib-content-components/blob/0c53d8c4919c263368c397eb9e32253f0a692a01/src/editors/data/services/cms/api.js#L275)

![image](https://github.com/user-attachments/assets/a56e8a2a-e8ef-4173-8096-27330e5fc114)

Any other `Video ID` will hide the thumbnail:

![image](https://github.com/user-attachments/assets/c229c13b-1107-4e1e-bdc0-02e1824525e3)

Additionally, this PR fixes a bug when trying to delete a `Fallback video URL`:

![image](https://github.com/user-attachments/assets/83bd157c-406c-480c-a00d-d3ba9735541a)

 