### PR TITLE
fix: course creation button is inactive

### DIFF
--- a/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
+++ b/src/editors/sharedComponents/TypeaheadDropdown/index.jsx
@@ -90,7 +90,7 @@ class TypeaheadDropdown extends React.Component {
       this.setValue(opt);
       this.setState({ displayValue: opt });
     } else {
-      this.setValue('');
+      this.setValue(value);
       this.setState({ displayValue: value });
     }
   }


### PR DESCRIPTION
When using Tab to move from Org field to the
next Course number field the Org value is not saved.

Closes https://github.com/openedx/frontend-app-authoring/issues/1199 for Redwood release.

This fix differs from the one to the [frontend-app-authoring](https://github.com/openedx/frontend-app-authoring/pull/1279) since the value we want to save in DB should be raw (not normalized).

Fixed behavior:

https://github.com/user-attachments/assets/f8d264eb-6232-4cb1-86ac-6cfa1afca245

